### PR TITLE
ml5.imageClassifier() loads pre-trained custom model

### DIFF
--- a/src/ImageClassifier/index.js
+++ b/src/ImageClassifier/index.js
@@ -105,11 +105,20 @@ class ImageClassifier {
     await this.ready;
     await tf.nextFrame();
 
+    if (imgToPredict instanceof HTMLVideoElement && imgToPredict.readyState === 0) {
+      const video = imgToPredict;
+      // Wait for the video to be ready
+      await new Promise(resolve => {
+        video.onloadeddata = () => resolve();
+      });
+    }
+
     if (this.video && this.video.readyState === 0) {
       await new Promise(resolve => {
         this.video.onloadeddata = () => resolve();
       });
     }
+
     if (this.modelUrl) {
       await tf.nextFrame();
       const predictedClasses = tf.tidy(() => {
@@ -172,6 +181,13 @@ class ImageClassifier {
       inputNumOrCallback.canvas instanceof HTMLCanvasElement
     ) {
       imgToPredict = inputNumOrCallback.canvas; // Handle p5.js image
+    } else if (inputNumOrCallback instanceof HTMLVideoElement) {
+      imgToPredict = inputNumOrCallback;
+    } else if (
+      typeof inputNumOrCallback === 'object' &&
+      inputNumOrCallback.elt instanceof HTMLVideoElement
+    ) {
+      imgToPredict = inputNumOrCallback.elt; // Handle p5.js video
     } else if (!(this.video instanceof HTMLVideoElement)) {
       // Handle unsupported input
       throw new Error(


### PR DESCRIPTION
## → Submit changes to the relevant branch 🌲
`development`

## → Description 📝

A clear and concise description of what the pull request is about. Let us know if you are:
- adding an update 🛠

## → Relevant Example or Paired Pull Request to [ml5-examples](https://github.com/ml5js/ml5-examples) 🦄
https://github.com/ml5js/ml5-examples/pull/156

## → Relevant documentation 🌴
This PR enables that ml5.imageClassifier can load a model -
1. from an external URL 
```javascript
classifier = ml5.imageClassifier('https://storage.googleapis.com/tm-pro-a6966.appspot.com/eyeo-test-yining/model.json', video);
```
2. from a local file path
```javascript
classifier = ml5.imageClassifier('model/image-model.json', video, modelReady);
```
They both support loading the model in the p5 `preload()` function as well as using a callback function.



