### PR TITLE
Add kmeans class

### DIFF
--- a/src/KMeans/index.js
+++ b/src/KMeans/index.js
@@ -51,7 +51,7 @@ class KMeans {
   /**
   * Create a K-Means.
   * @param {String || array || object} dataset - The dataset to cluster.
-  * @param {options} options - Optional. An object describing a model's parameters:
+  * @param {options} options - An object describing a model's parameters:
   *    - k: number of clusters
   *    - maxIter: Max number of iterations to try before forcing convergence.
   *    - threshold: Threshold for updated centriod distance before declaring convergence.
@@ -60,7 +60,7 @@ class KMeans {
   *    promise that will be resolved once the model has loaded.
   */
   constructor(dataset, options, callback) {
-    this.k = options.k;
+    this.k = options.k || DEFAULTS.k;
     this.maxIter = options.maxIter || DEFAULTS.maxIter;
     this.threshold = options.threshold || DEFAULTS.threshold;
     this.ready = callCallback(this.load(dataset), callback);

--- a/src/KMeans/index.js
+++ b/src/KMeans/index.js
@@ -60,9 +60,11 @@ class KMeans {
   *    promise that will be resolved once the model has loaded.
   */
   constructor(dataset, options, callback) {
-    this.k = options.k || DEFAULTS.k;
-    this.maxIter = options.maxIter || DEFAULTS.maxIter;
-    this.threshold = options.threshold || DEFAULTS.threshold;
+    this.config = {
+      k: options.k || DEFAULTS.k,
+      maxIter: options.maxIter || DEFAULTS.maxIter,
+      threshold: options.threshold || DEFAULTS.threshold
+     };
     this.ready = callCallback(this.load(dataset), callback);
   }
 
@@ -77,7 +79,7 @@ class KMeans {
       const tensors = tf.tensor1d(Object.values(d));
       d.tensor = tensors;
     });
-    this.centroids = tf.tensor2d(randomSample(this.dataset, this.k, false));
+    this.centroids = tf.tensor2d(randomSample(this.dataset, this.config.k, false));
     this.fit();
     return this;
   }
@@ -90,7 +92,7 @@ class KMeans {
     this.recenterCentroids();
     let centroidDistance = KMeans.getEuclidianDistance(this.centroids, this.centroidsOld);
     let iteration = 0;
-    while(centroidDistance > this.threshold &&  iteration < this.maxIter) {
+    while(centroidDistance > this.config.threshold &&  iteration < this.congif.maxIter) {
       this.getClosestCentroids();
       this.recenterCentroids();
       centroidDistance = KMeans.getEuclidianDistance(this.centroids, this.centroidsOld);

--- a/src/KMeans/index.js
+++ b/src/KMeans/index.js
@@ -19,9 +19,9 @@ const DEFAULTS = {
 };
 
 /**
- * Read in a csv file from a path to its location.
- * @param {string} path 
- */
+* Read in a csv file from a path to its location.
+* @param {string} path 
+*/
 async function readCsv(path) {
   const myCsv = tf.data.csv(path);
   const loadedData = await myCsv.toArray();
@@ -29,10 +29,10 @@ async function readCsv(path) {
 }
 
 /**
- * Load and flatten an array of arrays, an array of objects, or a string
- *   path to a csv.
- * @param {string || array || object} inputData 
- */
+* Load and flatten an array of arrays, an array of objects, or a string
+*   path to a csv.
+* @param {string || array || object} inputData 
+*/
 async function loadDataset(inputData) {
   let data;
   if (typeof inputData === 'string') {

--- a/src/KMeans/index.js
+++ b/src/KMeans/index.js
@@ -14,8 +14,8 @@ import { randomSample } from '../utils/random';
 
 const DEFAULTS = {
   'k': 3,
-	'maxIter': 5,
-	'threshold': 0.5,
+  'maxIter': 5,
+  'threshold': 0.5,
 };
 
 /**
@@ -23,9 +23,9 @@ const DEFAULTS = {
  * @param {string} path 
  */
 async function readCsv(path) {
-	const myCsv = tf.data.csv(path);
-	const loadedData = await myCsv.toArray();
-	return loadedData;
+  const myCsv = tf.data.csv(path);
+  const loadedData = await myCsv.toArray();
+  return loadedData;
 }
 
 /**
@@ -34,16 +34,16 @@ async function readCsv(path) {
  * @param {string || array || object} inputData 
  */
 async function loadDataset(inputData) {
-	let data;
-	if (typeof inputData === 'string') {
-		data = await readCsv(inputData);
-	} else {
-		data = inputData;
-	}
-	const dataFlat = data.map((d) => {
-		return Object.values(d)
-	});
-	return dataFlat;
+  let data;
+  if (typeof inputData === 'string') {
+    data = await readCsv(inputData);
+  } else {
+    data = inputData;
+  }
+  const dataFlat = data.map((d) => {
+    return Object.values(d)
+  });
+  return dataFlat;
 }
 
 
@@ -59,11 +59,11 @@ class KMeans {
   *    the model has loaded. If no callback is provided, it will return a 
   *    promise that will be resolved once the model has loaded.
   */
-	constructor(dataset, options, callback) {
+  constructor(dataset, options, callback) {
     this.k = options.k;
     this.maxIter = options.maxIter || DEFAULTS.maxIter;
     this.threshold = options.threshold || DEFAULTS.threshold;
-		this.ready = callCallback(this.load(dataset), callback);
+    this.ready = callCallback(this.load(dataset), callback);
   }
 
   /**
@@ -71,15 +71,15 @@ class KMeans {
   * @param {string || array || object} dataset 
   */
   async load(dataset) {
-		this.dataset = await loadDataset(dataset);
-	  this.dataTensor = tf.tensor2d(this.dataset);
-	  this.dataset.forEach(d => {
-	  	const tensors = tf.tensor1d(Object.values(d));
-	  	d.tensor = tensors;
-	  });
-	  this.centroids = tf.tensor2d(randomSample(this.dataset, this.k, false));
-	  this.fit();
-	  return this;
+    this.dataset = await loadDataset(dataset);
+    this.dataTensor = tf.tensor2d(this.dataset);
+    this.dataset.forEach(d => {
+      const tensors = tf.tensor1d(Object.values(d));
+      d.tensor = tensors;
+    });
+    this.centroids = tf.tensor2d(randomSample(this.dataset, this.k, false));
+    this.fit();
+    return this;
   }
 
   /**
@@ -115,7 +115,7 @@ class KMeans {
  * @param {string || array || object} inputData 
  */
   closestCentroid(dataTensor) {
-  	const dist = this.centroids.squaredDifference(dataTensor).sum(1).sqrt();
+    const dist = this.centroids.squaredDifference(dataTensor).sum(1).sqrt();
     const minCentroid = dist.argMin().arraySync();
     return minCentroid;
   }
@@ -125,8 +125,8 @@ class KMeans {
   * @param {array || object} value 
   */
   classify(value) {
-  	// input must be array or object
-  	const valueTensor = tf.tensor1d(Object.values(value));
+    // input must be array or object
+    const valueTensor = tf.tensor1d(Object.values(value));
     const minCentroid = this.closestCentroid(valueTensor);
     return minCentroid;
   }

--- a/src/KMeans/index.js
+++ b/src/KMeans/index.js
@@ -1,0 +1,137 @@
+// Copyright (c) 2019 ml5
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+/* eslint class-methods-use-this: ["error", { "exceptMethods": ["getInitialCentroids"] }] */
+/* eslint "no-param-reassign": [2, { "props": false }] */
+/*
+KMeans
+This class provides the following unsupervised clustering methods:
+- K-Means
+More will be added.
+*/
+
+import * as tf from '@tensorflow/tfjs';
+import callCallback from '../utils/callcallback';
+import { randomSample } from '../utils/random';
+
+const DEFAULTS = {
+	'maxIter': 5,
+	'threshold': 0.5,
+};
+
+async function readCsv(url) {
+	const myCsv = tf.data.csv(url);
+	const loadedData = await myCsv.toArray();
+	return loadedData;
+}
+
+async function loadDataset(inputData) {
+	let data;
+	if (typeof inputData === 'string') {
+		data = await readCsv(inputData);
+	} else {
+		data = inputData;
+	}
+	const dataFlat = data.map((d) => {
+		return Object.values(d)
+	});
+	return dataFlat;
+}
+
+
+class KMeans {
+
+	constructor(dataset, options, callback) {
+	    this.k = options.k;
+	    this.maxIter = options.maxIter || DEFAULTS.maxIter;
+	    this.threshold = options.threshold || DEFAULTS.threshold;
+			this.ready = callCallback(this.load(dataset), callback);
+  }
+
+  async load(dataset) {
+		this.dataset = await loadDataset(dataset);
+	  this.dataTensor = tf.tensor2d(this.dataset);
+	  this.dataset.forEach(d => {
+	  	const tensors = tf.tensor1d(Object.values(d));
+	  	d.tensor = tensors;
+	  });
+	  this.centroids = tf.tensor2d(randomSample(this.dataset, this.k, false));
+	  this.fit();
+	  console.log('final centroids:')
+	  this.centroids.print()
+	  return this;
+  }
+
+  fit() {
+    this.getClosestCentroids()
+    this.recenterCentroids();
+    let centroidDistance = KMeans.getEuclidianDistance(this.centroids, this.centroidsOld);
+    console.log(centroidDistance);
+    let iteration = 0;
+    while(centroidDistance > this.threshold &&  iteration < this.maxIter) {
+      this.getClosestCentroids();
+      this.recenterCentroids();
+      centroidDistance = KMeans.getEuclidianDistance(this.centroids, this.centroidsOld);
+      iteration += 1;
+      console.log('iteration: ', iteration)
+      console.log('centroidDistance: ', centroidDistance)
+    }
+  }
+
+  getClosestCentroids() {
+    // find closest initial tensor
+    this.dataset.forEach(d => {
+      const minCentroid = this.closestCentroid(d.tensor);
+      d.centroid = minCentroid;
+    })
+  }
+
+  closestCentroid(dataTensor) {
+  	const dist = this.centroids.squaredDifference(dataTensor).sum(1).sqrt();
+    const minCentroid = dist.argMin().arraySync();
+    return minCentroid;
+  }
+
+  classify(value) {
+  	// input must be array or object
+  	const valueTensor = tf.tensor1d(Object.values(value));
+    const minCentroid = this.closestCentroid(valueTensor);
+    return minCentroid;
+  }
+
+  recenterCentroids() {
+    // store previous run's centroids for convergence
+    this.centroidsOld = this.centroids;
+    // recenter each centroid
+    this.centroids = tf.stack(this.centroids.unstack().map((centroid, k) => {
+      // subset centroid to its cluster
+      const centroidK = this.dataset.filter(d => d.centroid === k);
+      // conver to tensor
+      const centroidKTensor = centroidK.map(d => d.tensor);
+      if (centroidKTensor.length === 0) {
+        return centroid;
+      } else if (centroidKTensor.length === 1) {
+        return centroidKTensor[0];
+      }
+      // grab mean for for cluster
+      const newCentroids = tf.tidy(() => tf.stack(centroidKTensor).mean(0));
+      return newCentroids
+    }))
+  }
+
+  static getEuclidianDistance(arr1, arr2) {
+    // calculate euclidian distance between two arrays
+    const distTensor = tf.tidy(() => {
+      const distance = tf.squaredDifference(arr1, arr2).sum().sqrt();
+      return distance.dataSync()
+    })
+    return distTensor[0];
+  }
+
+}
+
+const kmeans = (dataset, options, callback) => new KMeans(dataset, options, callback);
+
+export default kmeans;

--- a/src/index.js
+++ b/src/index.js
@@ -25,9 +25,11 @@ import { version } from '../package.json';
 import sentiment from './Sentiment';
 import bodyPix from './BodyPix';
 import faceApi from './FaceApi';
+import kmeans from './KMeans';
 
 const withPreload = {
   charRNN,
+  kmeans,
   CVAE,
   DCGAN,
   featureExtractor,

--- a/src/index.js
+++ b/src/index.js
@@ -29,11 +29,11 @@ import kmeans from './KMeans';
 
 const withPreload = {
   charRNN,
-  kmeans,
   CVAE,
   DCGAN,
   featureExtractor,
   imageClassifier,
+  kmeans,
   soundClassifier,
   pitchDetection,
   pix2pix,

--- a/src/utils/random.js
+++ b/src/utils/random.js
@@ -37,7 +37,7 @@ const randomGaussian = (mean = 0, sd = 1) => {
   return (y1 * sd) + mean;
 };
 
-// Returns a random sample (either with or without replacement) from an array
+// Returns a random sample (either with or without replacement) of size k from an array
 const randomSample = (arr, k, withReplacement = false) => {
   let sample;
   if (withReplacement === true) {  // sample with replacement

--- a/src/utils/random.js
+++ b/src/utils/random.js
@@ -37,4 +37,19 @@ const randomGaussian = (mean = 0, sd = 1) => {
   return (y1 * sd) + mean;
 };
 
-export { randomFloat, randomInt, randomGaussian };
+// Returns a random sample (either with or without replacement) from an array
+const randomSample = (arr, k, withReplacement = false) => {
+  let sample;
+  if (withReplacement === true) {  // sample with replacement
+    sample = Array.from({length: k}, () => arr[Math.floor(Math.random() * arr.length)]);
+  } else { // sample without replacement
+    if (k > arr.length) {
+      throw new RangeError('Sample size must be less than or equal to array length when sampling without replacement.')
+    }
+    sample = arr.map(a => [a, Math.random()]).sort((a, b) => {
+      return a[1] < b[1] ? -1 : 1;}).slice(0, k).map(a => a[0]); 
+    };
+  return sample;
+};
+
+export { randomFloat, randomInt, randomGaussian, randomSample };


### PR DESCRIPTION
Hey all,

This is the K-Means class. I'd like my JavaScript to be better, so please tear apart anything you see that's funky.

Regarding the class:
Three attributes are in the constructor:
- **dataset**: this should be an array of arrays, an array of objects, or a string path to a csv file. 
- **options**: Parameters for the model (see docstring).
- **callback**. I think I implemented this part how it's supposed to be, but let me know if not.

E.g.; `ml5.kmeans('iris.csv', options, modelReady)` or `ml5.kmeans([[1,2,3], [1,2,3], [2,2,2]], options)`.

All clusters/labels are stored in the `centroid` attribute:
e.g. ith observation's centroid is `km.dataset[i].centroid`

To cluster a new point from an existing model, simply use the `.classify()` method:
e.g. `km.classify([1,2,3])`
Note, the input to `.classify()` should be an array or object.

Some things worth discussing:
- Should I update the `dataset` attribute to load in json files as well?
- Originally we were discussing a `ml5.cluster` class to encapsulate kmeans, t-sne, pca, etc and be used as `ml5.cluster('algorithm', ...)` - I don't think t-sne or pca should go in that class (they're dim reduction, not clustering methods) BUT I think that's a good idea. I can add other clustering method(s) to accommodate such a class (I think DBSCAN would be a great addition, since it automatically finds `k` and works better for non-spherical data which are areas k-means kinda sucks at).