### PR TITLE
Add function to get a random word from Word2Vec

### DIFF
--- a/src/Word2vec/index.js
+++ b/src/Word2vec/index.js
@@ -51,6 +51,11 @@ class Word2Vec {
     return Word2Vec.nearest(this.model, vector, 1, max + 1);
   }
 
+  getRandomWord() {
+    const words = Object.keys(this.model);
+    return words[Math.floor(Math.random() * words.length)];
+  }
+
   static addOrSubtract(model, values, operation) {
     const vectors = [];
     const notFound = [];


### PR DESCRIPTION
When I'm doing generative text art, I often want to pick random words.
Normally I use a library like Rita for this purpose, but in the case of
Word2Vec I would only want to pick words that are in the model itself.
Technically an end user could simply do:

```
myRandomWord = Object.keys(wordVectors.model)[Math.floor(Math.random()*Object.keys(wordVectors.model).length)];
```

But also that is a lot, and since ml5 is meant to contain high level
functions that help artists, I thought it would be appropriate to add
this function.