### PR TITLE
renaming model names to ml5.soundClassifier(SpeechCommands18w)

### DIFF
--- a/src/SoundClassifier/index.js
+++ b/src/SoundClassifier/index.js
@@ -15,7 +15,7 @@ class SoundClassifier {
   /**
    * Create an SoundClassifier.
    * @param {modelName} modelName - The name of the model to use. Current options 
-   *    are: 'speech-commands'.
+   *    are: 'SpeechCommands18w'.
    * @param {object} options - An object with options.
    * @param {function} callback - A callback to be called when the model is ready.
    */
@@ -24,7 +24,7 @@ class SoundClassifier {
     this.model = null;
     this.options = options;
     switch (this.modelName) {
-      case 'speech-commands':
+      case 'speechcommands18w':
         this.modelToUse = speechCommands;
         break;
       default:
@@ -79,7 +79,7 @@ const soundClassifier = (modelName, optionsOrCallback, cb) => {
   if (typeof modelName === 'string') {
     model = modelName.toLowerCase();
   } else {
-    throw new Error('Please specify a model to use. E.g: "speech-commands"');
+    throw new Error('Please specify a model to use. E.g: "SpeechCommands18w"');
   }
 
   if (typeof optionsOrCallback === 'object') {


### PR DESCRIPTION
<!-- MANY MANY THANKS FOR YOUR CONTRIBUTION. ML5 ❤️S YOU! -->
## → Submit changes to the relevant branch 🌲
`development`

## → Description 📝
- adding an update 🛠


## → Relevant Example or Paired Pull Request to [ml5-examples](https://github.com/ml5js/ml5-examples) 🦄
https://github.com/ml5js/ml5-examples/pull/154

## → Relevant documentation 🌴
Based on the discussion here: https://github.com/ml5js/ml5-library/pull/389#issuecomment-496706704. We are renaming `speech-commands` model to `ml5.soundClassifier('SpeechCommands18w')`.



