### PR TITLE
Fix - Single pose mode should run if "single" is specified as "type".

### DIFF
--- a/src/PoseNet/index.js
+++ b/src/PoseNet/index.js
@@ -76,9 +76,9 @@ class PoseNet extends EventEmitter {
       }
       if (this.detectionType === 'single') {
         this.singlePose();
+      } else {
+        this.multiPose();
       }
-
-      this.multiPose();
     }
     return this;
   }


### PR DESCRIPTION
I found a bug that multi poses are estimated even if I set "single" as "type" of ml5.poseNet() as below:

```
let poseNet = ml5.poseNet(video, 'single', modelLoaded);
```

This PR is to fix the bug.

