### PR TITLE
Fix some bugs in p5 preload

### DIFF
--- a/src/utils/p5PreloadHelper.js
+++ b/src/utils/p5PreloadHelper.js
@@ -20,8 +20,20 @@ export default function registerPreload(obj) {
     const fn = obj[key];
 
     preloadFn[key] = function preloads(...args) {
-      return fn.apply(obj, [...args, function doingPreloads() {
+      let originCallback = null;
+      let argLen = args.length;
+      if (typeof args[argLen - 1] === 'function') {
+        // find callback function attached
+        originCallback = args[argLen - 1];
+        argLen -= 1;
+      }
+      return fn.apply(obj, [...args.slice(0, argLen), function doingPreloads() {
         const targetPreloadFn = '_decrementPreload';
+        try {
+          if (originCallback) originCallback();
+        } catch (err) {
+          console.error(err);
+        }
         if (window[targetPreloadFn]) return window[targetPreloadFn]();
         return null;
       }]);

--- a/webpack.test.babel.js
+++ b/webpack.test.babel.js
@@ -5,6 +5,7 @@
 
 import { existsSync, mkdirSync, writeFileSync, lstatSync } from 'fs';
 import { join } from 'path';
+import assert from 'assert';
 import merge from 'webpack-merge';
 import common from './webpack.common.babel';
 


### PR DESCRIPTION
Here are some bugs I find when I am trying to apply preload function to other classifiers (fixed in this pull request): 

- [x] When user passes a callback function (maybe mistakenly), the model will never be loaded.
- [x] When the manual-test folder exists, npm command will throw an error because of undeclaration of `assert`.