### PR TITLE
Forcing magenta dependency to 0.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,21 +5,21 @@
   "requires": true,
   "dependencies": {
     "@magenta/sketch": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@magenta/sketch/-/sketch-0.1.4.tgz",
-      "integrity": "sha512-4xMQ3Rual//L6pRxR1ajhIgNctya3pKWaRpPAFa7gNL8d2lnYW+tThW7jbxlaCXo5iW5ugGaYFcvPsTe3sJerQ==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@magenta/sketch/-/sketch-0.1.2.tgz",
+      "integrity": "sha512-VZZDvFFfrx5yBEoKx4Uh/PXY+kwimYnLaih/TTfi5V2sz+nVdDmZTS8/JAga6yEOvm5nMlcirYbDWaEpqMp1rQ==",
       "requires": {
-        "@tensorflow/tfjs": "^0.13.3"
+        "@tensorflow/tfjs": "^0.12.4"
       },
       "dependencies": {
         "@tensorflow/tfjs": {
-          "version": "0.13.5",
-          "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-0.13.5.tgz",
-          "integrity": "sha512-a0sbY2IShg+hAD+Es8fy1Ey/afoks4fxSi+PVSZc1st51brCnO3qBbqwDDctRNwx/EOfAroS8IWIKgaWTpsflg==",
+          "version": "0.12.7",
+          "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-0.12.7.tgz",
+          "integrity": "sha512-sGqnS7+Zj4SK6ap+fdFDGgddQf7l9RJBkWJc36frwP2F4LmFQQ5ED4+Wq7cBM1LzuyNq0p3pREWBbCfab0pnyw==",
           "requires": {
-            "@tensorflow/tfjs-converter": "0.6.7",
-            "@tensorflow/tfjs-core": "0.13.11",
-            "@tensorflow/tfjs-layers": "0.8.5"
+            "@tensorflow/tfjs-converter": "0.5.9",
+            "@tensorflow/tfjs-core": "0.12.17",
+            "@tensorflow/tfjs-layers": "0.7.5"
           }
         }
       }
@@ -438,29 +438,29 @@
       }
     },
     "@tensorflow/tfjs-converter": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-0.6.7.tgz",
-      "integrity": "sha512-7hsbLbx0KM1Bew00kVoslrnNMOUTyP9NZLDl03cEkrCbEYsaG7jouLxHVz+B0A6/ZPE1N40xmD2JRnu54VKT8g==",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-0.5.9.tgz",
+      "integrity": "sha512-48sw17WffIoPYTN2gNZ5HWvjKLtQYXrSy+mqaZtiWaRYVjDzJdla6g7dPAL77MR2rxQAfVYMXg8GRDBmkzyBDw==",
       "requires": {
         "@types/long": "~3.0.32",
         "protobufjs": "~6.8.6"
       }
     },
     "@tensorflow/tfjs-core": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-0.13.11.tgz",
-      "integrity": "sha512-jHTD7LbpC3JpsP2mBVD3ZiYV+Xr/l91zpA5HpQVnbdNat5J/IJHabeYwYtukiVyN4amHqyFvGFtX/gjLD82rXg==",
+      "version": "0.12.17",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-0.12.17.tgz",
+      "integrity": "sha512-CgFazQpGB21n1LRSxgyMwy0cN6WtuUPBP2W75zk6Rw+gFUXb8ZNh7fhn4nObjgKeIka36TI9MvT1FYrY+z150w==",
       "requires": {
-        "@types/seedrandom": "2.4.27",
-        "@types/webgl-ext": "0.0.30",
-        "@types/webgl2": "0.0.4",
-        "seedrandom": "2.4.3"
+        "@types/seedrandom": "~2.4.27",
+        "@types/webgl-ext": "~0.0.29",
+        "@types/webgl2": "~0.0.4",
+        "seedrandom": "~2.4.3"
       }
     },
     "@tensorflow/tfjs-layers": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-0.8.5.tgz",
-      "integrity": "sha512-yQoVyh5q3Hh3YmLXGvKAkgsLVFe0VQBRmgVxJkxzzWhCB+NrjUXU/IzHzCRoBcgcXKZTY9/XE5IcvPmJw9cIXw=="
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-0.7.5.tgz",
+      "integrity": "sha512-JIo4l0yEIfYi+quJG71wAeCP9tgXICg/MIOstowfCVGTHKh8oBVEm39bAI/zyTYYtFVLHeQSvY2KuRCN2h0nBg=="
     },
     "@types/long": {
       "version": "3.0.32",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     ]
   },
   "dependencies": {
-    "@magenta/sketch": "^0.1.2",
+    "@magenta/sketch": "0.1.2",
     "@tensorflow-models/mobilenet": "0.2.2",
     "@tensorflow-models/posenet": "0.2.2",
     "@tensorflow-models/knn-classifier": "0.2.2",


### PR DESCRIPTION
The SketchRNN example doesn't work with more recent magenta (0.1.4) probably due to us lagging behind in versions of tf.js?



