### PR TITLE
ml5.soundClassifier() loads pre-trained custom speech-commands model

### DIFF
--- a/src/SoundClassifier/speechcommands.js
+++ b/src/SoundClassifier/speechcommands.js
@@ -12,7 +12,9 @@ export class SpeechCommands {
   }
 
   async load() {
-    this.model = tfjsSpeechCommands.create('BROWSER_FFT');
+    const { modelJson, metadataJson } = this.options;
+    if (modelJson && metadataJson) this.model = tfjsSpeechCommands.create('BROWSER_FFT', undefined, modelJson, metadataJson);
+    else this.model = tfjsSpeechCommands.create('BROWSER_FFT');
     await this.model.ensureModelLoaded();
     this.allLabels = this.model.wordLabels();
   }


### PR DESCRIPTION
## → Submit changes to the relevant branch 🌲
`development`

## → Description 📝

A clear and concise description of what the pull request is about. Let us know if you are:
- adding an update 🛠

## → Relevant Example or Paired Pull Request to [ml5-examples](https://github.com/ml5js/ml5-examples) 🦄
https://github.com/ml5js/ml5-examples/pull/157

## → Relevant documentation 🌴
This PR enables ml5.soundClassifier to load a pre-trained custom speech commands model from an external URL
```javascript
const options = {
  probabilityThreshold: 0.5,
  overlapFactor: 0.75,
  modelJson: 'https://storage.googleapis.com/tm-speech-commands/eye-test-sound-yining/model.json',
  metadataJson: 'https://storage.googleapis.com/tm-speech-commands/eye-test-sound-yining/metadata.json'
};

function preload() {
  // Load SpeechCommands18w sound classifier model
  classifier = ml5.soundClassifier('SpeechCommands18w', options);
}
```

They both support loading the model in the p5 `preload()` function as well as using a callback function.