### PR TITLE
Patch styleTransfer() for non-square and canvas-derived inputs

### DIFF
--- a/src/StyleTransfer/index.js
+++ b/src/StyleTransfer/index.js
@@ -89,7 +89,9 @@ class StyleTransfer extends Video {
     let input;
     let callback = cb;
 
-    if (inputOrCallback instanceof HTMLVideoElement || inputOrCallback instanceof HTMLImageElement) {
+    if (inputOrCallback instanceof HTMLVideoElement ||
+        inputOrCallback instanceof HTMLImageElement ||
+        inputOrCallback instanceof ImageData) {
       input = inputOrCallback;
     } else if (typeof inputOrCallback === 'object' && (inputOrCallback.elt instanceof HTMLVideoElement || inputOrCallback.elt instanceof HTMLImageElement)) {
       input = inputOrCallback.elt;

--- a/src/utils/imageUtilities.js
+++ b/src/utils/imageUtilities.js
@@ -24,7 +24,7 @@ const processVideo = (input, size, callback = () => {}) => {
 
 // Converts a tf to DOM img
 const array3DToImage = (tensor) => {
-  const [imgWidth, imgHeight] = tensor.shape;
+  const [imgHeight, imgWidth] = tensor.shape;
   const data = tensor.dataSync();
   const canvas = document.createElement('canvas');
   canvas.width = imgWidth;


### PR DESCRIPTION
This fixes #310 by changing two lines of code. The change to array3DToImage will not affect pix2pix's square inputs, and has been tested successfully on StyleTransfer. (Sorry about forgetting to Commitizen, have not been able to revert my git tree.)

![](https://i.imgur.com/YQDp7dh.png)