### PR TITLE
added check for moz browser ref:https://stackoverflow.com/questions/4…

### DIFF
--- a/src/utils/Video.js
+++ b/src/utils/Video.js
@@ -22,9 +22,15 @@ class Video {
   }
 
   async loadVideo() {
+    let stream;
     return new Promise((resolve) => {
       this.video = document.createElement('video');
-      const stream = this.videoElt.captureStream();
+      const sUsrAg = navigator.userAgent;
+      if (sUsrAg.indexOf('Firefox') > -1) {
+        stream = this.videoElt.mozCaptureStream();
+      } else {
+        stream = this.videoElt.captureStream();
+      }
       this.video.srcObject = stream;
       this.video.width = this.size;
       this.video.height = this.size;


### PR DESCRIPTION
…8623376/typeerror-capturestream-is-not-a-function

<!-- MANY MANY THANKS FOR YOUR CONTRIBUTION. ML5 ❤️S YOU! -->
## → Submit changes to the relevant branch 🌲

`development`


## → Description 📝


- fixing a bug 🐛

This addresses the video capture breaking in YOLO and potentially other video based functions that require the use of `.captureStream()`. As the `.captureStream()` function is still experimental, this adds the `moz` prefix and a browser check to see if we are using firefox or not.

See discussion here: https://stackoverflow.com/questions/48623376/typeerror-capturestream-is-not-a-function

## → Screenshots 🖼
(Any relevant screenshots, sketches, or helpful concept diagrams - these are helpful for our release notes and for getting people excited about your super cool feature and/or fix!)

<img width="500" alt="Screen Shot 2019-05-20 at 14 33 57" src="https://user-images.githubusercontent.com/3622055/58043864-5658e080-7b0c-11e9-9312-cbd01eff03fc.png">



