### PR TITLE
[DO NOT  MERGE] Webeditor predict debugging

### DIFF
--- a/src/NeuralNetwork/index.js
+++ b/src/NeuralNetwork/index.js
@@ -578,8 +578,8 @@ class NeuralNetwork {
     this.data.inputs.forEach((name, idx) => {
       console.log(name);
       console.log(this.data.meta);
+      console.log(item);
       const item = this.data.meta.inputTypes.find((obj) => obj.name === name);
-
       if (item && item.dtype === 'number') {
         const val = (inputData[idx] - item.min) / (item.max - item.min);
         normalizedInputData.push(val);

--- a/src/NeuralNetwork/index.js
+++ b/src/NeuralNetwork/index.js
@@ -576,11 +576,14 @@ class NeuralNetwork {
     // for each input/output to use them here AND for unnormalizing for outputs
     let normalizedInputData = []
     this.data.inputs.forEach((name, idx) => {
+      console.log(name);
+      console.log(this.data.meta);
       const item = this.data.meta.inputTypes.find((obj) => obj.name === name);
-      if (item.dtype === 'number') {
+
+      if (item && item.dtype === 'number') {
         const val = (inputData[idx] - item.min) / (item.max - item.min);
         normalizedInputData.push(val);
-      } else if (item.dtype === 'string') {
+      } else if (item && item.dtype === 'string') {
         const val = item.legend[inputData[idx]]
         normalizedInputData = [...normalizedInputData, ...val]
       }


### PR DESCRIPTION
## → Describe your Pull Request 📝

This is a bug report rather than an actual pull request. I noticed for the titanic example that (in the web editor only!) this error appeared:

<img width="799" alt="Screen Shot 2019-09-27 at 8 48 35 AM" src="https://user-images.githubusercontent.com/191758/65773469-614efd80-e10a-11e9-846a-7927f635ba98.png">

I traced it back to the iteration `predictInternal()`:

```javascript
    this.data.inputs.forEach((name, idx) => {
      // console.log(name);
      // console.log(this.data.meta);
      // console.log(item);
       const item = this.data.meta.inputTypes.find((obj) => obj.name === name);
```

For whatever reason an extra `undefined` `item` appeared and the example fails when evaluating `item.dtype`.

I temporarily fixed this by checking `item` first:

```javascript
      if (item && item.dtype === 'number') {
        const val = (inputData[idx] - item.min) / (item.max - item.min);
        normalizedInputData.push(val);
      } else if (item && item.dtype === 'string') {
        const val = item.legend[inputData[idx]]
        normalizedInputData = [...normalizedInputData, ...val]
      }
```


<!--------------------------------------------
In order to help the ml5 team understand your pull request, 
we ask that you please submit an example to ml5-examples
showcasing how your integrated feature works. You're also welcome 
to show how this works by providing code that can be easily run by others. 

submit a PR with an example to: https://github.com/ml5js/ml5-examples
---------------------------------------------->

## → Share a Relevant Example 🦄

This working version is now deployed to:
https://editor.p5js.org/ima_ml/sketches/_I1AbpA9h

And you can see the broken version:
https://editor.p5js.org/ima_ml/sketches/0y01JgGaD










