### PR TITLE
Updating ml5js.org url #126

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,7 +163,7 @@ npm run test
 
 ## ML5 Website
 
-The [ML5 website](https://ml5js.github.io/) is built with [Docusaurus](https://docusaurus.io/).
+The [ML5 website](https://ml5js.org/) is built with [Docusaurus](https://docusaurus.io/).
 
 Docusaurus is an open-source library, built with React, to create and maintain documentation websites.
 

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ or
 
 ## Resources
 
-- [Getting Started](https://ml5js.github.io/docs/getting-started.html)
-- [API Reference](https://ml5js.github.io/docs/imagenet.html)
-- [Examples](https://ml5js.github.io/docs/simple-image-classification-example.html)
-- [Learn](https://ml5js.github.io/docs/glossary-statistics.html)
-- [Experiments](https://ml5js.github.io/en/experiments.html)
+- [Getting Started](https://ml5js.org/docs/getting-started.html)
+- [API Reference](https://ml5js.org/docs/imagenet.html)
+- [Examples](https://ml5js.org/docs/simple-image-classification-example.html)
+- [Learn](https://ml5js.org/docs/glossary-statistics.html)
+- [Experiments](https://ml5js.org/en/experiments.html)
 
 ## Standalone Examples
 


### PR DESCRIPTION
I believe these are the only places in this repo referring to `ml5js.github.io` as the URL.