### PR TITLE
Adds label number option to featureExtractor.classification() 

### DIFF
--- a/src/FeatureExtractor/Mobilenet.js
+++ b/src/FeatureExtractor/Mobilenet.js
@@ -92,15 +92,16 @@ class Mobilenet {
     return this;
   }
 
-  classification(video, numOrCallback = null, callback) {
+  classification(video, objOrCallback = null, callback) {
     let cb;
     
     this.usageType = 'classifier';
 
-    if (typeof numOrCallback === 'number') {
-      this.numLabels = numOrCallback;
-    } else if (typeof numOrCallback === 'function') {
-      cb = numOrCallback;
+    if (typeof objOrCallback === 'object') {      
+      Object.assign(this, objOrCallback);
+
+    } else if (typeof objOrCallback === 'function') {
+      cb = objOrCallback;
     }
 
     if (typeof callback === 'function') {

--- a/src/FeatureExtractor/Mobilenet.js
+++ b/src/FeatureExtractor/Mobilenet.js
@@ -60,14 +60,16 @@ class Mobilenet {
     this.topKPredictions = 10;
     this.hasAnyTrainedClass = false;
     this.customModel = null;
-    this.epochs = options.epochs || DEFAULTS.epochs;
-    this.version = options.version || DEFAULTS.version;
-    this.hiddenUnits = options.hiddenUnits || DEFAULTS.hiddenUnits;
-    this.numLabels = options.numLabels || DEFAULTS.numLabels;
-    this.learningRate = options.learningRate || DEFAULTS.learningRate;
-    this.batchSize = options.batchSize || DEFAULTS.batchSize;
-    this.layer = options.layer || DEFAULTS.layer;
-    this.alpha = options.alpha || DEFAULTS.alpha;
+    this.config = {
+      epochs: options.epochs || DEFAULTS.epochs,
+      version: options.version || DEFAULTS.version,
+      hiddenUnits: options.hiddenUnits || DEFAULTS.hiddenUnits,
+      numLabels: options.numLabels || DEFAULTS.numLabels,
+      learningRate: options.learningRate || DEFAULTS.learningRate,
+      batchSize: options.batchSize || DEFAULTS.batchSize,
+      layer: options.layer || DEFAULTS.layer,
+      alpha: options.alpha || DEFAULTS.alpha
+    }
     this.isPredicting = false;
     this.mapStringToIndex = [];
     this.usageType = null;
@@ -75,16 +77,16 @@ class Mobilenet {
 
     // for graph model
     this.model = null;
-    this.url = MODEL_INFO[this.version][this.alpha];
+    this.url = MODEL_INFO[this.config.version][this.config.alpha];
     this.normalizationOffset = tf.scalar(127.5);
   }
 
   async loadModel() {
-    this.mobilenet = await tf.loadLayersModel(`${BASE_URL}${this.version}_${this.alpha}_${IMAGE_SIZE}/model.json`);
+    this.mobilenet = await tf.loadLayersModel(`${BASE_URL}${this.config.version}_${this.config.alpha}_${IMAGE_SIZE}/model.json`);
     this.model = await tf.loadGraphModel(this.url, {fromTFHub: true});
 
 
-    const layer = this.mobilenet.getLayer(this.layer);
+    const layer = this.mobilenet.getLayer(this.config.layer);
     this.mobilenetFeatures = await tf.model({ inputs: this.mobilenet.inputs, outputs: layer.output });
     // if (this.video) {
     //   await this.mobilenet.classify(imgToTensor(this.video)); // Warm up
@@ -98,7 +100,7 @@ class Mobilenet {
     this.usageType = 'classifier';
 
     if (typeof objOrCallback === 'object') {      
-      Object.assign(this, objOrCallback);
+      Object.assign(this.config, objOrCallback);
 
     } else if (typeof objOrCallback === 'function') {
       cb = objOrCallback;
@@ -184,7 +186,7 @@ class Mobilenet {
       const prediction = this.mobilenetFeatures.predict(processedImg);
       let y;
       if (this.usageType === 'classifier') {
-        y = tf.tidy(() => tf.oneHot(tf.tensor1d([label], 'int32'), this.numLabels));
+        y = tf.tidy(() => tf.oneHot(tf.tensor1d([label], 'int32'), this.config.numLabels));
       } else if (this.usageType === 'regressor') {
         y = tf.tensor2d([[label]]);
       }
@@ -219,13 +221,13 @@ class Mobilenet {
         layers: [
           tf.layers.flatten({ inputShape: [7, 7, 256] }),
           tf.layers.dense({
-            units: this.hiddenUnits,
+            units: this.config.hiddenUnits,
             activation: 'relu',
             kernelInitializer: 'varianceScaling',
             useBias: true,
           }),
           tf.layers.dense({
-            units: this.numLabels,
+            units: this.config.numLabels,
             kernelInitializer: 'varianceScaling',
             useBias: false,
             activation: 'softmax',
@@ -238,7 +240,7 @@ class Mobilenet {
         layers: [
           tf.layers.flatten({ inputShape: [7, 7, 256] }),
           tf.layers.dense({
-            units: this.hiddenUnits,
+            units: this.config.hiddenUnits,
             activation: 'relu',
             kernelInitializer: 'varianceScaling',
             useBias: true,
@@ -253,16 +255,16 @@ class Mobilenet {
       });
     }
 
-    const optimizer = tf.train.adam(this.learningRate);
+    const optimizer = tf.train.adam(this.config.learningRate);
     this.customModel.compile({ optimizer, loss: this.loss });
-    const batchSize = Math.floor(this.xs.shape[0] * this.batchSize);
+    const batchSize = Math.floor(this.xs.shape[0] * this.config.batchSize);
     if (!(batchSize > 0)) {
       throw new Error('Batch size is 0 or NaN. Please choose a non-zero fraction.');
     }
 
     return this.customModel.fit(this.xs, this.ys, {
       batchSize,
-      epochs: this.epochs,
+      epochs: this.config.epochs,
       callbacks: {
         onBatchEnd: async (batch, logs) => {
           onProgress(logs.loss.toFixed(5));
@@ -435,7 +437,7 @@ class Mobilenet {
               const batched = resized.reshape([-1, IMAGE_SIZE, IMAGE_SIZE, 3]);
               let result;
               if (embedding) {
-                const embeddingName = EMBEDDING_NODES[this.version];
+                const embeddingName = EMBEDDING_NODES[this.config.version];
                 const internal = this.model.execute(batched, embeddingName);
                 result = internal.squeeze([1, 2]);
               } else {

--- a/src/FeatureExtractor/Mobilenet.js
+++ b/src/FeatureExtractor/Mobilenet.js
@@ -92,11 +92,25 @@ class Mobilenet {
     return this;
   }
 
-  classification(video, callback) {
+  classification(video, numOrCallback = null, callback) {
+    let cb;
+    
     this.usageType = 'classifier';
-    if (video) {
-      callCallback(this.loadVideo(video), callback);
+
+    if (typeof numOrCallback === 'number') {
+      this.numLabels = numOrCallback;
+    } else if (typeof numOrCallback === 'function') {
+      cb = numOrCallback;
     }
+
+    if (typeof callback === 'function') {
+      cb = callback;
+    }
+
+    if (video) {
+      callCallback(this.loadVideo(video), cb);
+    }
+
     return this;
   }
 

--- a/src/FeatureExtractor/Mobilenet.js
+++ b/src/FeatureExtractor/Mobilenet.js
@@ -24,7 +24,7 @@ const DEFAULTS = {
   learningRate: 0.0001,
   hiddenUnits: 100,
   epochs: 20,
-  numClasses: 2,
+  numLabels: 2,
   batchSize: 0.4,
   layer: 'conv_pw_13_relu',
 };
@@ -63,7 +63,7 @@ class Mobilenet {
     this.epochs = options.epochs || DEFAULTS.epochs;
     this.version = options.version || DEFAULTS.version;
     this.hiddenUnits = options.hiddenUnits || DEFAULTS.hiddenUnits;
-    this.numClasses = options.numClasses || DEFAULTS.numClasses;
+    this.numLabels = options.numLabels || DEFAULTS.numLabels;
     this.learningRate = options.learningRate || DEFAULTS.learningRate;
     this.batchSize = options.batchSize || DEFAULTS.batchSize;
     this.layer = options.layer || DEFAULTS.layer;
@@ -169,7 +169,7 @@ class Mobilenet {
       const prediction = this.mobilenetFeatures.predict(processedImg);
       let y;
       if (this.usageType === 'classifier') {
-        y = tf.tidy(() => tf.oneHot(tf.tensor1d([label], 'int32'), this.numClasses));
+        y = tf.tidy(() => tf.oneHot(tf.tensor1d([label], 'int32'), this.numLabels));
       } else if (this.usageType === 'regressor') {
         y = tf.tensor2d([[label]]);
       }
@@ -210,7 +210,7 @@ class Mobilenet {
             useBias: true,
           }),
           tf.layers.dense({
-            units: this.numClasses,
+            units: this.numLabels,
             kernelInitializer: 'varianceScaling',
             useBias: false,
             activation: 'softmax',

--- a/src/FeatureExtractor/index_test.js
+++ b/src/FeatureExtractor/index_test.js
@@ -9,7 +9,7 @@ const FEATURE_EXTRACTOR_DEFAULTS = {
   learningRate: 0.0001,
   hiddenUnits: 100,
   epochs: 20,
-  numClasses: 2,
+  numLabels: 2,
   batchSize: 0.4,
 };
 
@@ -25,7 +25,7 @@ describe('featureExtractor with Mobilenet', () => {
     expect(classifier.learningRate).toBe(FEATURE_EXTRACTOR_DEFAULTS.learningRate);
     expect(classifier.hiddenUnits).toBe(FEATURE_EXTRACTOR_DEFAULTS.hiddenUnits);
     expect(classifier.epochs).toBe(FEATURE_EXTRACTOR_DEFAULTS.epochs);
-    expect(classifier.numClasses).toBe(FEATURE_EXTRACTOR_DEFAULTS.numClasses);
+    expect(classifier.numLabels).toBe(FEATURE_EXTRACTOR_DEFAULTS.numLabels);
     expect(classifier.batchSize).toBe(FEATURE_EXTRACTOR_DEFAULTS.batchSize);
   });
 

--- a/src/FeatureExtractor/index_test.js
+++ b/src/FeatureExtractor/index_test.js
@@ -22,11 +22,11 @@ describe('featureExtractor with Mobilenet', () => {
   });
 
   it('Should create a featureExtractor with all the defaults', async () => {
-    expect(classifier.learningRate).toBe(FEATURE_EXTRACTOR_DEFAULTS.learningRate);
-    expect(classifier.hiddenUnits).toBe(FEATURE_EXTRACTOR_DEFAULTS.hiddenUnits);
-    expect(classifier.epochs).toBe(FEATURE_EXTRACTOR_DEFAULTS.epochs);
-    expect(classifier.numLabels).toBe(FEATURE_EXTRACTOR_DEFAULTS.numLabels);
-    expect(classifier.batchSize).toBe(FEATURE_EXTRACTOR_DEFAULTS.batchSize);
+    expect(classifier.config.learningRate).toBe(FEATURE_EXTRACTOR_DEFAULTS.learningRate);
+    expect(classifier.config.hiddenUnits).toBe(FEATURE_EXTRACTOR_DEFAULTS.hiddenUnits);
+    expect(classifier.config.epochs).toBe(FEATURE_EXTRACTOR_DEFAULTS.epochs);
+    expect(classifier.config.numLabels).toBe(FEATURE_EXTRACTOR_DEFAULTS.numLabels);
+    expect(classifier.config.batchSize).toBe(FEATURE_EXTRACTOR_DEFAULTS.batchSize);
   });
 
   // describe('predict', () => {


### PR DESCRIPTION
<!-- MANY MANY THANKS FOR YOUR CONTRIBUTION. ML5 ❤️S YOU! -->
## → Submit changes to the relevant branch 🌲

`development`


## → Description 📝

- fixing a bug 🐛
- adding an update 🛠

Adds the option to specify the number of labels to the featureExtractor.classificaiton() function as per the discussion here: https://github.com/ml5js/ml5-library/issues/164#issuecomment-454459683 

Maybe it is better to pass in an object rather than a number? 

## → Screenshots 🖼

in file: `/src/FeatureExtractor`:

```js
  classification(video, numOrCallback = null, callback) {
    let cb;
    
    this.usageType = 'classifier';

    if (typeof numOrCallback === 'number') {
      this.numLabels = numOrCallback;
    } else if (typeof numOrCallback === 'function') {
      cb = numOrCallback;
    }

    if (typeof callback === 'function') {
      cb = callback;
    }

    if (video) {
      callCallback(this.loadVideo(video), cb);
    }

    return this;
  }
```

## → Relevant Example or Paired Pull Request to [ml5-examples](https://github.com/ml5js/ml5-examples) 🦄

See: https://github.com/ml5js/ml5-examples/pull/142
 


