### PR TITLE
ImageClassifier: predict: handle unsupported input

### DIFF
--- a/src/ImageClassifier/index.js
+++ b/src/ImageClassifier/index.js
@@ -70,6 +70,9 @@ class ImageClassifier {
       imgToPredict = inputNumOrCallback;
     } else if (typeof inputNumOrCallback === 'object' && inputNumOrCallback.elt instanceof HTMLImageElement) {
       imgToPredict = inputNumOrCallback.elt; // Handle p5.js image
+    } else if (!(this.video instanceof HTMLVideoElement)) {
+      // Handle unsupported input
+      throw new Error('No input image provided. If you want to classify a video, pass the video element in the constructor. ');
     }
 
     if (typeof numOrCallback === 'number') {


### PR DESCRIPTION
**Issue**
If the input provided to `predict()` doesn't fall in the if chain, or no input is passed at all,
the function will default to using the video element provided in the constructor.
If no video was linked in the constructor however, we'll just be passing `undefined` to `model.classify()`
(maybe a check there would also be great?), causing eventually tensorflow to error:

> MathBackendWebGL.writePixels(): pixels can not be null

As an example, in @shiffman's [livestream](https://www.youtube.com/watch?v=Sz52VkVcW5o&t=2h7m46s) he believed he could pass a video source as input of `predict()`,
and the error message wasn't really clear about what the issue was.

**Proposed solution**
After checking that the first argument is neither the callback or the number of classes,
and after checking that the input type doesn't match the supported sources,
`HTMLImageElement` or `p5.Image`, check whether or not there's a video object
that is instance of an `HTMLVideoElement` (or just check if the object exists,
it should by definition be an `HTMLVideoElement` _unless manually edited_).
If not, `Error` out of execution of the function.

**Tests**
I compiled the library with `npm run-script build` and tested passing an invalid input,
and i correctly got the error
```
async function setup() {
	let video = createCapture(VIDEO);
	let model = await ml5.imageClassifier('MobileNet');
	let res = await model.predict(video); // Cannot pass it here
	console.log(res);
}
```
and tested linking a video source when constructing the ImageClassifier,
which was correctly detected and printed the results.
```
async function setup() {
	let video = createCapture(VIDEO);
	let model = await ml5.imageClassifier('MobileNet', video);
	let res = await model.predict();
	console.log(res);
}
```
