### PR TITLE
Return promise when creating a new styleTransfer method

### DIFF
--- a/src/StyleTransfer/index.js
+++ b/src/StyleTransfer/index.js
@@ -140,7 +140,8 @@ const styleTransfer = (model, videoOrCallback, cb) => {
     callback = videoOrCallback;
   }
 
-  return new StyleTransfer(model, video, callback);
+  const instance = new StyleTransfer(model, video, callback);
+  return callback ? instance : instance.ready;
 };
 
 export default styleTransfer;


### PR DESCRIPTION
Support promise when creating a new styleTransfer method

So people can do:
```javascript
ml5.styleTransfer('models/wave')
  .then(style1 => style1.transfer(inputImg))
```