### PR TITLE
Adjust charrnn test option length

### DIFF
--- a/src/CharRNN/index_test.js
+++ b/src/CharRNN/index_test.js
@@ -54,7 +54,7 @@ describe('charRnn', () => {
 
     it('generates content that follows the set options', async() => {
       const result = await rnn.generate(RNN_OPTIONS);
-      expect(result.sample.length).toBe(500);
+      expect(result.sample.length).toBe(100);
     });
   });
 });

--- a/src/CharRNN/index_test.js
+++ b/src/CharRNN/index_test.js
@@ -29,7 +29,7 @@ describe('charRnn', () => {
   let rnn;
 
   beforeAll(async () => {
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000; //set extra long interval due to issues with CharRNN generation time
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 120000; //set extra long interval due to issues with CharRNN generation time
     rnn  = await charRNN(RNN_MODEL_URL, undefined);
   });
 

--- a/src/CharRNN/index_test.js
+++ b/src/CharRNN/index_test.js
@@ -9,7 +9,7 @@ const RNN_MODEL_URL = 'https://raw.githubusercontent.com/ml5js/ml5-data-and-mode
 
 const RNN_MODEL_DEFAULTS = {
   cellsAmount: 2,
-  vocabSize: 223
+  vocabSize: 64
 };
 
 const RNN_DEFAULTS = {

--- a/src/CharRNN/index_test.js
+++ b/src/CharRNN/index_test.js
@@ -21,7 +21,7 @@ const RNN_DEFAULTS = {
 
 const RNN_OPTIONS = {
   seed: 'the meaning of pizza is: ',
-  length: 500,
+  length: 100,
   temperature: 0.7
 }
 


### PR DESCRIPTION
<!-- MANY MANY THANKS FOR YOUR CONTRIBUTION. ML5 ❤️S YOU! -->
## → Submit changes to the relevant branch 🌲

PRing into **development**


## → Description 📝

The CharRNN test takes maybe too long - the character length right now is 500. This PR switches it to 100 to reduce the generation time and thus the testing time which may be causing the travis-ci to fail. 

- fixing a bug 🐛


## → Screenshots 🖼
n/a


## → Relevant Example or Paired Pull Request to [ml5-examples](https://github.com/ml5js/ml5-examples) 🦄
n/a

## → Relevant documentation 🌴

Related to issues caused by: https://github.com/ml5js/ml5-library/pull/307 



