### PR TITLE
Adds face-api.js to ml5.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5195,6 +5195,29 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
+    "face-api.js": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/face-api.js/-/face-api.js-0.20.0.tgz",
+      "integrity": "sha512-9yDRChHdqT61AI+bGrNz5PJDHZl8+6CD4hoMChlteHAYInZIOEMhM6Wbn+2YcLVW+rUhufhanMQ9JjHV+x3ATg==",
+      "requires": {
+        "@tensorflow/tfjs-core": "1.0.3",
+        "tfjs-image-recognition-base": "^0.6.0",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@tensorflow/tfjs-core": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-1.0.3.tgz",
+          "integrity": "sha512-2UbjMQkmrykIIZuoRfmDPrtWm+6fdQRlYLCUJdiOIooeu/q4nye587HM1qKcdZosGPZTW6VvX+4VIVieYn5i0A==",
+          "requires": {
+            "@types/seedrandom": "2.4.27",
+            "@types/webgl-ext": "0.0.30",
+            "@types/webgl2": "0.0.4",
+            "seedrandom": "2.4.3"
+          }
+        }
+      }
+    },
     "fast-deep-equal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
@@ -13748,6 +13771,28 @@
       "integrity": "sha512-qftQXnX1DzpSV8EddtHIT0eDDEiBF8ywhFYR2lI9xrGtxqKN+CvLXhACeCIGbCpQfxxERbrkZEFb8cZcDKbVZA==",
       "dev": true
     },
+    "tfjs-image-recognition-base": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tfjs-image-recognition-base/-/tfjs-image-recognition-base-0.6.0.tgz",
+      "integrity": "sha512-wFk3ivWjdQwsXgEfU1PdTf3smve2AbCjiwJKrq9lDGmKh75aL8UIy0bVNa15r+8sFaT4vJz/9AKOSI0w78wW0g==",
+      "requires": {
+        "@tensorflow/tfjs-core": "1.0.3",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@tensorflow/tfjs-core": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-1.0.3.tgz",
+          "integrity": "sha512-2UbjMQkmrykIIZuoRfmDPrtWm+6fdQRlYLCUJdiOIooeu/q4nye587HM1qKcdZosGPZTW6VvX+4VIVieYn5i0A==",
+          "requires": {
+            "@types/seedrandom": "2.4.27",
+            "@types/webgl-ext": "0.0.30",
+            "@types/webgl2": "0.0.4",
+            "seedrandom": "2.4.3"
+          }
+        }
+      }
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -13919,8 +13964,7 @@
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-      "dev": true
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tsscmp": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -89,12 +89,13 @@
   },
   "dependencies": {
     "@magenta/sketch": "0.2.0",
+    "@tensorflow-models/body-pix": "1.0.1",
     "@tensorflow-models/knn-classifier": "1.0.0",
     "@tensorflow-models/mobilenet": "1.0.0",
     "@tensorflow-models/posenet": "1.0.0",
     "@tensorflow-models/speech-commands": "0.3.8",
-    "@tensorflow-models/body-pix": "1.0.1",
     "@tensorflow/tfjs": "1.1.2",
-    "events": "^3.0.0"
+    "events": "^3.0.0",
+    "face-api.js": "^0.20.0"
   }
 }

--- a/src/FaceApi/index.js
+++ b/src/FaceApi/index.js
@@ -55,15 +55,6 @@ class FaceApiBase {
         this.ready = callCallback(this.loadModel(), callback);
     }
 
-    checkUndefined(_param, _default) {
-        return _param !== undefined ? _param : _default;
-    }
-
-    getModelPath(absoluteOrRelativeUrl) {
-        const modelJsonPath = this.isAbsoluteURL(absoluteOrRelativeUrl) ? absoluteOrRelativeUrl : window.location.pathname + absoluteOrRelativeUrl
-        return modelJsonPath;
-    }
-
     /**
      * Load the model and set it to this.model
      * @return {this} the BodyPix model.
@@ -171,6 +162,7 @@ class FaceApiBase {
             });
         }
 
+        // sets the return options if any are passed in during .detect() or .detectSingle()
         this.config = this.setReturnOptions(faceApiOptions);
 
         const {
@@ -196,7 +188,7 @@ class FaceApiBase {
             result = await this.model.detectAllFaces(imgToClassify).withFaceLandmarks().withFaceExpressions().withFaceDescriptors();
         }
 
-        
+
         // always resize the results to the input image size
         result = this.resizeResults(result, imgToClassify.width, imgToClassify.height)
         // assign the {parts} object after resizing
@@ -275,6 +267,7 @@ class FaceApiBase {
             });
         }
 
+        // sets the return options if any are passed in during .detect() or .detectSingle()
         this.config = this.setReturnOptions(faceApiOptions);
 
         const {
@@ -282,7 +275,6 @@ class FaceApiBase {
             withExpressions,
             withDescriptors
         } = this.config
-
 
         let result;
         if (withLandmarks) {
@@ -309,13 +301,35 @@ class FaceApiBase {
         return result
     }
 
-    
-    setReturnOptions(faceApiOptions){
+    /**
+     * Check if the given _param is undefined, otherwise return the _default
+     * @param {*} _param 
+     * @param {*} _default 
+     */
+    checkUndefined(_param, _default) {
+        return _param !== undefined ? _param : _default;
+    }
+
+    /**
+     * Checks if the given string is an absolute or relative path and returns 
+     *      the path to the modelJson 
+     * @param {String} absoluteOrRelativeUrl 
+     */
+    getModelPath(absoluteOrRelativeUrl) {
+        const modelJsonPath = this.isAbsoluteURL(absoluteOrRelativeUrl) ? absoluteOrRelativeUrl : window.location.pathname + absoluteOrRelativeUrl
+        return modelJsonPath;
+    }
+
+    /**
+     * Sets the return options for .detect() or .detectSingle() in case any are given
+     * @param {Object} faceApiOptions 
+     */
+    setReturnOptions(faceApiOptions) {
         const output = Object.assign({}, this.config);
         const options = ["withLandmarks", "withLandmarks", "withDescriptors"];
 
         options.forEach(prop => {
-            if(faceApiOptions[prop] !== undefined){
+            if (faceApiOptions[prop] !== undefined) {
                 this.config[prop] = faceApiOptions[prop]
             } else {
                 output[prop] = this.config[prop];
@@ -324,7 +338,6 @@ class FaceApiBase {
 
         return output;
     }
-
 
     /**
      * Resize results to size of input image
@@ -350,24 +363,26 @@ class FaceApiBase {
      * get parts from landmarks
      * @param {*} result 
      */
-    landmarkParts(result){
+    landmarkParts(result) {
         let output;
         // multiple detections is an array
-        if(Array.isArray(result) === true){
-            output = result.map( item => {
+        if (Array.isArray(result) === true) {
+            output = result.map(item => {
                 // if landmarks exist return parts
                 const newItem = Object.assign({}, item);
-                if(newItem.landmarks){
-                    const {landmarks} = newItem;
+                if (newItem.landmarks) {
+                    const {
+                        landmarks
+                    } = newItem;
                     newItem.parts = {
-                        mouth:landmarks.getMouth(),
-                        nose:landmarks.getNose(),
-                        leftEye:landmarks.getLeftEye(),
-                        leftEyeBrow:landmarks.getLeftEyeBrow(),
-                        rightEye:landmarks.getRightEye(),
-                        rightEyeBrow:landmarks.getRightEyeBrow()
+                        mouth: landmarks.getMouth(),
+                        nose: landmarks.getNose(),
+                        leftEye: landmarks.getLeftEye(),
+                        leftEyeBrow: landmarks.getLeftEyeBrow(),
+                        rightEye: landmarks.getRightEye(),
+                        rightEyeBrow: landmarks.getRightEyeBrow()
                     }
-                } else{
+                } else {
                     newItem.parts = {
                         mouth: [],
                         nose: [],
@@ -379,20 +394,22 @@ class FaceApiBase {
                 }
                 return newItem;
             })
-        // single detection is an object
+            // single detection is an object
         } else {
             output = Object.assign({}, result);
-            if(output.landmarks){
-                const {landmarks} = result;
+            if (output.landmarks) {
+                const {
+                    landmarks
+                } = result;
                 output.parts = {
-                    mouth:landmarks.getMouth(),
-                    nose:landmarks.getNose(),
-                    leftEye:landmarks.getLeftEye(),
-                    leftEyeBrow:landmarks.getLeftEyeBrow(),
-                    rightEye:landmarks.getRightEye(),
-                    rightEyeBrow:landmarks.getRightEyeBrow()
+                    mouth: landmarks.getMouth(),
+                    nose: landmarks.getNose(),
+                    leftEye: landmarks.getLeftEye(),
+                    leftEyeBrow: landmarks.getLeftEyeBrow(),
+                    rightEye: landmarks.getRightEye(),
+                    rightEyeBrow: landmarks.getRightEyeBrow()
                 }
-            } else{
+            } else {
                 output.parts = {
                     mouth: [],
                     nose: [],

--- a/src/FaceApi/index.js
+++ b/src/FaceApi/index.js
@@ -102,7 +102,7 @@ class FaceApiBase {
 
 
     /**
-     * detect multiple
+     * .detect() - classifies multiple features by default
      * @param {*} optionsOrCallback 
      * @param {*} configOrCallback 
      * @param {*} cb 
@@ -171,9 +171,7 @@ class FaceApiBase {
             });
         }
 
-        this.config.withLandmarks = faceApiOptions.withLandmarks !== undefined ? faceApiOptions.withLandmarks : this.config.withLandmarks;
-        this.config.withExpressions = faceApiOptions.withExpressions !== undefined ? faceApiOptions.withExpressions : this.config.withExpressions;
-        this.config.withDescriptors = faceApiOptions.withDescriptors !== undefined ? faceApiOptions.withDescriptors : this.config.withDescriptors;
+        this.config = this.setReturnOptions(faceApiOptions);
 
         const {
             withLandmarks,
@@ -208,7 +206,7 @@ class FaceApiBase {
     }
 
     /**
-     * detect single
+     * .detecSinglet() - classifies a single feature with higher accuracy
      * @param {*} optionsOrCallback 
      * @param {*} configOrCallback 
      * @param {*} cb 
@@ -277,9 +275,7 @@ class FaceApiBase {
             });
         }
 
-        this.config.withLandmarks = faceApiOptions.withLandmarks !== undefined ? faceApiOptions.withLandmarks : this.config.withLandmarks;
-        this.config.withExpressions = faceApiOptions.withLandmarks !== undefined ? faceApiOptions.withExpressions : this.config.withExpressions;
-        this.config.withDescriptors = faceApiOptions.withLandmarks !== undefined ? faceApiOptions.withDescriptors : this.config.withDescriptors;
+        this.config = this.setReturnOptions(faceApiOptions);
 
         const {
             withLandmarks,
@@ -311,6 +307,22 @@ class FaceApiBase {
         result = this.landmarkParts(result);
 
         return result
+    }
+
+    
+    setReturnOptions(faceApiOptions){
+        const output = Object.assign({}, this.config);
+        const options = ["withLandmarks", "withLandmarks", "withDescriptors"];
+
+        options.forEach(prop => {
+            if(faceApiOptions[prop] !== undefined){
+                this.config[prop] = faceApiOptions[prop]
+            } else {
+                output[prop] = this.config[prop];
+            }
+        })
+
+        return output;
     }
 
 

--- a/src/FaceApi/index.js
+++ b/src/FaceApi/index.js
@@ -1,0 +1,157 @@
+// Copyright (c) 2019 ml5
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+/* eslint prefer-destructuring: ["error", {AssignmentExpression: {array: false}}] */
+/* eslint no-await-in-loop: "off" */
+
+/*
+ * BodyPix: Real-time Person Segmentation in the Browser
+ * Ported and integrated from all the hard work by: https://github.com/tensorflow/tfjs-models/tree/master/body-pix
+ */
+
+import * as tf from '@tensorflow/tfjs';
+import * as faceapi from 'face-api.js';
+import callCallback from '../utils/callcallback';
+// import * as p5Utils from '../utils/p5Utils';
+
+// const DEFAULTS = {
+//     MODEL_URL: ''
+// }
+
+class FaceApiBase {
+    /**
+     * Create FaceApi.
+     * @param {HTMLVideoElement} video - An HTMLVideoElement.
+     * @param {object} options - An object with options.
+     * @param {function} callback - A callback to be called when the model is ready.
+     */
+    constructor(modelPath, video, options, callback) {
+        this.video = video;
+        this.model = null;
+        this.modelReady = false;
+        this.modelPath = modelPath;
+        this.config = {}
+
+        this.ready = callCallback(this.loadModel(), callback);
+    }
+
+    /**
+     * Load the model and set it to this.model
+     * @return {this} the BodyPix model.
+     */
+    async loadModel() {
+        this.model = faceapi;
+        await this.model.loadSsdMobilenetv1Model(this.modelPath)
+        await this.model.loadFaceLandmarkModel(this.modelPath)
+        await this.model.loadFaceRecognitionModel(this.modelPath)
+        await this.model.loadFaceExpressionModel(this.modelPath)
+        console.log('done!')
+        this.modelReady = true;
+        return this;
+    }
+
+    async classifyExpressionsInternal(imgToClassify){
+        await this.ready;
+        await tf.nextFrame();
+
+        if (this.video && this.video.readyState === 0) {
+            await new Promise(resolve => {
+                this.video.onloadeddata = () => resolve();
+            });
+        }
+
+        const expression = await this.model.detectAllFaces(imgToClassify).withFaceExpressions()
+        return expression
+    }
+
+    async classifyExpressions(optionsOrCallback, configOrCallback, cb){
+        let imgToClassify = this.video;
+        let callback;
+        // let segmentationOptions = this.config;
+
+        // Handle the image to predict
+        if (typeof optionsOrCallback === 'function') {
+            imgToClassify = this.video;
+            callback = optionsOrCallback;
+            // clean the following conditional statement up!
+        } else if (optionsOrCallback instanceof HTMLImageElement) {
+            imgToClassify = optionsOrCallback;
+        } else if (
+            typeof optionsOrCallback === 'object' &&
+            optionsOrCallback.elt instanceof HTMLImageElement
+        ) {
+            imgToClassify = optionsOrCallback.elt; // Handle p5.js image
+        } else if (optionsOrCallback instanceof HTMLCanvasElement) {
+            imgToClassify = optionsOrCallback;
+        } else if (
+            typeof optionsOrCallback === 'object' &&
+            optionsOrCallback.elt instanceof HTMLCanvasElement
+        ) {
+            imgToClassify = optionsOrCallback.elt; // Handle p5.js image
+        } else if (
+            typeof optionsOrCallback === 'object' &&
+            optionsOrCallback.canvas instanceof HTMLCanvasElement
+        ) {
+            imgToClassify = optionsOrCallback.canvas; // Handle p5.js image
+        } else if (!(this.video instanceof HTMLVideoElement)) {
+            // Handle unsupported input
+            throw new Error(
+                'No input image provided. If you want to classify a video, pass the video element in the constructor. ',
+            );
+        }
+
+        // if (typeof configOrCallback === 'object') {
+        //     segmentationOptions = configOrCallback;
+        // } else 
+        
+        if (typeof configOrCallback === 'function') {
+            callback = configOrCallback;
+        }
+
+        if (typeof cb === 'function') {
+            callback = cb;
+        }
+
+        return callCallback(this.classifyExpressionsInternal(imgToClassify), callback);
+
+    }
+
+}
+
+const faceApi = (modelPath, videoOrOptionsOrCallback, optionsOrCallback, cb) => {
+    let video;
+    let options = {};
+    let callback = cb;
+
+    if (typeof modelPath !== 'string') {
+        throw new Error('Please specify a relative path to your model to use. E.g: "/models/"');
+    }
+
+   const model = modelPath;
+
+    if (videoOrOptionsOrCallback instanceof HTMLVideoElement) {
+        video = videoOrOptionsOrCallback;
+    } else if (
+        typeof videoOrOptionsOrCallback === 'object' &&
+        videoOrOptionsOrCallback.elt instanceof HTMLVideoElement
+    ) {
+        video = videoOrOptionsOrCallback.elt; // Handle a p5.js video element
+    } else if (typeof videoOrOptionsOrCallback === 'object') {
+        options = videoOrOptionsOrCallback;
+    } else if (typeof videoOrOptionsOrCallback === 'function') {
+        callback = videoOrOptionsOrCallback;
+    }
+
+    if (typeof optionsOrCallback === 'object') {
+        options = optionsOrCallback;
+    } else if (typeof optionsOrCallback === 'function') {
+        callback = optionsOrCallback;
+    }
+
+    const instance = new FaceApiBase(model, video, options, callback);
+    return callback ? instance : instance.ready;
+}
+
+export default faceApi;

--- a/src/FaceApi/index.js
+++ b/src/FaceApi/index.js
@@ -19,6 +19,7 @@ const DEFAULTS = {
     MODEL_URLS: {
         Mobilenetv1Model: 'https://raw.githubusercontent.com/ml5js/ml5-data-and-models/face-api/models/faceapi/ssd_mobilenetv1_model-weights_manifest.json',
         FaceLandmarkModel: 'https://raw.githubusercontent.com/ml5js/ml5-data-and-models/face-api/models/faceapi/face_landmark_68_model-weights_manifest.json',
+        FaceLandmark68TinyNet: 'https://raw.githubusercontent.com/ml5js/ml5-data-and-models/face-api/models/faceapi/face_landmark_68_tiny_model-weights_manifest.json',
         FaceRecognitionModel: 'https://raw.githubusercontent.com/ml5js/ml5-data-and-models/face-api/models/faceapi/face_recognition_model-weights_manifest.json',
         FaceExpressionModel: 'https://raw.githubusercontent.com/ml5js/ml5-data-and-models/face-api/models/faceapi/face_expression_model-weights_manifest.json'
     }
@@ -39,6 +40,7 @@ class FaceApiBase {
             MODEL_URLS: {
                 Mobilenetv1Model: options.Mobilenetv1Model || DEFAULTS.MODEL_URLS.Mobilenetv1Model,
                 FaceLandmarkModel: options.FaceLandmarkModel || DEFAULTS.MODEL_URLS.FaceLandmarkModel,
+                FaceLandmark68TinyNet: options.FaceLandmark68TinyNet || DEFAULTS.MODEL_URLS.FaceLandmark68TinyNet,
                 FaceRecognitionModel: options.FaceRecognitionModel || DEFAULTS.MODEL_URLS.FaceRecognitionModel,
                 FaceExpressionModel: options.FaceExpressionModel || DEFAULTS.MODEL_URLS.FaceExpressionModel,
             }
@@ -57,6 +59,7 @@ class FaceApiBase {
         this.model = faceapi;
         await this.model.loadSsdMobilenetv1Model(Mobilenetv1Model)
         await this.model.loadFaceLandmarkModel(FaceLandmarkModel)
+        // await this.model.loadFaceLandmarkTinyModel(FaceLandmark68TinyNet) 
         await this.model.loadFaceRecognitionModel(FaceRecognitionModel)
         await this.model.loadFaceExpressionModel(FaceExpressionModel)
         this.modelReady = true;

--- a/src/FaceApi/index.js
+++ b/src/FaceApi/index.js
@@ -38,11 +38,11 @@ class FaceApiBase {
         this.modelReady = false;
         this.config = {
             MODEL_URLS: {
-                Mobilenetv1Model: this.getModelPath(options.Mobilenetv1Model) || DEFAULTS.MODEL_URLS.Mobilenetv1Model,
-                FaceLandmarkModel: this.getModelPath(options.FaceLandmarkModel) || DEFAULTS.MODEL_URLS.FaceLandmarkModel,
-                FaceLandmark68TinyNet: this.getModelPath(options.FaceLandmark68TinyNet) || DEFAULTS.MODEL_URLS.FaceLandmark68TinyNet,
-                FaceRecognitionModel: this.getModelPath(options.FaceRecognitionModel) || DEFAULTS.MODEL_URLS.FaceRecognitionModel,
-                FaceExpressionModel: this.getModelPath(options.FaceExpressionModel) || DEFAULTS.MODEL_URLS.FaceExpressionModel,
+                Mobilenetv1Model: options.Mobilenetv1Model || DEFAULTS.MODEL_URLS.Mobilenetv1Model,
+                FaceLandmarkModel: options.FaceLandmarkModel || DEFAULTS.MODEL_URLS.FaceLandmarkModel,
+                FaceLandmark68TinyNet: options.FaceLandmark68TinyNet || DEFAULTS.MODEL_URLS.FaceLandmark68TinyNet,
+                FaceRecognitionModel: options.FaceRecognitionModel || DEFAULTS.MODEL_URLS.FaceRecognitionModel,
+                FaceExpressionModel: options.FaceExpressionModel || DEFAULTS.MODEL_URLS.FaceExpressionModel,
             }
         }
 
@@ -59,7 +59,22 @@ class FaceApiBase {
      * @return {this} the BodyPix model.
      */
     async loadModel() {
+        const modelOptions = [
+            "Mobilenetv1Model",
+            "FaceLandmarkModel",
+            "FaceLandmark68TinyNet",
+            "FaceRecognitionModel",
+            "FaceExpressionModel",
+        ];
+
+        Object.keys(this.config.MODEL_URLS).forEach(item => {
+            if(modelOptions.includes(item)){
+                this.config.MODEL_URLS[item] = this.getModelPath(this.config.MODEL_URLS[item]);
+            }
+        });
+
         const {Mobilenetv1Model, FaceLandmarkModel, FaceRecognitionModel, FaceExpressionModel} = this.config.MODEL_URLS;
+
         
         this.model = faceapi;
         await this.model.loadSsdMobilenetv1Model(Mobilenetv1Model)

--- a/src/FaceApi/index.js
+++ b/src/FaceApi/index.js
@@ -95,6 +95,13 @@ class FaceApiBase {
         return this;
     }
 
+
+    /**
+     * detect multiple
+     * @param {*} optionsOrCallback 
+     * @param {*} configOrCallback 
+     * @param {*} cb 
+     */
     async detect(optionsOrCallback, configOrCallback, cb){
         let imgToClassify = this.video;
         let callback;
@@ -145,7 +152,7 @@ class FaceApiBase {
     }
 
     /**
-     * Detects multiple
+     * Detects multiple internal function
      * @param {HTMLImageElement || HTMLVideoElement} imgToClassify 
      * @param {Object} faceApiOptions 
      */
@@ -181,9 +188,19 @@ class FaceApiBase {
             result = await this.model.detectAllFaces(imgToClassify).withFaceLandmarks().withFaceExpressions().withFaceDescriptors();
         }
         
+        // always resize the results to the input image size
+        result = this.resizeResults(result, imgToClassify.width, imgToClassify.height)
+
         return result
     }
 
+
+    /**
+     * detect single
+     * @param {*} optionsOrCallback 
+     * @param {*} configOrCallback 
+     * @param {*} cb 
+     */
     async detectSingle(optionsOrCallback, configOrCallback, cb){
         let imgToClassify = this.video;
         let callback;
@@ -256,9 +273,9 @@ class FaceApiBase {
 
 
         let result;
-
         if(withFaceLandmarks){
             if (withFaceExpressions && withFaceDescriptors) {
+                
                 result = await this.model.detectSingleFace(imgToClassify).withFaceLandmarks().withFaceExpressions().withFaceDescriptor();
             } else if(withFaceExpressions){
                 result = await this.model.detectSingleFace(imgToClassify).withFaceLandmarks().withFaceExpressions();
@@ -270,8 +287,23 @@ class FaceApiBase {
         } else {
             result = await this.model.detectSingleFace(imgToClassify).withFaceLandmarks().withFaceExpressions().withFaceDescriptor();
         }
+
+        // always resize the results to the input image size
+        result = this.resizeResults(result, imgToClassify.width, imgToClassify.height)
         
         return result
+    }
+
+
+    /**
+     * 
+     * @param {*} str 
+     */
+    resizeResults(detections, width, height){
+        if(width === undefined || height === undefined){
+            throw new Error('width and height must be defined')
+        }
+        return this.model.resizeResults(detections, {"width": width, "height": height})
     }
 
     /* eslint class-methods-use-this: "off" */
@@ -279,6 +311,10 @@ class FaceApiBase {
         const pattern = new RegExp('^(?:[a-z]+:)?//', 'i');
         return !!pattern.test(str);
     }
+
+
+
+
 
 }
 

--- a/src/FaceApi/index.js
+++ b/src/FaceApi/index.js
@@ -38,16 +38,21 @@ class FaceApiBase {
         this.modelReady = false;
         this.config = {
             MODEL_URLS: {
-                Mobilenetv1Model: options.Mobilenetv1Model || DEFAULTS.MODEL_URLS.Mobilenetv1Model,
-                FaceLandmarkModel: options.FaceLandmarkModel || DEFAULTS.MODEL_URLS.FaceLandmarkModel,
-                FaceLandmark68TinyNet: options.FaceLandmark68TinyNet || DEFAULTS.MODEL_URLS.FaceLandmark68TinyNet,
-                FaceRecognitionModel: options.FaceRecognitionModel || DEFAULTS.MODEL_URLS.FaceRecognitionModel,
-                FaceExpressionModel: options.FaceExpressionModel || DEFAULTS.MODEL_URLS.FaceExpressionModel,
+                Mobilenetv1Model: this.getModelPath(options.Mobilenetv1Model) || DEFAULTS.MODEL_URLS.Mobilenetv1Model,
+                FaceLandmarkModel: this.getModelPath(options.FaceLandmarkModel) || DEFAULTS.MODEL_URLS.FaceLandmarkModel,
+                FaceLandmark68TinyNet: this.getModelPath(options.FaceLandmark68TinyNet) || DEFAULTS.MODEL_URLS.FaceLandmark68TinyNet,
+                FaceRecognitionModel: this.getModelPath(options.FaceRecognitionModel) || DEFAULTS.MODEL_URLS.FaceRecognitionModel,
+                FaceExpressionModel: this.getModelPath(options.FaceExpressionModel) || DEFAULTS.MODEL_URLS.FaceExpressionModel,
             }
         }
 
         this.ready = callCallback(this.loadModel(), callback);
     }
+
+    getModelPath(absoluteOrRelativeUrl ){
+        const modelJsonPath = this.isAbsoluteURL(absoluteOrRelativeUrl) ? absoluteOrRelativeUrl : window.location.pathname + absoluteOrRelativeUrl
+        return modelJsonPath;
+    }   
 
     /**
      * Load the model and set it to this.model
@@ -196,6 +201,12 @@ class FaceApiBase {
 
         return callCallback(this.classifyExpressionsSingleInternal(imgToClassify), callback);
 
+    }
+
+    /* eslint class-methods-use-this: "off" */
+    isAbsoluteURL(str) {
+        const pattern = new RegExp('^(?:[a-z]+:)?//', 'i');
+        return !!pattern.test(str);
     }
 
 }

--- a/src/FaceApi/index.js
+++ b/src/FaceApi/index.js
@@ -86,7 +86,7 @@ class FaceApiBase {
         return this;
     }
 
-    async classifyExpressionsMultipleInternal(imgToClassify){
+    async classifyMultipleInternal(imgToClassify){
         await this.ready;
         await tf.nextFrame();
 
@@ -100,7 +100,7 @@ class FaceApiBase {
         return expression
     }
 
-    async classifyExpressionsMultiple(optionsOrCallback, configOrCallback, cb){
+    async classifyMultiple(optionsOrCallback, configOrCallback, cb){
         let imgToClassify = this.video;
         let callback;
         // let faceApiOptions = this.config;
@@ -148,11 +148,11 @@ class FaceApiBase {
             callback = cb;
         }
 
-        return callCallback(this.classifyExpressionsMultipleInternal(imgToClassify), callback);
+        return callCallback(this.classifyMultipleInternal(imgToClassify), callback);
 
     }
 
-    async classifyExpressionsSingleInternal(imgToClassify){
+    async classifySingleInternal(imgToClassify){
         await this.ready;
         await tf.nextFrame();
 
@@ -166,7 +166,7 @@ class FaceApiBase {
         return expression
     }
 
-    async classifyExpressionsSingle(optionsOrCallback, configOrCallback, cb){
+    async classifySingle(optionsOrCallback, configOrCallback, cb){
         let imgToClassify = this.video;
         let callback;
         // let faceApiOptions = this.config;
@@ -214,7 +214,7 @@ class FaceApiBase {
             callback = cb;
         }
 
-        return callCallback(this.classifyExpressionsSingleInternal(imgToClassify), callback);
+        return callCallback(this.classifySingleInternal(imgToClassify), callback);
 
     }
 

--- a/src/FaceApi/index.js
+++ b/src/FaceApi/index.js
@@ -40,19 +40,23 @@ class FaceApiBase {
         this.model = null;
         this.modelReady = false;
         this.config = {
-            withFaceLandmarks: options.withFaceLandmarks || DEFAULTS.withFaceLandmarks,
-            withFaceExpressions: options.withFaceExpressions || DEFAULTS.withFaceExpressions,
-            withFaceDescriptors: options.withFaceDescriptors || DEFAULTS.withFaceDescriptors,
+            withFaceLandmarks: this.checkUndefined(options.withFaceLandmarks, DEFAULTS.withFaceLandmarks),
+            withFaceExpressions: this.checkUndefined(options.withFaceExpressions, DEFAULTS.withFaceExpressions),
+            withFaceDescriptors: this.checkUndefined(options.withFaceDescriptors, DEFAULTS.withFaceDescriptors),
             MODEL_URLS: {
-                Mobilenetv1Model: options.Mobilenetv1Model || DEFAULTS.MODEL_URLS.Mobilenetv1Model,
-                FaceLandmarkModel: options.FaceLandmarkModel || DEFAULTS.MODEL_URLS.FaceLandmarkModel,
-                FaceLandmark68TinyNet: options.FaceLandmark68TinyNet || DEFAULTS.MODEL_URLS.FaceLandmark68TinyNet,
-                FaceRecognitionModel: options.FaceRecognitionModel || DEFAULTS.MODEL_URLS.FaceRecognitionModel,
-                FaceExpressionModel: options.FaceExpressionModel || DEFAULTS.MODEL_URLS.FaceExpressionModel,
+                Mobilenetv1Model: this.checkUndefined(options.Mobilenetv1Model, DEFAULTS.MODEL_URLS.Mobilenetv1Model),
+                FaceLandmarkModel: this.checkUndefined(options.FaceLandmarkModel, DEFAULTS.MODEL_URLS.FaceLandmarkModel),
+                FaceLandmark68TinyNet: this.checkUndefined(options.FaceLandmark68TinyNet, DEFAULTS.MODEL_URLS.FaceLandmark68TinyNet),
+                FaceRecognitionModel: this.checkUndefined(options.FaceRecognitionModel, DEFAULTS.MODEL_URLS.FaceRecognitionModel),
+                FaceExpressionModel: this.checkUndefined(options.FaceExpressionModel, DEFAULTS.MODEL_URLS.FaceExpressionModel),
             }
         }
-
+        
         this.ready = callCallback(this.loadModel(), callback);
+    }
+
+    checkUndefined(_param, _default){
+        return _param !== undefined ? _param : _default;
     }
 
     getModelPath(absoluteOrRelativeUrl ){
@@ -80,7 +84,6 @@ class FaceApiBase {
         });
 
         const {Mobilenetv1Model, FaceLandmarkModel, FaceRecognitionModel, FaceExpressionModel} = this.config.MODEL_URLS;
-
         
         this.model = faceapi;
         await this.model.loadSsdMobilenetv1Model(Mobilenetv1Model)
@@ -141,6 +144,11 @@ class FaceApiBase {
         return callCallback(this.detectInternal(imgToClassify, faceApiOptions), callback);
     }
 
+    /**
+     * Detects multiple
+     * @param {HTMLImageElement || HTMLVideoElement} imgToClassify 
+     * @param {Object} faceApiOptions 
+     */
     async detectInternal(imgToClassify, faceApiOptions){
         await this.ready;
         await tf.nextFrame();
@@ -156,7 +164,6 @@ class FaceApiBase {
         this.config.withFaceDescriptors =   faceApiOptions.withFaceDescriptors !== undefined ? faceApiOptions.withFaceDescriptors : this.config.withFaceDescriptors;
 
         const {withFaceLandmarks, withFaceExpressions, withFaceDescriptors} = this.config
-
 
         let result;
 
@@ -226,6 +233,11 @@ class FaceApiBase {
         return callCallback(this.detectSingleInternal(imgToClassify, faceApiOptions), callback);
     }
 
+    /**
+     * Detects only a single feature
+     * @param {HTMLImageElement || HTMLVideoElement} imgToClassify 
+     * @param {Object} faceApiOptions 
+     */
     async detectSingleInternal(imgToClassify, faceApiOptions){
         await this.ready;
         await tf.nextFrame();
@@ -275,12 +287,6 @@ const faceApi = (videoOrOptionsOrCallback, optionsOrCallback, cb) => {
     let options = {};
     let callback = cb;
 
-//     if (typeof modelPath !== 'string') {
-//         throw new Error('Please specify a relative path to your model to use. E.g: "/models/"');
-//     }
-
-//    const model = modelPath;
-
     if (videoOrOptionsOrCallback instanceof HTMLVideoElement) {
         video = videoOrOptionsOrCallback;
     } else if (
@@ -295,7 +301,9 @@ const faceApi = (videoOrOptionsOrCallback, optionsOrCallback, cb) => {
     }
 
     if (typeof optionsOrCallback === 'object') {
+        
         options = optionsOrCallback;
+        console.log(options)
     } else if (typeof optionsOrCallback === 'function') {
         callback = optionsOrCallback;
     }

--- a/src/FaceApi/index.js
+++ b/src/FaceApi/index.js
@@ -51,18 +51,18 @@ class FaceApiBase {
                 FaceExpressionModel: this.checkUndefined(options.FaceExpressionModel, DEFAULTS.MODEL_URLS.FaceExpressionModel),
             }
         }
-        
+
         this.ready = callCallback(this.loadModel(), callback);
     }
 
-    checkUndefined(_param, _default){
+    checkUndefined(_param, _default) {
         return _param !== undefined ? _param : _default;
     }
 
-    getModelPath(absoluteOrRelativeUrl ){
+    getModelPath(absoluteOrRelativeUrl) {
         const modelJsonPath = this.isAbsoluteURL(absoluteOrRelativeUrl) ? absoluteOrRelativeUrl : window.location.pathname + absoluteOrRelativeUrl
         return modelJsonPath;
-    }   
+    }
 
     /**
      * Load the model and set it to this.model
@@ -78,13 +78,18 @@ class FaceApiBase {
         ];
 
         Object.keys(this.config.MODEL_URLS).forEach(item => {
-            if(modelOptions.includes(item)){
+            if (modelOptions.includes(item)) {
                 this.config.MODEL_URLS[item] = this.getModelPath(this.config.MODEL_URLS[item]);
             }
         });
 
-        const {Mobilenetv1Model, FaceLandmarkModel, FaceRecognitionModel, FaceExpressionModel} = this.config.MODEL_URLS;
-        
+        const {
+            Mobilenetv1Model,
+            FaceLandmarkModel,
+            FaceRecognitionModel,
+            FaceExpressionModel
+        } = this.config.MODEL_URLS;
+
         this.model = faceapi;
         await this.model.loadSsdMobilenetv1Model(Mobilenetv1Model)
         await this.model.loadFaceLandmarkModel(FaceLandmarkModel)
@@ -102,7 +107,7 @@ class FaceApiBase {
      * @param {*} configOrCallback 
      * @param {*} cb 
      */
-    async detect(optionsOrCallback, configOrCallback, cb){
+    async detect(optionsOrCallback, configOrCallback, cb) {
         let imgToClassify = this.video;
         let callback;
         let faceApiOptions = this.config;
@@ -138,7 +143,7 @@ class FaceApiBase {
             );
         }
 
-         if (typeof configOrCallback === 'object') {
+        if (typeof configOrCallback === 'object') {
             faceApiOptions = configOrCallback;
         } else if (typeof configOrCallback === 'function') {
             callback = configOrCallback;
@@ -156,7 +161,7 @@ class FaceApiBase {
      * @param {HTMLImageElement || HTMLVideoElement} imgToClassify 
      * @param {Object} faceApiOptions 
      */
-    async detectInternal(imgToClassify, faceApiOptions){
+    async detectInternal(imgToClassify, faceApiOptions) {
         await this.ready;
         await tf.nextFrame();
 
@@ -166,18 +171,22 @@ class FaceApiBase {
             });
         }
 
-        this.config.withFaceLandmarks =  faceApiOptions.withFaceLandmarks !== undefined ? faceApiOptions.withFaceLandmarks : this.config.withFaceLandmarks;
-        this.config.withFaceExpressions =   faceApiOptions.withFaceExpressions !== undefined ? faceApiOptions.withFaceExpressions : this.config.withFaceExpressions;
-        this.config.withFaceDescriptors =   faceApiOptions.withFaceDescriptors !== undefined ? faceApiOptions.withFaceDescriptors : this.config.withFaceDescriptors;
+        this.config.withFaceLandmarks = faceApiOptions.withFaceLandmarks !== undefined ? faceApiOptions.withFaceLandmarks : this.config.withFaceLandmarks;
+        this.config.withFaceExpressions = faceApiOptions.withFaceExpressions !== undefined ? faceApiOptions.withFaceExpressions : this.config.withFaceExpressions;
+        this.config.withFaceDescriptors = faceApiOptions.withFaceDescriptors !== undefined ? faceApiOptions.withFaceDescriptors : this.config.withFaceDescriptors;
 
-        const {withFaceLandmarks, withFaceExpressions, withFaceDescriptors} = this.config
+        const {
+            withFaceLandmarks,
+            withFaceExpressions,
+            withFaceDescriptors
+        } = this.config
 
         let result;
 
-        if(withFaceLandmarks){
+        if (withFaceLandmarks) {
             if (withFaceExpressions && withFaceDescriptors) {
                 result = await this.model.detectAllFaces(imgToClassify).withFaceLandmarks().withFaceExpressions().withFaceDescriptors();
-            } else if(withFaceExpressions){
+            } else if (withFaceExpressions) {
                 result = await this.model.detectAllFaces(imgToClassify).withFaceLandmarks().withFaceExpressions();
             } else {
                 result = await this.model.detectAllFaces(imgToClassify).withFaceLandmarks()
@@ -187,7 +196,7 @@ class FaceApiBase {
         } else {
             result = await this.model.detectAllFaces(imgToClassify).withFaceLandmarks().withFaceExpressions().withFaceDescriptors();
         }
-        
+
         // always resize the results to the input image size
         result = this.resizeResults(result, imgToClassify.width, imgToClassify.height)
 
@@ -201,7 +210,7 @@ class FaceApiBase {
      * @param {*} configOrCallback 
      * @param {*} cb 
      */
-    async detectSingle(optionsOrCallback, configOrCallback, cb){
+    async detectSingle(optionsOrCallback, configOrCallback, cb) {
         let imgToClassify = this.video;
         let callback;
         let faceApiOptions = this.config;
@@ -237,7 +246,7 @@ class FaceApiBase {
             );
         }
 
-         if (typeof configOrCallback === 'object') {
+        if (typeof configOrCallback === 'object') {
             faceApiOptions = configOrCallback;
         } else if (typeof configOrCallback === 'function') {
             callback = configOrCallback;
@@ -255,7 +264,7 @@ class FaceApiBase {
      * @param {HTMLImageElement || HTMLVideoElement} imgToClassify 
      * @param {Object} faceApiOptions 
      */
-    async detectSingleInternal(imgToClassify, faceApiOptions){
+    async detectSingleInternal(imgToClassify, faceApiOptions) {
         await this.ready;
         await tf.nextFrame();
 
@@ -265,19 +274,22 @@ class FaceApiBase {
             });
         }
 
-        this.config.withFaceLandmarks =  faceApiOptions.withFaceLandmarks !== undefined ? faceApiOptions.withFaceLandmarks : this.config.withFaceLandmarks;
-        this.config.withFaceExpressions =   faceApiOptions.withFaceLandmarks !== undefined ? faceApiOptions.withFaceExpressions : this.config.withFaceExpressions;
-        this.config.withFaceDescriptors =   faceApiOptions.withFaceLandmarks !== undefined ? faceApiOptions.withFaceDescriptors : this.config.withFaceDescriptors;
+        this.config.withFaceLandmarks = faceApiOptions.withFaceLandmarks !== undefined ? faceApiOptions.withFaceLandmarks : this.config.withFaceLandmarks;
+        this.config.withFaceExpressions = faceApiOptions.withFaceLandmarks !== undefined ? faceApiOptions.withFaceExpressions : this.config.withFaceExpressions;
+        this.config.withFaceDescriptors = faceApiOptions.withFaceLandmarks !== undefined ? faceApiOptions.withFaceDescriptors : this.config.withFaceDescriptors;
 
-        const {withFaceLandmarks, withFaceExpressions, withFaceDescriptors} = this.config
+        const {
+            withFaceLandmarks,
+            withFaceExpressions,
+            withFaceDescriptors
+        } = this.config
 
 
         let result;
-        if(withFaceLandmarks){
+        if (withFaceLandmarks) {
             if (withFaceExpressions && withFaceDescriptors) {
-                
                 result = await this.model.detectSingleFace(imgToClassify).withFaceLandmarks().withFaceExpressions().withFaceDescriptor();
-            } else if(withFaceExpressions){
+            } else if (withFaceExpressions) {
                 result = await this.model.detectSingleFace(imgToClassify).withFaceLandmarks().withFaceExpressions();
             } else {
                 result = await this.model.detectSingleFace(imgToClassify).withFaceLandmarks()
@@ -290,20 +302,23 @@ class FaceApiBase {
 
         // always resize the results to the input image size
         result = this.resizeResults(result, imgToClassify.width, imgToClassify.height)
-        
+
         return result
     }
 
 
     /**
-     * 
+     * Resize results to size of input image
      * @param {*} str 
      */
-    resizeResults(detections, width, height){
-        if(width === undefined || height === undefined){
+    resizeResults(detections, width, height) {
+        if (width === undefined || height === undefined) {
             throw new Error('width and height must be defined')
         }
-        return this.model.resizeResults(detections, {"width": width, "height": height})
+        return this.model.resizeResults(detections, {
+            "width": width,
+            "height": height
+        })
     }
 
     /* eslint class-methods-use-this: "off" */
@@ -311,10 +326,6 @@ class FaceApiBase {
         const pattern = new RegExp('^(?:[a-z]+:)?//', 'i');
         return !!pattern.test(str);
     }
-
-
-
-
 
 }
 
@@ -337,7 +348,7 @@ const faceApi = (videoOrOptionsOrCallback, optionsOrCallback, cb) => {
     }
 
     if (typeof optionsOrCallback === 'object') {
-        
+
         options = optionsOrCallback;
         console.log(options)
     } else if (typeof optionsOrCallback === 'function') {

--- a/src/FaceApi/index.js
+++ b/src/FaceApi/index.js
@@ -16,9 +16,9 @@ import * as faceapi from 'face-api.js';
 import callCallback from '../utils/callcallback';
 
 const DEFAULTS = {
-    withFaceLandmarks: true,
-    withFaceExpressions: true,
-    withFaceDescriptors: true,
+    withLandmarks: true,
+    withExpressions: true,
+    withDescriptors: true,
     MODEL_URLS: {
         Mobilenetv1Model: 'https://raw.githubusercontent.com/ml5js/ml5-data-and-models/face-api/models/faceapi/ssd_mobilenetv1_model-weights_manifest.json',
         FaceLandmarkModel: 'https://raw.githubusercontent.com/ml5js/ml5-data-and-models/face-api/models/faceapi/face_landmark_68_model-weights_manifest.json',
@@ -40,9 +40,9 @@ class FaceApiBase {
         this.model = null;
         this.modelReady = false;
         this.config = {
-            withFaceLandmarks: this.checkUndefined(options.withFaceLandmarks, DEFAULTS.withFaceLandmarks),
-            withFaceExpressions: this.checkUndefined(options.withFaceExpressions, DEFAULTS.withFaceExpressions),
-            withFaceDescriptors: this.checkUndefined(options.withFaceDescriptors, DEFAULTS.withFaceDescriptors),
+            withLandmarks: this.checkUndefined(options.withLandmarks, DEFAULTS.withLandmarks),
+            withExpressions: this.checkUndefined(options.withExpressions, DEFAULTS.withExpressions),
+            withDescriptors: this.checkUndefined(options.withDescriptors, DEFAULTS.withDescriptors),
             MODEL_URLS: {
                 Mobilenetv1Model: this.checkUndefined(options.Mobilenetv1Model, DEFAULTS.MODEL_URLS.Mobilenetv1Model),
                 FaceLandmarkModel: this.checkUndefined(options.FaceLandmarkModel, DEFAULTS.MODEL_URLS.FaceLandmarkModel),
@@ -171,28 +171,28 @@ class FaceApiBase {
             });
         }
 
-        this.config.withFaceLandmarks = faceApiOptions.withFaceLandmarks !== undefined ? faceApiOptions.withFaceLandmarks : this.config.withFaceLandmarks;
-        this.config.withFaceExpressions = faceApiOptions.withFaceExpressions !== undefined ? faceApiOptions.withFaceExpressions : this.config.withFaceExpressions;
-        this.config.withFaceDescriptors = faceApiOptions.withFaceDescriptors !== undefined ? faceApiOptions.withFaceDescriptors : this.config.withFaceDescriptors;
+        this.config.withLandmarks = faceApiOptions.withLandmarks !== undefined ? faceApiOptions.withLandmarks : this.config.withLandmarks;
+        this.config.withExpressions = faceApiOptions.withExpressions !== undefined ? faceApiOptions.withExpressions : this.config.withExpressions;
+        this.config.withDescriptors = faceApiOptions.withDescriptors !== undefined ? faceApiOptions.withDescriptors : this.config.withDescriptors;
 
         const {
-            withFaceLandmarks,
-            withFaceExpressions,
-            withFaceDescriptors
+            withLandmarks,
+            withExpressions,
+            withDescriptors
         } = this.config
 
         let result;
 
-        if (withFaceLandmarks) {
-            if (withFaceExpressions && withFaceDescriptors) {
+        if (withLandmarks) {
+            if (withExpressions && withDescriptors) {
                 result = await this.model.detectAllFaces(imgToClassify).withFaceLandmarks().withFaceExpressions().withFaceDescriptors();
-            } else if (withFaceExpressions) {
+            } else if (withExpressions) {
                 result = await this.model.detectAllFaces(imgToClassify).withFaceLandmarks().withFaceExpressions();
             } else {
                 result = await this.model.detectAllFaces(imgToClassify).withFaceLandmarks()
             }
 
-        } else if (withFaceLandmarks === false) {
+        } else if (withLandmarks === false) {
             result = await this.model.detectAllFaces(imgToClassify).withFaceExpressions()
         } else {
             result = await this.model.detectAllFaces(imgToClassify).withFaceLandmarks().withFaceExpressions().withFaceDescriptors();
@@ -277,28 +277,28 @@ class FaceApiBase {
             });
         }
 
-        this.config.withFaceLandmarks = faceApiOptions.withFaceLandmarks !== undefined ? faceApiOptions.withFaceLandmarks : this.config.withFaceLandmarks;
-        this.config.withFaceExpressions = faceApiOptions.withFaceLandmarks !== undefined ? faceApiOptions.withFaceExpressions : this.config.withFaceExpressions;
-        this.config.withFaceDescriptors = faceApiOptions.withFaceLandmarks !== undefined ? faceApiOptions.withFaceDescriptors : this.config.withFaceDescriptors;
+        this.config.withLandmarks = faceApiOptions.withLandmarks !== undefined ? faceApiOptions.withLandmarks : this.config.withLandmarks;
+        this.config.withExpressions = faceApiOptions.withLandmarks !== undefined ? faceApiOptions.withExpressions : this.config.withExpressions;
+        this.config.withDescriptors = faceApiOptions.withLandmarks !== undefined ? faceApiOptions.withDescriptors : this.config.withDescriptors;
 
         const {
-            withFaceLandmarks,
-            withFaceExpressions,
-            withFaceDescriptors
+            withLandmarks,
+            withExpressions,
+            withDescriptors
         } = this.config
 
 
         let result;
-        if (withFaceLandmarks) {
-            if (withFaceExpressions && withFaceDescriptors) {
+        if (withLandmarks) {
+            if (withExpressions && withDescriptors) {
                 result = await this.model.detectSingleFace(imgToClassify).withFaceLandmarks().withFaceExpressions().withFaceDescriptor();
-            } else if (withFaceExpressions) {
+            } else if (withExpressions) {
                 result = await this.model.detectSingleFace(imgToClassify).withFaceLandmarks().withFaceExpressions();
             } else {
                 result = await this.model.detectSingleFace(imgToClassify).withFaceLandmarks()
             }
 
-        } else if (withFaceLandmarks === false) {
+        } else if (withLandmarks === false) {
             result = await this.model.detectSingleFace(imgToClassify).withFaceExpressions()
         } else {
             result = await this.model.detectSingleFace(imgToClassify).withFaceLandmarks().withFaceExpressions().withFaceDescriptor();

--- a/src/FaceApi/index.js
+++ b/src/FaceApi/index.js
@@ -191,16 +191,77 @@ class FaceApiBase {
             } else {
                 result = await this.model.detectAllFaces(imgToClassify).withFaceLandmarks()
             }
+
         } else if (withFaceLandmarks === false) {
             result = await this.model.detectAllFaces(imgToClassify).withFaceExpressions()
         } else {
             result = await this.model.detectAllFaces(imgToClassify).withFaceLandmarks().withFaceExpressions().withFaceDescriptors();
         }
 
+        
         // always resize the results to the input image size
         result = this.resizeResults(result, imgToClassify.width, imgToClassify.height)
+        // assign the {parts} object after resizing
+        result = this.landmarkParts(result);
 
         return result
+    }
+
+    landmarkParts(result){
+        let output;
+        // multiple detections is an array
+        if(Array.isArray(result) === true){
+            output = result.map( item => {
+                // if landmarks exist return parts
+                const newItem = Object.assign({}, item);
+                if(newItem.landmarks){
+                    const {landmarks} = newItem;
+                    newItem.parts = {
+                        mouth:landmarks.getMouth(),
+                        nose:landmarks.getNose(),
+                        leftEye:landmarks.getLeftEye(),
+                        leftEyeBrow:landmarks.getLeftEyeBrow(),
+                        rightEye:landmarks.getRightEye(),
+                        rightEyeBrow:landmarks.getRightEyeBrow()
+                    }
+                } else{
+                    newItem.parts = {
+                        mouth: [],
+                        nose: [],
+                        leftEye: [],
+                        leftEyeBrow: [],
+                        rightEye: [],
+                        rightEyeBrow: []
+                    }
+                }
+                return newItem;
+            })
+        // single detection is an object
+        } else {
+            output = Object.assign({}, result);
+            if(output.landmarks){
+                const {landmarks} = result;
+                output.parts = {
+                    mouth:landmarks.getMouth(),
+                    nose:landmarks.getNose(),
+                    leftEye:landmarks.getLeftEye(),
+                    leftEyeBrow:landmarks.getLeftEyeBrow(),
+                    rightEye:landmarks.getRightEye(),
+                    rightEyeBrow:landmarks.getRightEyeBrow()
+                }
+            } else{
+                output.parts = {
+                    mouth: [],
+                    nose: [],
+                    leftEye: [],
+                    leftEyeBrow: [],
+                    rightEye: [],
+                    rightEyeBrow: []
+                }
+            }
+        }
+
+        return output;
     }
 
 
@@ -294,6 +355,7 @@ class FaceApiBase {
             } else {
                 result = await this.model.detectSingleFace(imgToClassify).withFaceLandmarks()
             }
+
         } else if (withFaceLandmarks === false) {
             result = await this.model.detectSingleFace(imgToClassify).withFaceExpressions()
         } else {
@@ -302,6 +364,9 @@ class FaceApiBase {
 
         // always resize the results to the input image size
         result = this.resizeResults(result, imgToClassify.width, imgToClassify.height)
+
+        // assign the {parts} object after resizing
+        result = this.landmarkParts(result);
 
         return result
     }

--- a/src/FaceApi/index.js
+++ b/src/FaceApi/index.js
@@ -178,6 +178,8 @@ class FaceApiBase {
                 result = await this.model.detectAllFaces(imgToClassify).withFaceLandmarks().withFaceExpressions().withFaceDescriptors();
             } else if (withExpressions) {
                 result = await this.model.detectAllFaces(imgToClassify).withFaceLandmarks().withFaceExpressions();
+            } else if (withDescriptors) {
+                result = await this.model.detectAllFaces(imgToClassify).withFaceLandmarks().withFaceDescriptors();
             } else {
                 result = await this.model.detectAllFaces(imgToClassify).withFaceLandmarks()
             }
@@ -282,6 +284,8 @@ class FaceApiBase {
                 result = await this.model.detectSingleFace(imgToClassify).withFaceLandmarks().withFaceExpressions().withFaceDescriptor();
             } else if (withExpressions) {
                 result = await this.model.detectSingleFace(imgToClassify).withFaceLandmarks().withFaceExpressions();
+            } else if (withDescriptors) {
+                result = await this.model.detectSingleFace(imgToClassify).withFaceLandmarks().withFaceDescriptor();
             } else {
                 result = await this.model.detectSingleFace(imgToClassify).withFaceLandmarks()
             }
@@ -380,7 +384,8 @@ class FaceApiBase {
                         leftEye: landmarks.getLeftEye(),
                         leftEyeBrow: landmarks.getLeftEyeBrow(),
                         rightEye: landmarks.getRightEye(),
-                        rightEyeBrow: landmarks.getRightEyeBrow()
+                        rightEyeBrow: landmarks.getRightEyeBrow(),
+                        jawOutline: landmarks.getJawOutline(),
                     }
                 } else {
                     newItem.parts = {
@@ -389,7 +394,8 @@ class FaceApiBase {
                         leftEye: [],
                         leftEyeBrow: [],
                         rightEye: [],
-                        rightEyeBrow: []
+                        rightEyeBrow: [],
+                        jawOutline: [],
                     }
                 }
                 return newItem;

--- a/src/FaceApi/index.js
+++ b/src/FaceApi/index.js
@@ -207,64 +207,6 @@ class FaceApiBase {
         return result
     }
 
-    landmarkParts(result){
-        let output;
-        // multiple detections is an array
-        if(Array.isArray(result) === true){
-            output = result.map( item => {
-                // if landmarks exist return parts
-                const newItem = Object.assign({}, item);
-                if(newItem.landmarks){
-                    const {landmarks} = newItem;
-                    newItem.parts = {
-                        mouth:landmarks.getMouth(),
-                        nose:landmarks.getNose(),
-                        leftEye:landmarks.getLeftEye(),
-                        leftEyeBrow:landmarks.getLeftEyeBrow(),
-                        rightEye:landmarks.getRightEye(),
-                        rightEyeBrow:landmarks.getRightEyeBrow()
-                    }
-                } else{
-                    newItem.parts = {
-                        mouth: [],
-                        nose: [],
-                        leftEye: [],
-                        leftEyeBrow: [],
-                        rightEye: [],
-                        rightEyeBrow: []
-                    }
-                }
-                return newItem;
-            })
-        // single detection is an object
-        } else {
-            output = Object.assign({}, result);
-            if(output.landmarks){
-                const {landmarks} = result;
-                output.parts = {
-                    mouth:landmarks.getMouth(),
-                    nose:landmarks.getNose(),
-                    leftEye:landmarks.getLeftEye(),
-                    leftEyeBrow:landmarks.getLeftEyeBrow(),
-                    rightEye:landmarks.getRightEye(),
-                    rightEyeBrow:landmarks.getRightEyeBrow()
-                }
-            } else{
-                output.parts = {
-                    mouth: [],
-                    nose: [],
-                    leftEye: [],
-                    leftEyeBrow: [],
-                    rightEye: [],
-                    rightEyeBrow: []
-                }
-            }
-        }
-
-        return output;
-    }
-
-
     /**
      * detect single
      * @param {*} optionsOrCallback 
@@ -390,6 +332,67 @@ class FaceApiBase {
     isAbsoluteURL(str) {
         const pattern = new RegExp('^(?:[a-z]+:)?//', 'i');
         return !!pattern.test(str);
+    }
+
+    /**
+     * get parts from landmarks
+     * @param {*} result 
+     */
+    landmarkParts(result){
+        let output;
+        // multiple detections is an array
+        if(Array.isArray(result) === true){
+            output = result.map( item => {
+                // if landmarks exist return parts
+                const newItem = Object.assign({}, item);
+                if(newItem.landmarks){
+                    const {landmarks} = newItem;
+                    newItem.parts = {
+                        mouth:landmarks.getMouth(),
+                        nose:landmarks.getNose(),
+                        leftEye:landmarks.getLeftEye(),
+                        leftEyeBrow:landmarks.getLeftEyeBrow(),
+                        rightEye:landmarks.getRightEye(),
+                        rightEyeBrow:landmarks.getRightEyeBrow()
+                    }
+                } else{
+                    newItem.parts = {
+                        mouth: [],
+                        nose: [],
+                        leftEye: [],
+                        leftEyeBrow: [],
+                        rightEye: [],
+                        rightEyeBrow: []
+                    }
+                }
+                return newItem;
+            })
+        // single detection is an object
+        } else {
+            output = Object.assign({}, result);
+            if(output.landmarks){
+                const {landmarks} = result;
+                output.parts = {
+                    mouth:landmarks.getMouth(),
+                    nose:landmarks.getNose(),
+                    leftEye:landmarks.getLeftEye(),
+                    leftEyeBrow:landmarks.getLeftEyeBrow(),
+                    rightEye:landmarks.getRightEye(),
+                    rightEyeBrow:landmarks.getRightEyeBrow()
+                }
+            } else{
+                output.parts = {
+                    mouth: [],
+                    nose: [],
+                    leftEye: [],
+                    leftEyeBrow: [],
+                    rightEye: [],
+                    rightEyeBrow: []
+                }
+            }
+        }
+
+        return output;
     }
 
 }

--- a/src/FaceApi/index.js
+++ b/src/FaceApi/index.js
@@ -14,11 +14,15 @@
 import * as tf from '@tensorflow/tfjs';
 import * as faceapi from 'face-api.js';
 import callCallback from '../utils/callcallback';
-// import * as p5Utils from '../utils/p5Utils';
 
-// const DEFAULTS = {
-//     MODEL_URL: ''
-// }
+const DEFAULTS = {
+    MODEL_URLS: {
+        Mobilenetv1Model: 'https://raw.githubusercontent.com/ml5js/ml5-data-and-models/face-api/models/faceapi/ssd_mobilenetv1_model-weights_manifest.json',
+        FaceLandmarkModel: 'https://raw.githubusercontent.com/ml5js/ml5-data-and-models/face-api/models/faceapi/face_landmark_68_model-weights_manifest.json',
+        FaceRecognitionModel: 'https://raw.githubusercontent.com/ml5js/ml5-data-and-models/face-api/models/faceapi/face_recognition_model-weights_manifest.json',
+        FaceExpressionModel: 'https://raw.githubusercontent.com/ml5js/ml5-data-and-models/face-api/models/faceapi/face_expression_model-weights_manifest.json'
+    }
+}
 
 class FaceApiBase {
     /**
@@ -27,12 +31,18 @@ class FaceApiBase {
      * @param {object} options - An object with options.
      * @param {function} callback - A callback to be called when the model is ready.
      */
-    constructor(modelPath, video, options, callback) {
+    constructor(video, options, callback) {
         this.video = video;
         this.model = null;
         this.modelReady = false;
-        this.modelPath = modelPath;
-        this.config = {}
+        this.config = {
+            MODEL_URLS: {
+                Mobilenetv1Model: options.Mobilenetv1Model || DEFAULTS.MODEL_URLS.Mobilenetv1Model,
+                FaceLandmarkModel: options.FaceLandmarkModel || DEFAULTS.MODEL_URLS.FaceLandmarkModel,
+                FaceRecognitionModel: options.FaceRecognitionModel || DEFAULTS.MODEL_URLS.FaceRecognitionModel,
+                FaceExpressionModel: options.FaceExpressionModel || DEFAULTS.MODEL_URLS.FaceExpressionModel,
+            }
+        }
 
         this.ready = callCallback(this.loadModel(), callback);
     }
@@ -42,12 +52,13 @@ class FaceApiBase {
      * @return {this} the BodyPix model.
      */
     async loadModel() {
+        const {Mobilenetv1Model, FaceLandmarkModel, FaceRecognitionModel, FaceExpressionModel} = this.config.MODEL_URLS;
+        
         this.model = faceapi;
-        await this.model.loadSsdMobilenetv1Model(this.modelPath)
-        await this.model.loadFaceLandmarkModel(this.modelPath)
-        await this.model.loadFaceRecognitionModel(this.modelPath)
-        await this.model.loadFaceExpressionModel(this.modelPath)
-        console.log('done!')
+        await this.model.loadSsdMobilenetv1Model(Mobilenetv1Model)
+        await this.model.loadFaceLandmarkModel(FaceLandmarkModel)
+        await this.model.loadFaceRecognitionModel(FaceRecognitionModel)
+        await this.model.loadFaceExpressionModel(FaceExpressionModel)
         this.modelReady = true;
         return this;
     }
@@ -69,7 +80,7 @@ class FaceApiBase {
     async classifyExpressionsMultiple(optionsOrCallback, configOrCallback, cb){
         let imgToClassify = this.video;
         let callback;
-        // let segmentationOptions = this.config;
+        // let faceApiOptions = this.config;
 
         // Handle the image to predict
         if (typeof optionsOrCallback === 'function') {
@@ -102,8 +113,8 @@ class FaceApiBase {
             );
         }
 
-        // if (typeof configOrCallback === 'object') {
-        //     segmentationOptions = configOrCallback;
+         // if (typeof configOrCallback === 'object') {
+        //     faceApiOptions = configOrCallback;
         // } else 
         
         if (typeof configOrCallback === 'function') {
@@ -135,7 +146,7 @@ class FaceApiBase {
     async classifyExpressionsSingle(optionsOrCallback, configOrCallback, cb){
         let imgToClassify = this.video;
         let callback;
-        // let segmentationOptions = this.config;
+        // let faceApiOptions = this.config;
 
         // Handle the image to predict
         if (typeof optionsOrCallback === 'function') {
@@ -169,7 +180,7 @@ class FaceApiBase {
         }
 
         // if (typeof configOrCallback === 'object') {
-        //     segmentationOptions = configOrCallback;
+        //     faceApiOptions = configOrCallback;
         // } else 
         
         if (typeof configOrCallback === 'function') {
@@ -186,16 +197,16 @@ class FaceApiBase {
 
 }
 
-const faceApi = (modelPath, videoOrOptionsOrCallback, optionsOrCallback, cb) => {
+const faceApi = (videoOrOptionsOrCallback, optionsOrCallback, cb) => {
     let video;
     let options = {};
     let callback = cb;
 
-    if (typeof modelPath !== 'string') {
-        throw new Error('Please specify a relative path to your model to use. E.g: "/models/"');
-    }
+//     if (typeof modelPath !== 'string') {
+//         throw new Error('Please specify a relative path to your model to use. E.g: "/models/"');
+//     }
 
-   const model = modelPath;
+//    const model = modelPath;
 
     if (videoOrOptionsOrCallback instanceof HTMLVideoElement) {
         video = videoOrOptionsOrCallback;
@@ -216,7 +227,7 @@ const faceApi = (modelPath, videoOrOptionsOrCallback, optionsOrCallback, cb) => 
         callback = optionsOrCallback;
     }
 
-    const instance = new FaceApiBase(model, video, options, callback);
+    const instance = new FaceApiBase(video, options, callback);
     return callback ? instance : instance.ready;
 }
 

--- a/src/FaceApi/index_test.js
+++ b/src/FaceApi/index_test.js
@@ -1,11 +1,11 @@
-import { KeyObject } from "crypto";
-
 // Copyright (c) 2018 ml5
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-const { faceApi } = ml5;
+const {
+    faceApi
+} = ml5;
 
 const FACEAPI_DEFAULTS = {
     withFaceLandmarks: true,
@@ -22,45 +22,57 @@ const FACEAPI_DEFAULTS = {
 
 
 describe('faceApi', () => {
-  let faceapi;
+    let faceapi;
 
-  async function getImage() {
-    const img = new Image();
-    img.crossOrigin = true;
-    img.src = 'https://cdn.jsdelivr.net/gh/ml5js/ml5-data-and-models@master/tests/images/harriet_128x128.jpg';
-    await new Promise((resolve) => { img.onload = resolve; });
-    return img;
-  }
+    async function getImage() {
+        const img = new Image();
+        img.crossOrigin = true;
+        img.src = 'https://raw.githubusercontent.com/ml5js/ml5-examples/face-api/p5js/FaceApi/FaceApi_Image_Landmarks/assets/frida.jpg';
+        await new Promise((resolve) => {
+            img.onload = resolve;
+        });
+        return img;
+    }
 
-  async function getCanvas() {
-    const img = await getImage();
-    const canvas = document.createElement('canvas');
-    canvas.width = img.width;
-    canvas.height = img.height;
-    canvas.getContext('2d').drawImage(img, 0, 0);
-    return canvas;
-  }
+    async function getCanvas() {
+        const img = await getImage();
+        const canvas = document.createElement('canvas');
+        canvas.width = img.width;
+        canvas.height = img.height;
+        canvas.getContext('2d').drawImage(img, 0, 0);
+        return canvas;
+    }
 
-  beforeEach(async () => {
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
-    faceapi = await faceApi();
-  });
-
-  it('Should create faceApi with all the defaults', async () => {
-    expect(bp.config.withFaceLandmarks).toBe(FACEAPI_DEFAULTS.withFaceLandmarks);
-    expect(bp.config.withFaceExpressions).toBe(FACEAPI_DEFAULTS.withFaceExpressions);
-    expect(bp.config.withFaceDescriptors).toBe(FACEAPI_DEFAULTS.withFaceDescriptors);
-  });
-
-  describe('expressions', () => {
-    it('Should get expressions for Harriet Tubman', async () => {
-      const img = await getImage();
-      await faceapi.detectSingle(img)
-        .then(results => {
-            expect(results.expressions).any(Object);
-
-        })
+    beforeEach(async () => {
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
+        faceapi = await faceApi();
     });
 
-  });
+    it('Should create faceApi with all the defaults', async () => {
+        expect(faceapi.config.withFaceLandmarks).toBe(FACEAPI_DEFAULTS.withFaceLandmarks);
+        expect(faceapi.config.withFaceExpressions).toBe(FACEAPI_DEFAULTS.withFaceExpressions);
+        expect(faceapi.config.withFaceDescriptors).toBe(FACEAPI_DEFAULTS.withFaceDescriptors);
+    });
+
+    describe('expressions', () => {
+        it('Should get expressions for Frida', async () => {
+            const img = await getImage();
+            await faceapi.detectSingle(img)
+                .then(results => {
+                    expect(results.expressions).toEqual(jasmine.any(Object));
+
+                })
+        });
+    });
+    
+    describe('landmarks', () => {
+        it('Should get landmarks for Frida', async () => {
+            const img = await getImage();
+            await faceapi.detectSingle(img)
+                .then(results => {
+                    expect(results.landmarks).toEqual(jasmine.any(Object));
+
+                })
+        });
+    });
 });

--- a/src/FaceApi/index_test.js
+++ b/src/FaceApi/index_test.js
@@ -1,0 +1,66 @@
+import { KeyObject } from "crypto";
+
+// Copyright (c) 2018 ml5
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+const { faceApi } = ml5;
+
+const FACEAPI_DEFAULTS = {
+    withFaceLandmarks: true,
+    withFaceExpressions: true,
+    withFaceDescriptors: true,
+    MODEL_URLS: {
+        Mobilenetv1Model: 'https://raw.githubusercontent.com/ml5js/ml5-data-and-models/face-api/models/faceapi/ssd_mobilenetv1_model-weights_manifest.json',
+        FaceLandmarkModel: 'https://raw.githubusercontent.com/ml5js/ml5-data-and-models/face-api/models/faceapi/face_landmark_68_model-weights_manifest.json',
+        FaceLandmark68TinyNet: 'https://raw.githubusercontent.com/ml5js/ml5-data-and-models/face-api/models/faceapi/face_landmark_68_tiny_model-weights_manifest.json',
+        FaceRecognitionModel: 'https://raw.githubusercontent.com/ml5js/ml5-data-and-models/face-api/models/faceapi/face_recognition_model-weights_manifest.json',
+        FaceExpressionModel: 'https://raw.githubusercontent.com/ml5js/ml5-data-and-models/face-api/models/faceapi/face_expression_model-weights_manifest.json'
+    }
+}
+
+
+describe('faceApi', () => {
+  let faceapi;
+
+  async function getImage() {
+    const img = new Image();
+    img.crossOrigin = true;
+    img.src = 'https://cdn.jsdelivr.net/gh/ml5js/ml5-data-and-models@master/tests/images/harriet_128x128.jpg';
+    await new Promise((resolve) => { img.onload = resolve; });
+    return img;
+  }
+
+  async function getCanvas() {
+    const img = await getImage();
+    const canvas = document.createElement('canvas');
+    canvas.width = img.width;
+    canvas.height = img.height;
+    canvas.getContext('2d').drawImage(img, 0, 0);
+    return canvas;
+  }
+
+  beforeEach(async () => {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
+    faceapi = await faceApi();
+  });
+
+  it('Should create faceApi with all the defaults', async () => {
+    expect(bp.config.withFaceLandmarks).toBe(FACEAPI_DEFAULTS.withFaceLandmarks);
+    expect(bp.config.withFaceExpressions).toBe(FACEAPI_DEFAULTS.withFaceExpressions);
+    expect(bp.config.withFaceDescriptors).toBe(FACEAPI_DEFAULTS.withFaceDescriptors);
+  });
+
+  describe('expressions', () => {
+    it('Should get expressions for Harriet Tubman', async () => {
+      const img = await getImage();
+      await faceapi.detectSingle(img)
+        .then(results => {
+            expect(results.expressions).any(Object);
+
+        })
+    });
+
+  });
+});

--- a/src/FaceApi/index_test.js
+++ b/src/FaceApi/index_test.js
@@ -8,9 +8,9 @@ const {
 } = ml5;
 
 const FACEAPI_DEFAULTS = {
-    withFaceLandmarks: true,
-    withFaceExpressions: true,
-    withFaceDescriptors: true,
+    withLandmarks: true,
+    withExpressions: true,
+    withDescriptors: true,
     MODEL_URLS: {
         Mobilenetv1Model: 'https://raw.githubusercontent.com/ml5js/ml5-data-and-models/face-api/models/faceapi/ssd_mobilenetv1_model-weights_manifest.json',
         FaceLandmarkModel: 'https://raw.githubusercontent.com/ml5js/ml5-data-and-models/face-api/models/faceapi/face_landmark_68_model-weights_manifest.json',
@@ -49,9 +49,9 @@ describe('faceApi', () => {
     });
 
     it('Should create faceApi with all the defaults', async () => {
-        expect(faceapi.config.withFaceLandmarks).toBe(FACEAPI_DEFAULTS.withFaceLandmarks);
-        expect(faceapi.config.withFaceExpressions).toBe(FACEAPI_DEFAULTS.withFaceExpressions);
-        expect(faceapi.config.withFaceDescriptors).toBe(FACEAPI_DEFAULTS.withFaceDescriptors);
+        expect(faceapi.config.withLandmarks).toBe(FACEAPI_DEFAULTS.withLandmarks);
+        expect(faceapi.config.withExpressions).toBe(FACEAPI_DEFAULTS.withExpressions);
+        expect(faceapi.config.withDescriptors).toBe(FACEAPI_DEFAULTS.withDescriptors);
     });
 
     describe('expressions', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ import preloadRegister from './utils/p5PreloadHelper';
 import { version } from '../package.json';
 import sentiment from './Sentiment';
 import bodyPix from './BodyPix';
+import faceApi from './FaceApi';
 
 const withPreload = {
   charRNN,
@@ -49,4 +50,5 @@ module.exports = Object.assign({}, preloadRegister(withPreload), {
   version,
   sentiment,
   bodyPix,
+  faceApi,
 });


### PR DESCRIPTION
<!-- MANY MANY THANKS FOR YOUR CONTRIBUTION. ML5 ❤️S YOU! -->
## → Submit changes to the relevant branch 🌲

`development`


## → Description 📝

- submitting a new feature 🆕 

Adds [face-api.js](https://github.com/justadudewhohacks/face-api.js?files=1) to ml5.js. 

- Added the models to `ml5-models-and-data`: https://github.com/ml5js/ml5-data-and-models/pull/38

There's a lot of functionality baked into face-api.js, so i'll do my best to support as much of it in ml5. I will try to structure as best as possible the API around wrapping these chained functions together: https://github.com/justadudewhohacks/face-api.js?files=1#composition-of-tasks 

Issue here: https://github.com/ml5js/ml5-library/issues/179


## → Screenshots 🖼
(Any relevant screenshots, sketches, or helpful concept diagrams - these are helpful for our release notes and for getting people excited about your super cool feature and/or fix!)


## .detect(imgToDetect, options)

> returns an array of objects [{Object}]

`{options}` - people can set which data they want returned. By default all data is returned. 

```javascript
{
    withLandmarks: true,
    withExpressions: false,
    withDescriptors: false,
}
```

Detecting multiple is the default here.

![Screen Shot 2019-06-04 at 16 13 36](https://user-images.githubusercontent.com/3622055/58910633-04a37f00-86e4-11e9-8310-b915ff8fedd2.png)

![Screen Shot 2019-06-06 at 12 03 17](https://user-images.githubusercontent.com/3622055/59049452-fbd2ba80-8855-11e9-8223-5bc21f294672.png)


## .detectSingle(imgToDetect, options)

> returns {Object}

People can choose to explicitly use `.detectSingle()` to get back a single detection with higher accuracy.

`{options}` - people can set which data they want returned. By default all data is returned. 

```javascript
{
    withFaceLandmarks: true,
    withFaceExpressions: false,
    withFaceDescriptors: false,
}
```

## → Relevant Example or Paired Pull Request to [ml5-examples](https://github.com/ml5js/ml5-examples) 🦄

See: https://github.com/ml5js/ml5-examples/pull/161

## → Relevant documentation 🌴

+ We can load models from relative paths passed in as an `{option}`, where `"models"` is the name of the directory in the project folder. If the models were to live in a child directory called `mysubfolder`, it would be, `models/mysubfolder`: 
```
const options = {
    Mobilenetv1Model: 'models',
    FaceLandmarkModel: 'models',
    FaceRecognitionModel: 'models',
    FaceExpressionModel: 'models',
}

const faceapi = ml5.faceApi(video, options, modelReady)
```

+ If no model URLs are passed in, then we default to the models hosted on `ml5-models-and-data`: https://github.com/ml5js/ml5-data-and-models/pull/38

```javascript
const DEFAULTS = {
    MODEL_URLS: {
        Mobilenetv1Model: 'https://raw.githubusercontent.com/ml5js/ml5-data-and-models/face-api/models/faceapi/ssd_mobilenetv1_model-weights_manifest.json',
        FaceLandmarkModel: 'https://raw.githubusercontent.com/ml5js/ml5-data-and-models/face-api/models/faceapi/face_landmark_68_model-weights_manifest.json',
        FaceLandmark68TinyNet: 'https://raw.githubusercontent.com/ml5js/ml5-data-and-models/face-api/models/faceapi/face_landmark_68_tiny_model-weights_manifest.json',
        FaceRecognitionModel: 'https://raw.githubusercontent.com/ml5js/ml5-data-and-models/face-api/models/faceapi/face_recognition_model-weights_manifest.json',
        FaceExpressionModel: 'https://raw.githubusercontent.com/ml5js/ml5-data-and-models/face-api/models/faceapi/face_expression_model-weights_manifest.json'
    }
}
```


## Further discussion
From an ethics and conceptual point of view, I'm curious how people feel about the [**age and gender** estimation](https://github.com/justadudewhohacks/face-api.js?files=1#models-age-and-gender-recognition) 😬. The **expressions** models do a good job at helping to express these ideas of "what does surprise or happiness look like" depending on the training data and therefore can be instructive without being offensive.

With "age and gender" these are much trickier to nail down from a data and modeling perspective, not even getting into cultural constructions of gender. I personally don't want to support adding more accessibility to models that could be potentially harmful or offensive, but I also recognize that it offers the ability for people to poke at the biases embedded in data creation. 

Thanks for reading! 


