### PR TITLE
fix: Use Blobs to save files of larger sizes

### DIFF
--- a/src/KNNClassifier/index.js
+++ b/src/KNNClassifier/index.js
@@ -139,7 +139,7 @@ class KNN {
     this.knnClassifier.dispose();
   }
 
-  save(name) {
+  async save(name) {
     const dataset = this.knnClassifier.getClassifierDataset();
     if (this.mapStringToIndex.length > 0) {
       Object.keys(dataset).forEach((key) => {
@@ -159,7 +159,7 @@ class KNN {
     if (name) {
       fileName = name.endsWith('.json') ? name : `${name}.json`;
     }
-    io.saveFile(fileName, JSON.stringify({ dataset, tensors }));
+    await io.saveBlob(JSON.stringify({ dataset, tensors }), fileName, 'application/octet-stream');
   }
 
   load(path, callback) {

--- a/src/utils/io.js
+++ b/src/utils/io.js
@@ -3,20 +3,6 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-// Save a File
-const saveFile = (name, data) => {
-  const downloadElt = document.createElement('a');
-  const blob = new Blob([data], { type: 'octet/stream' });
-  const url = URL.createObjectURL(blob);
-  downloadElt.setAttribute('href', url);
-  downloadElt.setAttribute('download', name);
-  downloadElt.style.display = 'none';
-  document.body.appendChild(downloadElt);
-  downloadElt.click();
-  document.body.removeChild(downloadElt);
-  URL.revokeObjectURL(url);
-};
-
 const saveBlob = async (data, name, type) => {
   const link = document.createElement('a');
   link.style.display = 'none';
@@ -40,7 +26,6 @@ const loadFile = async (path, callback) => fetch(path)
   });
 
 export {
-  saveFile,
   saveBlob,
   loadFile,
 };

--- a/src/utils/io.js
+++ b/src/utils/io.js
@@ -6,12 +6,15 @@
 // Save a File
 const saveFile = (name, data) => {
   const downloadElt = document.createElement('a');
-  downloadElt.setAttribute('href', `data:text/plain;charset=utf-8,${encodeURIComponent(data)}`);
+  const blob = new Blob([data], { type: 'octet/stream' });
+  const url = URL.createObjectURL(blob);
+  downloadElt.setAttribute('href', url);
   downloadElt.setAttribute('download', name);
   downloadElt.style.display = 'none';
   document.body.appendChild(downloadElt);
   downloadElt.click();
   document.body.removeChild(downloadElt);
+  URL.revokeObjectURL(url);
 };
 
 const saveBlob = async (data, name, type) => {


### PR DESCRIPTION
fix #270 

Blobs allow for larger file sizes (100s of MBs) than the existing plain text download. This is a common case for saving from `KNNClassifier`.