### PR TITLE
Reproduce previous results from color classifier [DO NOT MERGE]

### DIFF
--- a/src/NeuralNetwork/NeuralNetworkData.js
+++ b/src/NeuralNetwork/NeuralNetworkData.js
@@ -127,65 +127,109 @@ class NeuralNetworkData {
    * Requires the inputTypes and outputTypes to be defined
    */
   normalize() {
-    if (this.data === null) {
-      this.syncData();
+    console.log(this.xs);
+    console.log(this.ys);
 
-      // TODO: check data and set inputTypes and outputTypes
-      this.meta.inputTypes = this.ensureIOTypes('input')
-      this.meta.outputTypes = this.ensureIOTypes('output')
+    const labelList = [
+      'red-ish',
+      'green-ish',
+      'blue-ish',
+      'orange-ish',
+      'yellow-ish',
+      'pink-ish',
+      'purple-ish',
+      'brown-ish',
+      'grey-ish'
+    ]
 
+    const colors = [];
+    const labels = [];
+
+    for (let i = 0; i < this.xs.length; i += 1) {
+      const col = [this.xs[i].r / 255, this.xs[i].g / 255, this.xs[i].b / 255];
+      colors.push(col);
     }
 
-    // get the labels
-    const {
-      inputTypes,
-      outputTypes
-    } = this.meta;
+    for (let i = 0; i < this.ys.length; i += 1) {
+      labels.push(labelList.indexOf(this.ys[i].label));
+    }
 
-    // TODO: STEP X - Check which data are string types
-    const inputs = this.encodeValues(inputTypes, 'input')
-    const targets = this.encodeValues(outputTypes, 'output');
+    const inputTensor = tf.tensor2d(colors);
+    const labelsTensor = tf.tensor1d(labels, 'int32');
 
-    // convert those data to tensors after encoding oneHot() or not
-    const inputTensor = tf.tensor(inputs);
-    const outputTensor = tf.tensor(targets).cast('float32');
+    const outputTensor = tf.oneHot(labelsTensor, 9).cast('float32');
+    labelsTensor.dispose();
 
-    // // Step 3. Normalize the data to the range 0 - 1 using min-max scaling
-    // TODO: need to ensure to preserve the axis correctly! - Subject to change!
-    const inputMax = inputTensor.max(1, true);
-    const inputMin = inputTensor.min(1, true);
-    const targetMax = outputTensor.max(1, true);
-    const targetMin = outputTensor.min(1, true);
+    // if (this.data === null) {
+    //   this.syncData();
 
-    inputMax.print()
-    inputMin.print()
-    targetMax.print()
-    targetMin.print()
+    //   // TODO: check data and set inputTypes and outputTypes
+    //   this.meta.inputTypes = this.ensureIOTypes('input')
+    //   this.meta.outputTypes = this.ensureIOTypes('output')
 
-    const normalizedInputs = inputTensor
-      .sub(inputMin)
-      .div(inputMax.sub(inputMin))
-      .flatten()
-      .reshape([this.data.length, this.meta.inputUnits]);
-    const normalizedOutputs = outputTensor
-      .sub(targetMin)
-      .div(targetMax.sub(targetMin))
-      .flatten().reshape([this.data.length, this.meta.outputUnits]);
+    // }
+
+    // // get the labels
+    // const {
+    //   inputTypes,
+    //   outputTypes
+    // } = this.meta;
+
+    // console.log(inputTypes);
+    // console.log(outputTypes);
+
+    // // TODO: STEP X - Check which data are string types
+    // const inputs = this.encodeValues(inputTypes, 'input')
+    // const targets = this.encodeValues(outputTypes, 'output');
+
+    // // convert those data to tensors after encoding oneHot() or not
+    // const inputTensor = tf.tensor(inputs);
+    // const outputTensor = tf.tensor(targets).cast('float32');
+    // console.log(inputTensor.shape);
+    // console.log(outputTensor.shape);
+
+    // // // Step 3. Normalize the data to the range 0 - 1 using min-max scaling
+    // // TODO: need to ensure to preserve the axis correctly! - Subject to change!
+    // const inputMax = inputTensor.max(1, true);
+    // const inputMin = inputTensor.min(1, true);
+    // const targetMax = outputTensor.max(1, true);
+    // const targetMin = outputTensor.min(1, true);
+
+    // inputMax.print()
+    // inputMin.print()
+    // targetMax.print()
+    // targetMin.print()
+
+    // const normalizedInputs = inputTensor
+    //   .sub(inputMin)
+    //   .div(inputMax.sub(inputMin))
+    //   .flatten()
+    //   .reshape([this.data.length, this.meta.inputUnits]);
+    // const normalizedOutputs = outputTensor
+    //   .sub(targetMin)
+    //   .div(targetMax.sub(targetMin))
+    //   .flatten().reshape([this.data.length, this.meta.outputUnits]);
+
+    // console.log(normalizedInputs.shape);
+    // console.log(normalizedOutputs.shape);
+
 
     this.normalizedData = {
       // Return the min/max bounds so we can use them later.
       tensors: {
-        inputs: normalizedInputs, // normalizedInputs,
-        targets: normalizedOutputs,
-        inputMax,
-        inputMin,
-        targetMax,
-        targetMin,
+        // inputs: normalizedInputs, // normalizedInputs,
+        // targets: normalizedOutputs,
+        inputs: inputTensor,
+        targets: outputTensor,
+        // inputMax,
+        // inputMin,
+        // targetMax,
+        // targetMin,
       },
-      inputMax: inputMax.arraySync(),
-      inputMin: inputMin.arraySync(),
-      targetMax: targetMax.arraySync(),
-      targetMin: targetMin.arraySync()
+      // inputMax: inputMax.arraySync(),
+      // inputMin: inputMin.arraySync(),
+      // targetMax: targetMax.arraySync(),
+      // targetMin: targetMin.arraySync()
     }
     // });
   }

--- a/src/NeuralNetwork/NeuralNetworkData.js
+++ b/src/NeuralNetwork/NeuralNetworkData.js
@@ -53,13 +53,13 @@ class NeuralNetworkData {
   }
 
   /**
-   * 
+   *
    */
-  encodeValues(ioTypeArray, ioType){
-    
+  encodeValues(ioTypeArray, ioType) {
+
     let dval;
     let ioUnits;
-    if(ioType === 'input'){
+    if (ioType === 'input') {
       dval = 'xs';
       ioUnits = this.meta.inputUnits;
     } else {
@@ -72,14 +72,14 @@ class NeuralNetworkData {
         dtype,
         name
       } = header;
-      
+
       let encodedValues;
 
       if (dtype === 'string') {
-        const dataArray = this.data.map(d => d[dval][name]);        
+        const dataArray = this.data.map(d => d[dval][name]);
         const uniqueValues = [...new Set(dataArray)];
         const oneHotValues = dataArray.map((item) => {
-            return uniqueValues.indexOf(item)
+          return uniqueValues.indexOf(item)
         })
 
         encodedValues = tf.oneHot(tf.tensor1d(oneHotValues, 'int32'), ioUnits);
@@ -95,9 +95,9 @@ class NeuralNetworkData {
 
   }
 
-  ensureIOTypes(ioType){
+  ensureIOTypes(ioType) {
     let dval;
-    if(ioType === 'input'){
+    if (ioType === 'input') {
       dval = 'xs'
     } else {
       dval = 'ys'
@@ -111,9 +111,9 @@ class NeuralNetworkData {
         name: prop,
         dtype: null
       }
-      if(typeof val === 'string'){
+      if (typeof val === 'string') {
         output.dtype = 'string'
-      } else{
+      } else {
         output.dtype = 'number'
       }
 
@@ -129,7 +129,7 @@ class NeuralNetworkData {
   normalize() {
     if (this.data === null) {
       this.syncData();
-      
+
       // TODO: check data and set inputTypes and outputTypes
       this.meta.inputTypes = this.ensureIOTypes('input')
       this.meta.outputTypes = this.ensureIOTypes('output')
@@ -144,11 +144,11 @@ class NeuralNetworkData {
 
     // TODO: STEP X - Check which data are string types
     const inputs = this.encodeValues(inputTypes, 'input')
-    const targets = this.encodeValues(outputTypes, 'output')
+    const targets = this.encodeValues(outputTypes, 'output');
 
     // convert those data to tensors after encoding oneHot() or not
-    const inputTensor =  tf.tensor(inputs);
-    const outputTensor = tf.tensor(targets);
+    const inputTensor = tf.tensor(inputs);
+    const outputTensor = tf.tensor(targets).cast('float32');
 
     // // Step 3. Normalize the data to the range 0 - 1 using min-max scaling
     // TODO: need to ensure to preserve the axis correctly! - Subject to change!
@@ -192,8 +192,8 @@ class NeuralNetworkData {
 
   /**
    * Normalize one value or array
-   * TODO: not sure this is the best way! 
-   * @param {*} arr 
+   * TODO: not sure this is the best way!
+   * @param {*} arr
    */
   normalizeSingle(val, io) {
 
@@ -228,8 +228,8 @@ class NeuralNetworkData {
    * unnormalizeSingle()
    * Get back a number or array being normalized
    * based on the input data
-   * @param {*} val 
-   * @param {*} io 
+   * @param {*} val
+   * @param {*} io
    */
   unnormalizeSingle(val, io) {
     let min;
@@ -260,10 +260,10 @@ class NeuralNetworkData {
   }
 
   /**
-   * Gets the total number of inputs/outputs based on the data type 
-   * Uses the relevant function to convert values e.g. oneHot() and 
+   * Gets the total number of inputs/outputs based on the data type
+   * Uses the relevant function to convert values e.g. oneHot() and
    * sends back the appropriate length of values
-   * @param {*} val 
+   * @param {*} val
    */
   getIOUnits() {
     let inputUnits = 0;
@@ -300,8 +300,8 @@ class NeuralNetworkData {
    * These data get "mashed" into the data object
    * when .normalize() or .shuffle() are called
    * TODO: Figure out a way to sync all this!
-   * @param {*} xs 
-   * @param {*} ys 
+   * @param {*} xs
+   * @param {*} ys
    */
   addData(xs, ys) {
     this.xs.push(xs);

--- a/src/NeuralNetwork/NeuralNetworkData.js
+++ b/src/NeuralNetwork/NeuralNetworkData.js
@@ -154,11 +154,11 @@ class NeuralNetworkData {
       labels.push(labelList.indexOf(this.ys[i].label));
     }
 
-    const inputTensor = tf.tensor2d(colors);
-    const labelsTensor = tf.tensor1d(labels, 'int32');
+    const inputTensorA = tf.tensor2d(colors);
+    const labelsTensorA = tf.tensor1d(labels, 'int32');
 
-    const outputTensor = tf.oneHot(labelsTensor, 9).cast('float32');
-    labelsTensor.dispose();
+    const outputTensorA = tf.oneHot(labelsTensorA, 9).cast('float32');
+    labelsTensorA.dispose();
 
     // if (this.data === null) {
     //   this.syncData();
@@ -169,46 +169,55 @@ class NeuralNetworkData {
 
     // }
 
-    // // get the labels
-    // const {
-    //   inputTypes,
-    //   outputTypes
-    // } = this.meta;
+    // get the labels
+    const {
+      inputTypes,
+      outputTypes
+    } = this.meta;
 
-    // console.log(inputTypes);
-    // console.log(outputTypes);
+    console.log(inputTypes);
+    console.log(outputTypes);
 
     // // TODO: STEP X - Check which data are string types
-    // const inputs = this.encodeValues(inputTypes, 'input')
-    // const targets = this.encodeValues(outputTypes, 'output');
+    const inputs = this.encodeValues(inputTypes, 'input')
+    const targets = this.encodeValues(outputTypes, 'output');
+
+    console.log(inputs);
+    console.log(targets);
+
 
     // // convert those data to tensors after encoding oneHot() or not
-    // const inputTensor = tf.tensor(inputs);
-    // const outputTensor = tf.tensor(targets).cast('float32');
+    const inputTensor = tf.tensor(inputs);
+    const outputTensor = tf.tensor(targets).cast('float32');
     // console.log(inputTensor.shape);
     // console.log(outputTensor.shape);
 
     // // // Step 3. Normalize the data to the range 0 - 1 using min-max scaling
-    // // TODO: need to ensure to preserve the axis correctly! - Subject to change!
-    // const inputMax = inputTensor.max(1, true);
-    // const inputMin = inputTensor.min(1, true);
-    // const targetMax = outputTensor.max(1, true);
-    // const targetMin = outputTensor.min(1, true);
+    // // TODO: need to ensure to preserve the axis correctly! - Subject to change
+    const inputMax = inputTensor.max(1, true);
+    const inputMin = inputTensor.min(1, true);
+    inputMin.print();
+    inputMax.print();
 
-    // inputMax.print()
-    // inputMin.print()
-    // targetMax.print()
-    // targetMin.print()
+    const targetMax = outputTensor.max(1, true);
+    const targetMin = outputTensor.min(1, true);
+    targetMin.print();
+    targetMax.print();
 
-    // const normalizedInputs = inputTensor
-    //   .sub(inputMin)
-    //   .div(inputMax.sub(inputMin))
-    //   .flatten()
-    //   .reshape([this.data.length, this.meta.inputUnits]);
-    // const normalizedOutputs = outputTensor
-    //   .sub(targetMin)
-    //   .div(targetMax.sub(targetMin))
-    //   .flatten().reshape([this.data.length, this.meta.outputUnits]);
+
+    const normalizedInputs = inputTensor
+      .sub(inputMin)
+      .div(inputMax.sub(inputMin))
+      .flatten()
+      .reshape([this.data.length, this.meta.inputUnits]);
+    inputTensorA.print();
+    normalizedInputs.print();
+    const normalizedOutputs = outputTensor
+      .sub(targetMin)
+      .div(targetMax.sub(targetMin))
+      .flatten().reshape([this.data.length, this.meta.outputUnits]);
+    outputTensorA.print();
+    normalizedOutputs.print();
 
     // console.log(normalizedInputs.shape);
     // console.log(normalizedOutputs.shape);
@@ -219,8 +228,8 @@ class NeuralNetworkData {
       tensors: {
         // inputs: normalizedInputs, // normalizedInputs,
         // targets: normalizedOutputs,
-        inputs: inputTensor,
-        targets: outputTensor,
+        inputs: inputTensorA,
+        targets: outputTensorA,
         // inputMax,
         // inputMin,
         // targetMax,

--- a/src/NeuralNetwork/index.js
+++ b/src/NeuralNetwork/index.js
@@ -404,8 +404,7 @@ class NeuralNetwork {
       targets
     } = this.data.normalizedData.tensors;
 
-    console.log('targets!')
-    targets.print();
+    // targets.print();
 
     // check if the inputs are tensors, if not, convert!
     if (!(inputs instanceof tf.Tensor)) {

--- a/src/NeuralNetwork/index.js
+++ b/src/NeuralNetwork/index.js
@@ -80,20 +80,20 @@ class NeuralNetwork {
 
     // Create the model
     if (this.config.dataUrl !== null) {
-      // If dataUrl is specified: 
-      // * load any relevant data 
-      // * run the getIOUnits() function to 
+      // If dataUrl is specified:
+      // * load any relevant data
+      // * run the getIOUnits() function to
       // * create the model
       this.ready = this.createModelFromData(callback);
     } else {
-      // If dataUrl is not specified: 
+      // If dataUrl is not specified:
       // * set the inputUnits and outputUnits
       // * create the model
       this.data.meta.inputUnits = this.config.inputs;
       this.data.meta.outputUnits = this.config.outputs;
-      // convert the inputs and outputs to arrays 
-      // if they are not specified this way already 
-      // e.g. input1, input2, input3 
+      // convert the inputs and outputs to arrays
+      // if they are not specified this way already
+      // e.g. input1, input2, input3
       // e.g. output1, output2, output3
       this.data.inputs = this.createNamedIO(this.config.inputs, 'input');
       this.data.outputs = this.createNamedIO(this.config.outputs, 'output');
@@ -108,8 +108,8 @@ class NeuralNetwork {
    * Takes in a number or array and then either returns
    * the array or returns an array of ['input0','input1']
    * the array or returns an array of ['output0','output1']
-   * @param {*} val 
-   * @param {*} inputType 
+   * @param {*} val
+   * @param {*} inputType
    */
   // eslint-disable-next-line class-methods-use-this
   createNamedIO(val, inputType) {
@@ -120,12 +120,12 @@ class NeuralNetwork {
 
   /**
    * Create model from data
-   * @param {*} callback 
+   * @param {*} callback
    */
   createModelFromData(callback) {
     return callCallback(this.createModelFromDataInternal(), callback)
   }
-  
+
   async createModelFromDataInternal() {
     // load the data
     await this.loadData();
@@ -138,8 +138,8 @@ class NeuralNetwork {
     this.model = this.createModel();
   }
 
-  
-  async loadJSONInternal(){
+
+  async loadJSONInternal() {
     const outputLabels = this.config.outputs;
     const inputLabels = this.config.inputs;
 
@@ -147,11 +147,11 @@ class NeuralNetwork {
     const json = await data.json();
 
     // TODO: recurse through the object to find
-    // which object contains the 
+    // which object contains the
     let parentProp;
-    if( Object.keys(json).includes('entries')){
+    if (Object.keys(json).includes('entries')) {
       parentProp = 'entries'
-    } else if (Object.keys(json).includes('data')){
+    } else if (Object.keys(json).includes('data')) {
       parentProp = 'data'
     } else {
       console.log(`your data must be contained in an array in \n
@@ -166,7 +166,7 @@ class NeuralNetwork {
 
       const output = {};
       props.forEach(prop => {
-        if(inputLabels.includes(prop)){
+        if (inputLabels.includes(prop)) {
           output[prop] = item[prop]
         }
       })
@@ -179,17 +179,17 @@ class NeuralNetwork {
 
       const output = {};
       props.forEach(prop => {
-        if(outputLabels.includes(prop)){
+        if (outputLabels.includes(prop)) {
           output[prop] = item[prop]
         }
       })
-      
+
       return output;
     })
 
     this.data.data = [];
-    
-    this.data.ys.forEach( (item, idx) =>  {
+
+    this.data.ys.forEach((item, idx) => {
       const output = {};
       output.xs = this.data.xs[idx]
       output.ys = this.data.ys[idx]
@@ -209,7 +209,7 @@ class NeuralNetwork {
     console.log(this.data.data)
   }
 
-  async loadCSVInternal(){
+  async loadCSVInternal() {
     const outputLabels = this.config.outputs;
     const inputLabels = this.config.inputs;
 
@@ -257,7 +257,7 @@ class NeuralNetwork {
     // console.log(this.data.meta)
 
     if (this.config.debug) {
-      outputLabels.forEach( outputLabel => {
+      outputLabels.forEach(outputLabel => {
         const values = inputLabels.map(label => {
           return data.map(item => {
             return {
@@ -282,15 +282,15 @@ class NeuralNetwork {
     }
   }
 
-  
+
   /**
-   * Loads data if a dataUrl is specified in the 
+   * Loads data if a dataUrl is specified in the
    * constructor
    */
   async loadData() {
-    if(this.config.dataUrl.endsWith('.csv')){
+    if (this.config.dataUrl.endsWith('.csv')) {
       await this.loadCSVInternal();
-    } else if (this.config.dataUrl.endsWith('.json')){
+    } else if (this.config.dataUrl.endsWith('.json')) {
       await this.loadJSONInternal();
     } else {
       console.log('Not a valid data format. Must be csv or json')
@@ -315,11 +315,12 @@ class NeuralNetwork {
 
       case 'classification': // Create a model for classification
         // set classification model parameters
+        console.log(this.config);
         this.config.hiddenUnits = 16;
-        this.config.activationHidden = 'relu' // 'relu',
+        this.config.activationHidden = 'sigmoid' // 'relu',
         this.config.activationOutput = 'softmax' // 'relu',
         this.config.modelLoss = 'categoricalCrossentropy'
-        this.config.modelOptimizer = tf.train.adam();
+        this.config.modelOptimizer = tf.train.sgd(DEFAULTS.learningRate); // tf.train.adam();
 
         return this.createModelInternal();
 
@@ -371,8 +372,8 @@ class NeuralNetwork {
 
   /**
    * User-facing neural network training
-   * @param {*} optionsOrCallback 
-   * @param {*} callback 
+   * @param {*} optionsOrCallback
+   * @param {*} callback
    */
   train(optionsOrCallback, callback) {
     let options;
@@ -390,7 +391,7 @@ class NeuralNetwork {
 
   /**
    * Train the neural network
-   * @param {*} options 
+   * @param {*} options
    */
   async trainInternal(options) {
     const batchSize = options.batchSize || this.config.batchSize;
@@ -418,24 +419,25 @@ class NeuralNetwork {
     let modelFitCallbacks;
     if (this.config.debug) {
       modelFitCallbacks = [tfvis.show.fitCallbacks({
-            name: 'Training Performance'
-          },
-          ['loss', 'accuracy'], {
-            height: 200,
-            callbacks: ['onEpochEnd']
-          }
-        ),
-        {
-          onEpochEnd: (epoch, logs) => console.log(`Epoch: ${epoch} - accuracy: ${logs.loss.toFixed(3)}`)
-        },
-        {
-          onTrainEnd: () => console.log(`training complete!`)
-        },
+        name: 'Training Performance'
+      },
+        ['loss', 'accuracy'], {
+        height: 200,
+        callbacks: ['onEpochEnd']
+      }
+      ),
+      {
+        onEpochEnd: (epoch, logs) => console.log(`Epoch: ${epoch} - accuracy: ${logs.loss.toFixed(3)}`)
+      },
+      {
+        onTrainEnd: () => console.log(`training complete!`)
+      },
       ]
     } else {
       modelFitCallbacks = []
     }
 
+    console.log(ys);
     await this.model.fit(xs, ys, {
       shuffle: true,
       batchSize,
@@ -452,8 +454,8 @@ class NeuralNetwork {
    * Classify()
    * Runs the classification if the neural network is doing a
    * classification task
-   * @param {*} input 
-   * @param {*} callback 
+   * @param {*} input
+   * @param {*} callback
    */
   classify(input, callback) {
     return callCallback(this.predictInternal(input), callback);
@@ -461,8 +463,8 @@ class NeuralNetwork {
 
   /**
    * Userfacing prediction function
-   * @param {*} input 
-   * @param {*} callback 
+   * @param {*} input
+   * @param {*} callback
    */
   predict(input, callback) {
     return callCallback(this.predictInternal(input), callback);
@@ -470,7 +472,7 @@ class NeuralNetwork {
 
   /**
    * Make a prediction based on the given input
-   * @param {*} sample 
+   * @param {*} sample
    */
   async predictInternal(sample) {
     const xs = tf.tensor(sample, [1, sample.length]);
@@ -478,7 +480,7 @@ class NeuralNetwork {
 
     let results;
     if (this.config.task === 'classification') {
-      // TODO: change the output format based on the 
+      // TODO: change the output format based on the
       // type of behavior
       results = {
         output: await ys.data(),
@@ -499,8 +501,8 @@ class NeuralNetwork {
 
   /**
    * Save the model and weights
-   * @param {*} callback 
-   * @param {*} name 
+   * @param {*} callback
+   * @param {*} name
    */
   async save(callback, name) {
     this.model.save(tf.io.withSaveHandler(async (data) => {
@@ -524,8 +526,8 @@ class NeuralNetwork {
 
   /**
    * Load the model and weights in from a file
-   * @param {*} filesOrPath 
-   * @param {*} callback 
+   * @param {*} filesOrPath
+   * @param {*} callback
    */
   async load(filesOrPath = null, callback) {
     if (typeof filesOrPath !== 'string') {
@@ -556,9 +558,9 @@ class NeuralNetwork {
 
 /**
  * Create an instance of the NeuralNetwork
- * @param {*} inputsOrOptions 
- * @param {*} outputsOrCallback 
- * @param {*} callback 
+ * @param {*} inputsOrOptions
+ * @param {*} outputsOrCallback
+ * @param {*} callback
  */
 const neuralNetwork = (inputsOrOptions, outputsOrCallback, callback) => {
 


### PR DESCRIPTION
## → Describe your Pull Request 📝

For some reason, the implementation in ml5 does not produce the same results as the example I made previously (see: [02_Color_Classifier](https://github.com/shiffman/Tensorflow-JS-Examples/tree/master/02_Color_Classifier)).

This is the loss I see in my previous example with the same data:

<img width="902" alt="Screen Shot 2019-09-22 at 3 14 56 PM" src="https://user-images.githubusercontent.com/191758/65393197-c17d2280-dd4b-11e9-82e0-e025ef170644.png">

Trying a bunch of different things here, I am never able to get the loss to improve beyond tiny increments with the ml5.js version. (example found in: https://github.com/ml5js/ml5-examples/pull/164 with `colorData.json` rather than `small`.)

<img width="725" alt="Screen Shot 2019-09-22 at 3 12 10 PM" src="https://user-images.githubusercontent.com/191758/65393183-7d8a1d80-dd4b-11e9-944b-fd736883c521.png">

So far in this branch, I've tried matching the following differences:

1. Even though the output is a label and one hot encoded into a tensor, I previously cast it as  `float32` rather than `int32`. Not sure this actually matters?
2. I used `sigmoid` and `sgd` instead of `relu` and `adam`.

But so far no improvement.








