### PR TITLE
Update ImageClassifier and FeatureExtractor to return [{label, confidence}]

### DIFF
--- a/src/FeatureExtractor/Mobilenet.js
+++ b/src/FeatureExtractor/Mobilenet.js
@@ -247,18 +247,21 @@ class Mobilenet {
     }
     await tf.nextFrame();
     this.isPredicting = true;
-    const predictedClass = tf.tidy(() => {
+    const predictedClasses = tf.tidy(() => {
       const imageResize = (imgToPredict === this.video) ? null : [IMAGE_SIZE, IMAGE_SIZE];
       const processedImg = imgToTensor(imgToPredict, imageResize);
       const activation = this.mobilenetFeatures.predict(processedImg);
       const predictions = this.customModel.predict(activation);
-      return predictions.as1D().argMax();
+      return Array.from(predictions.as1D().dataSync());
     });
-    let classId = (await predictedClass.data())[0];
-    if (this.mapStringToIndex.length > 0) {
-      classId = this.mapStringToIndex[classId];
-    }
-    return classId;
+    const results = await predictedClasses.map((confidence, index) => {
+      const label = (this.mapStringToIndex.length > 0 && this.mapStringToIndex[index]) ? this.mapStringToIndex[index] : index;
+      return {
+        label,
+        confidence,
+      };
+    }).sort((a, b) => b.confidence - a.confidence);
+    return results;
   }
 
   /* eslint max-len: ["error", { "code": 180 }] */

--- a/src/FeatureExtractor/Mobilenet.js
+++ b/src/FeatureExtractor/Mobilenet.js
@@ -295,7 +295,7 @@ class Mobilenet {
     });
     const prediction = await predictedClass.data();
     predictedClass.dispose();
-    return prediction[0];
+    return { value: prediction[0] };
   }
 
   async load(filesOrPath = null, callback) {

--- a/src/ImageClassifier/index.js
+++ b/src/ImageClassifier/index.js
@@ -65,7 +65,7 @@ class ImageClassifier {
     return this.model.classify(imgToPredict, numberOfClasses);
   }
 
-  async predict(inputNumOrCallback, numOrCallback = null, cb) {
+  async classify(inputNumOrCallback, numOrCallback = null, cb) {
     let imgToPredict = this.video;
     let numberOfClasses = this.topk;
     let callback;
@@ -103,6 +103,10 @@ class ImageClassifier {
     }
 
     return callCallback(this.predictInternal(imgToPredict, numberOfClasses), callback);
+  }
+
+  async predict(inputNumOrCallback, numOrCallback, cb) {
+    return this.classify(inputNumOrCallback, numOrCallback || null, cb);
   }
 }
 

--- a/src/ImageClassifier/index.js
+++ b/src/ImageClassifier/index.js
@@ -52,7 +52,7 @@ class ImageClassifier {
     return this;
   }
 
-  async predictInternal(imgToPredict, numberOfClasses) {
+  async classifyInternal(imgToPredict, numberOfClasses) {
     // Wait for the model to be ready
     await this.ready;
     await tf.nextFrame();
@@ -62,7 +62,9 @@ class ImageClassifier {
         this.video.onloadeddata = () => resolve();
       });
     }
-    return this.model.classify(imgToPredict, numberOfClasses);
+    return this.model
+      .classify(imgToPredict, numberOfClasses)
+      .then(classes => classes.map(c => ({ label: c.className, confidence: c.probability })));
   }
 
   async classify(inputNumOrCallback, numOrCallback = null, cb) {
@@ -102,7 +104,7 @@ class ImageClassifier {
       callback = cb;
     }
 
-    return callCallback(this.predictInternal(imgToPredict, numberOfClasses), callback);
+    return callCallback(this.classifyInternal(imgToPredict, numberOfClasses), callback);
   }
 
   async predict(inputNumOrCallback, numOrCallback, cb) {

--- a/src/ImageClassifier/index_test.js
+++ b/src/ImageClassifier/index_test.js
@@ -48,35 +48,35 @@ describe('imageClassifier', () => {
     expect(classifier.ready).toBeTruthy();
   });
 
-  describe('predict', () => {
+  describe('classify', () => {
     it('Should classify an image of a Robin', async () => {
       const img = await getImage();
-      await classifier.predict(img)
-        .then(results => expect(results[0].className).toBe('robin, American robin, Turdus migratorius'));
+      await classifier.classify(img)
+        .then(results => expect(results[0].label).toBe('robin, American robin, Turdus migratorius'));
     });
 
     it('Should support p5 elements with an image on .elt', async () => {
       const img = await getImage();
-      await classifier.predict({ elt: img })
-        .then(results => expect(results[0].className).toBe('robin, American robin, Turdus migratorius'));
+      await classifier.classify({ elt: img })
+        .then(results => expect(results[0].label).toBe('robin, American robin, Turdus migratorius'));
     });
 
     it('Should support HTMLCanvasElement', async () => {
       const canvas = await getCanvas();
-      await classifier.predict(canvas)
-        .then(results => expect(results[0].className).toBe('robin, American robin, Turdus migratorius'));
+      await classifier.classify(canvas)
+        .then(results => expect(results[0].label).toBe('robin, American robin, Turdus migratorius'));
     });
 
     it('Should support p5 elements with canvas on .canvas', async () => {
       const canvas = await getCanvas();
-      await classifier.predict({ canvas })
-        .then(results => expect(results[0].className).toBe('robin, American robin, Turdus migratorius'));
+      await classifier.classify({ canvas })
+        .then(results => expect(results[0].label).toBe('robin, American robin, Turdus migratorius'));
     });
 
     it('Should support p5 elements with canvas on .elt', async () => {
       const canvas = await getCanvas();
-      await classifier.predict({ elt: canvas })
-        .then(results => expect(results[0].className).toBe('robin, American robin, Turdus migratorius'));
+      await classifier.classify({ elt: canvas })
+        .then(results => expect(results[0].label).toBe('robin, American robin, Turdus migratorius'));
     });
   });
 });


### PR DESCRIPTION
This PR updates some API namings in ImageClassifier and FeatureExtractor -

1. image classifier (plain MobileNet): use`.classify()` instead of `.predict()`, `predict()` still works, will continue supporting it unitl later versions, discussed in #192.
2. image classifier (plain MobileNet):  returns `[{label, confidence}]` instead of `[{className, probability}]`
3. feature extractor classifier: returns `[{label, confidence}]` instead of just a label.
4. feature extractor regressor: returns `{value: a number}` instead of just a number.

2,3,4 are related to #200.

Here is a related PR from ml5-example: https://github.com/ml5js/ml5-examples/pull/93

Below is an example of the output of feature extractor classifier:
![screen shot 2019-02-21 at 1 09 49 pm](https://user-images.githubusercontent.com/8662372/53195491-c4603b00-35e3-11e9-9226-8d851f0cd84b.png)


