### PR TITLE
check preload support for other nets and classifiers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,20 +20,20 @@ import preloadRegister from './utils/p5PreloadHelper';
 import { version } from '../package.json';
 
 const withPreload = {
+  charRNN,
+  featureExtractor,
   imageClassifier,
+  pitchDetection,
+  pix2pix,
+  poseNet,
+  SketchRNN,
+  styleTransfer,
+  word2vec,
+  YOLO,
 };
 
 module.exports = Object.assign({}, preloadRegister(withPreload), {
   KNNClassifier,
-  featureExtractor,
-  pitchDetection,
-  YOLO,
-  word2vec,
-  styleTransfer,
-  poseNet,
-  charRNN,
-  pix2pix,
-  SketchRNN,
   ...imageUtils,
   tf,
   version,


### PR DESCRIPTION
Hi, all! After checking all the classifiers, I find out all of these, if necessary, can be implemented by p5 preload:

- `charRNN`
- `featureExtractor`
- `imageClassifier`
- `pitchDetection`
- `pix2pix`
- `poseNet`
- `SketchRNN`
- `styleTransfer`
- `word2vec`
- `YOLO`

`KNNClassifier` does not need `callback` so this one also do not need to be supported by `preload()`.