### PR TITLE
    feat(KNNClassifier): Add loadData() that enables user to load dat…

### DIFF
--- a/src/KNNClassifier/index.js
+++ b/src/KNNClassifier/index.js
@@ -14,8 +14,6 @@ import * as knnClassifier from '@tensorflow-models/knn-classifier';
 import * as io from '../utils/io';
 import callCallback from '../utils/callcallback';
 
-const loadData = Symbol('loadData');
-
 class KNN {
   constructor() {
     this.knnClassifier = knnClassifier.create();
@@ -164,17 +162,13 @@ class KNN {
     await io.saveBlob(JSON.stringify({ dataset, tensors }), fileName, 'application/octet-stream');
   }
 
-  load(pathOrData, callback) {
+  async load(pathOrData, callback) {
+    let data;
     if (typeof pathOrData === 'object') {
-      this[loadData](pathOrData, callback);
+      data = pathOrData;
     } else {
-      io.loadFile(pathOrData, (err, data) => {
-        this[loadData](data, callback);
-      });
+      data = await io.loadFile(pathOrData);
     }
-  }
-
-  [loadData](data, callback) {
     if (data) {
       const { dataset, tensors } = data;
       this.mapStringToIndex = Object.keys(dataset).map(key => dataset[key].label);

--- a/src/KNNClassifier/index.js
+++ b/src/KNNClassifier/index.js
@@ -164,27 +164,31 @@ class KNN {
 
   load(path, callback) {
     io.loadFile(path, (err, data) => {
-      if (data) {
-        const { dataset, tensors } = data;
-        this.mapStringToIndex = Object.keys(dataset).map(key => dataset[key].label);
-        const tensorsData = tensors
-          .map((tensor, i) => {
-            if (tensor) {
-              const values = Object.keys(tensor).map(v => tensor[v]);
-              return tf.tensor(values, dataset[i].shape, dataset[i].dtype);
-            }
-            return null;
-          })
-          .reduce((acc, cur, j) => {
-            acc[j] = cur;
-            return acc;
-          }, {});
-        this.knnClassifier.setClassifierDataset(tensorsData);
-        if (callback) {
-          callback();
-        }
-      }
+      this.loadData(data, callback);
     });
+  }
+
+  loadData(data, callback) {
+    if (data) {
+      const { dataset, tensors } = data;
+      this.mapStringToIndex = Object.keys(dataset).map(key => dataset[key].label);
+      const tensorsData = tensors
+        .map((tensor, i) => {
+          if (tensor) {
+            const values = Object.keys(tensor).map(v => tensor[v]);
+            return tf.tensor(values, dataset[i].shape, dataset[i].dtype);
+          }
+          return null;
+        })
+        .reduce((acc, cur, j) => {
+          acc[j] = cur;
+          return acc;
+        }, {});
+      this.knnClassifier.setClassifierDataset(tensorsData);
+      if (callback) {
+        callback();
+      }
+    }
   }
 }
 

--- a/src/KNNClassifier/index.js
+++ b/src/KNNClassifier/index.js
@@ -14,6 +14,8 @@ import * as knnClassifier from '@tensorflow-models/knn-classifier';
 import * as io from '../utils/io';
 import callCallback from '../utils/callcallback';
 
+const loadData = Symbol('loadData');
+
 class KNN {
   constructor() {
     this.knnClassifier = knnClassifier.create();
@@ -162,13 +164,17 @@ class KNN {
     await io.saveBlob(JSON.stringify({ dataset, tensors }), fileName, 'application/octet-stream');
   }
 
-  load(path, callback) {
-    io.loadFile(path, (err, data) => {
-      this.loadData(data, callback);
-    });
+  load(pathOrData, callback) {
+    if (typeof pathOrData === 'object') {
+      this[loadData](pathOrData, callback);
+    } else {
+      io.loadFile(pathOrData, (err, data) => {
+        this[loadData](data, callback);
+      });
+    }
   }
 
-  loadData(data, callback) {
+  [loadData](data, callback) {
     if (data) {
       const { dataset, tensors } = data;
       this.mapStringToIndex = Object.keys(dataset).map(key => dataset[key].label);

--- a/src/utils/io.js
+++ b/src/utils/io.js
@@ -16,11 +16,15 @@ const saveBlob = async (data, name, type) => {
 const loadFile = async (path, callback) => fetch(path)
   .then(response => response.json())
   .then((json) => {
-    callback(null, json);
+    if (callback) {
+      callback(null, json);
+    }
     return json;
   })
   .catch((error) => {
-    callback(error);
+    if (callback) {
+      callback(error);
+    }
     console.error(`There has been a problem loading the file: ${error.message}`);
     throw error;
   });


### PR DESCRIPTION
…aset from raw data instead of file

    With load(), file path needs to be provided to load dataset. This means that JSON file that has
    dataset needs to be located on the server. You can give a way to download dataset using save(), but
    you cannot give a way to upload that file and load the dataset. This commit adds loadData() that
    enables user to load dataset from raw data. By combining this method and <INPUT type="file"> tag,
    you can give a way for user to upload dataset file.

Example of using loadData() with &lt;INPUT type="file"&gt; tag:
https://github.com/champierre/ml2scratch/blob/master/app/javascripts/scripts.js#L381