### PR TITLE
Changing vector->word in word2vec results

### DIFF
--- a/src/Word2vec/index.js
+++ b/src/Word2vec/index.js
@@ -96,9 +96,9 @@ class Word2Vec {
 
   static nearest(model, input, start, max) {
     const nearestVectors = [];
-    Object.keys(model).forEach((vector) => {
-      const distance = tf.util.distSquared(input.dataSync(), model[vector].dataSync());
-      nearestVectors.push({ vector, distance });
+    Object.keys(model).forEach((word) => {
+      const distance = tf.util.distSquared(input.dataSync(), model[word].dataSync());
+      nearestVectors.push({ word, distance });
     });
     nearestVectors.sort((a, b) => a.distance - b.distance);
     return nearestVectors.slice(start, max);


### PR DESCRIPTION
This should address #153. I've tested the example with this and will post a corresponding pull request there. It's possible, however, I've missed somewhere else in the source where `vector` is also returned?