### PR TITLE
Divide by 0 issue when data is not normalized

### DIFF
--- a/src/NeuralNetwork/NeuralNetworkData.js
+++ b/src/NeuralNetwork/NeuralNetworkData.js
@@ -33,10 +33,10 @@ class NeuralNetworkData {
     }
 
     // TODO: temp fix - check normalizationOptions
-    if(options.dataOptions.normalizationOptions !== null && options.dataOptions.normalizationOptions !== undefined){
+    if (options.dataOptions.normalizationOptions !== null && options.dataOptions.normalizationOptions !== undefined) {
       const items = ['inputMax', 'inputMin', 'outputMax', 'outputMin'];
       items.forEach(prop => {
-        if(options.dataOptions.normalizationOptions[prop] !== null && options.dataOptions.normalizationOptions[prop] !== undefined ){
+        if (options.dataOptions.normalizationOptions[prop] !== null && options.dataOptions.normalizationOptions[prop] !== undefined) {
           this.data[prop] = options.dataOptions.normalizationOptions[prop]
         }
       })
@@ -45,7 +45,7 @@ class NeuralNetworkData {
   }
 
 
-  
+
 
   /**
    * load data
@@ -343,7 +343,7 @@ class NeuralNetworkData {
    * normalize the data.raw
    */
   normalize() {
-    
+
     // always make sure to check set the data types
     this.setDTypes();
     // always make sure that the IO units are set
@@ -413,7 +413,7 @@ class NeuralNetworkData {
     // TODO: this is terrible and can be handled way better!
     // REFACTOR THIS!!!
     if (this.config.architecture.task === 'regression') {
-      if(this.config.dataOptions.normalizationOptions instanceof Object){
+      if (this.config.dataOptions.normalizationOptions instanceof Object) {
         // if there is an object with normalizationOptions
         inputMax = this.data.inputMax !== null ? tf.tensor1d(this.data.inputMax) : inputTensor.max(0);
         inputMin = this.data.inputMin !== null ? tf.tensor1d(this.data.inputMin) : inputTensor.min(0);
@@ -428,7 +428,7 @@ class NeuralNetworkData {
         outputMin = outputTensor.min(0);
       }
     } else if (this.config.architecture.task === 'classification') {
-      if(this.config.dataOptions.normalizationOptions instanceof Object){
+      if (this.config.dataOptions.normalizationOptions instanceof Object) {
         // if there is an object with normalizationOptions
         inputMax = this.data.inputMax !== null ? tf.tensor1d(this.data.inputMax) : inputTensor.max(0);
         inputMin = this.data.inputMin !== null ? tf.tensor1d(this.data.inputMin) : inputTensor.min(0);
@@ -460,7 +460,7 @@ class NeuralNetworkData {
   /**
    * Assemble the data for training
    */
-  warmUp(){
+  warmUp() {
     // always make sure to check set the data types
     this.setDTypes();
     // always make sure that the IO units are set
@@ -473,62 +473,62 @@ class NeuralNetworkData {
     } = this.convertRawToTensor();
 
 
-    inputTensor.print()
-    outputTensor.print()
+    // inputTensor.print()
+    // outputTensor.print()
 
-    let inputMax;
-    let inputMin;
-    let outputMax;
-    let outputMin;
+    // let inputMax;
+    // let inputMin;
+    // let outputMax;
+    // let outputMin;
 
     // TODO: this is terrible and can be handled way better!
     // REFACTOR THIS!!!
-    if (this.config.architecture.task === 'regression') {
-      if(this.config.dataOptions.normalizationOptions instanceof Object){
-        // if there is an object with normalizationOptions
-        inputMax = this.data.inputMax !== null ? tf.tensor1d(this.data.inputMax) : inputTensor.max(0);
-        inputMin = this.data.inputMin !== null ? tf.tensor1d(this.data.inputMin) : inputTensor.min(0);
-        outputMax = this.data.outputMax !== null ? tf.tensor1d(this.data.outputMax) : outputTensor.max(0);
-        outputMin = this.data.outputMin !== null ? tf.tensor1d(this.data.outputMin) : outputTensor.min(0);
-      } else {
-        // if the task is a regression, return all the
-        // output stats as an array
-        inputMax = inputTensor.max(0);
-        inputMin = inputTensor.min(0);
-        outputMax = outputTensor.max(0);
-        outputMin = outputTensor.min(0);
-      }
-    } else if (this.config.architecture.task === 'classification') {
-      if(this.config.dataOptions.normalizationOptions instanceof Object){
-        // if there is an object with normalizationOptions
-        inputMax = this.data.inputMax !== null ? tf.tensor1d(this.data.inputMax) : inputTensor.max(0);
-        inputMin = this.data.inputMin !== null ? tf.tensor1d(this.data.inputMin) : inputTensor.min(0);
-        outputMax = this.data.outputMax !== null ? tf.tensor1d(this.data.outputMax) : outputTensor.max();
-        outputMin = this.data.outputMin !== null ? tf.tensor1d(this.data.outputMin) : outputTensor.min();
-      } else {
-        // if the task is a classification, return the single value
-        inputMax = inputTensor.max(0);
-        inputMin = inputTensor.min(0);
-        outputMax = outputTensor.max();
-        outputMin = outputTensor.min();
-      }
-    }
+    // if (this.config.architecture.task === 'regression') {
+    //   if (this.config.dataOptions.normalizationOptions instanceof Object) {
+    //     // if there is an object with normalizationOptions
+    //     inputMax = this.data.inputMax !== null ? tf.tensor1d(this.data.inputMax) : inputTensor.max(0);
+    //     inputMin = this.data.inputMin !== null ? tf.tensor1d(this.data.inputMin) : inputTensor.min(0);
+    //     outputMax = this.data.outputMax !== null ? tf.tensor1d(this.data.outputMax) : outputTensor.max(0);
+    //     outputMin = this.data.outputMin !== null ? tf.tensor1d(this.data.outputMin) : outputTensor.min(0);
+    //   } else {
+    //     // if the task is a regression, return all the
+    //     // output stats as an array
+    //     inputMax = inputTensor.max(0);
+    //     inputMin = inputTensor.min(0);
+    //     outputMax = outputTensor.max(0);
+    //     outputMin = outputTensor.min(0);
+    //   }
+    // } else if (this.config.architecture.task === 'classification') {
+    //   if (this.config.dataOptions.normalizationOptions instanceof Object) {
+    //     // if there is an object with normalizationOptions
+    //     inputMax = this.data.inputMax !== null ? tf.tensor1d(this.data.inputMax) : inputTensor.max(0);
+    //     inputMin = this.data.inputMin !== null ? tf.tensor1d(this.data.inputMin) : inputTensor.min(0);
+    //     outputMax = this.data.outputMax !== null ? tf.tensor1d(this.data.outputMax) : outputTensor.max();
+    //     outputMin = this.data.outputMin !== null ? tf.tensor1d(this.data.outputMin) : outputTensor.min();
+    //   } else {
+    //     // if the task is a classification, return the single value
+    //     inputMax = inputTensor.max(0);
+    //     inputMin = inputTensor.min(0);
+    //     outputMax = outputTensor.max();
+    //     outputMin = outputTensor.min();
+    //   }
+    // }
 
 
     this.data.tensor = {
       inputs: inputTensor,
       outputs: outputTensor,
-      inputMax,
-      inputMin,
-      outputMax,
-      outputMin,
+      // inputMax,
+      // inputMin,
+      // outputMax,
+      // outputMin,
     }
 
     // set the input/output Min and max values as numbers
-    this.data.inputMin = inputMin.arraySync();
-    this.data.inputMax = inputMax.arraySync();
-    this.data.outputMax = outputMax.arraySync();
-    this.data.outputMin = outputMin.arraySync();
+    // this.data.inputMin = inputMin.arraySync();
+    // this.data.inputMax = inputMax.arraySync();
+    // this.data.outputMax = outputMax.arraySync();
+    // this.data.outputMin = outputMin.arraySync();
 
   }
 

--- a/src/NeuralNetwork/NeuralNetworkData.js
+++ b/src/NeuralNetwork/NeuralNetworkData.js
@@ -476,59 +476,59 @@ class NeuralNetworkData {
     // inputTensor.print()
     // outputTensor.print()
 
-    // let inputMax;
-    // let inputMin;
-    // let outputMax;
-    // let outputMin;
+    let inputMax;
+    let inputMin;
+    let outputMax;
+    let outputMin;
 
     // TODO: this is terrible and can be handled way better!
     // REFACTOR THIS!!!
-    // if (this.config.architecture.task === 'regression') {
-    //   if (this.config.dataOptions.normalizationOptions instanceof Object) {
-    //     // if there is an object with normalizationOptions
-    //     inputMax = this.data.inputMax !== null ? tf.tensor1d(this.data.inputMax) : inputTensor.max(0);
-    //     inputMin = this.data.inputMin !== null ? tf.tensor1d(this.data.inputMin) : inputTensor.min(0);
-    //     outputMax = this.data.outputMax !== null ? tf.tensor1d(this.data.outputMax) : outputTensor.max(0);
-    //     outputMin = this.data.outputMin !== null ? tf.tensor1d(this.data.outputMin) : outputTensor.min(0);
-    //   } else {
-    //     // if the task is a regression, return all the
-    //     // output stats as an array
-    //     inputMax = inputTensor.max(0);
-    //     inputMin = inputTensor.min(0);
-    //     outputMax = outputTensor.max(0);
-    //     outputMin = outputTensor.min(0);
-    //   }
-    // } else if (this.config.architecture.task === 'classification') {
-    //   if (this.config.dataOptions.normalizationOptions instanceof Object) {
-    //     // if there is an object with normalizationOptions
-    //     inputMax = this.data.inputMax !== null ? tf.tensor1d(this.data.inputMax) : inputTensor.max(0);
-    //     inputMin = this.data.inputMin !== null ? tf.tensor1d(this.data.inputMin) : inputTensor.min(0);
-    //     outputMax = this.data.outputMax !== null ? tf.tensor1d(this.data.outputMax) : outputTensor.max();
-    //     outputMin = this.data.outputMin !== null ? tf.tensor1d(this.data.outputMin) : outputTensor.min();
-    //   } else {
-    //     // if the task is a classification, return the single value
-    //     inputMax = inputTensor.max(0);
-    //     inputMin = inputTensor.min(0);
-    //     outputMax = outputTensor.max();
-    //     outputMin = outputTensor.min();
-    //   }
-    // }
+    if (this.config.architecture.task === 'regression') {
+      if (this.config.dataOptions.normalizationOptions instanceof Object) {
+        // if there is an object with normalizationOptions
+        inputMax = this.data.inputMax !== null ? tf.tensor1d(this.data.inputMax) : inputTensor.max(0);
+        inputMin = this.data.inputMin !== null ? tf.tensor1d(this.data.inputMin) : inputTensor.min(0);
+        outputMax = this.data.outputMax !== null ? tf.tensor1d(this.data.outputMax) : outputTensor.max(0);
+        outputMin = this.data.outputMin !== null ? tf.tensor1d(this.data.outputMin) : outputTensor.min(0);
+      } else {
+        // if the task is a regression, return all the
+        // output stats as an array
+        inputMax = inputTensor.max(0);
+        inputMin = inputTensor.min(0);
+        outputMax = outputTensor.max(0);
+        outputMin = outputTensor.min(0);
+      }
+    } else if (this.config.architecture.task === 'classification') {
+      if (this.config.dataOptions.normalizationOptions instanceof Object) {
+        // if there is an object with normalizationOptions
+        inputMax = this.data.inputMax !== null ? tf.tensor1d(this.data.inputMax) : inputTensor.max(0);
+        inputMin = this.data.inputMin !== null ? tf.tensor1d(this.data.inputMin) : inputTensor.min(0);
+        outputMax = this.data.outputMax !== null ? tf.tensor1d(this.data.outputMax) : outputTensor.max();
+        outputMin = this.data.outputMin !== null ? tf.tensor1d(this.data.outputMin) : outputTensor.min();
+      } else {
+        // if the task is a classification, return the single value
+        inputMax = inputTensor.max(0);
+        inputMin = inputTensor.min(0);
+        outputMax = outputTensor.max();
+        outputMin = outputTensor.min();
+      }
+    }
 
 
     this.data.tensor = {
       inputs: inputTensor,
       outputs: outputTensor,
-      // inputMax,
-      // inputMin,
-      // outputMax,
-      // outputMin,
+      inputMax,
+      inputMin,
+      outputMax,
+      outputMin,
     }
 
     // set the input/output Min and max values as numbers
-    // this.data.inputMin = inputMin.arraySync();
-    // this.data.inputMax = inputMax.arraySync();
-    // this.data.outputMax = outputMax.arraySync();
-    // this.data.outputMin = outputMin.arraySync();
+    this.data.inputMin = inputMin.arraySync();
+    this.data.inputMax = inputMax.arraySync();
+    this.data.outputMax = outputMax.arraySync();
+    this.data.outputMin = outputMin.arraySync();
 
   }
 


### PR DESCRIPTION
## → Describe your Pull Request 📝

This is a bug report and crude "fix" for an issue I discovered in the week 6 material for https://github.com/ml5js/Intro-ML-Arts-IMA/pull/56.

If `normalizeData()` is not called, the data is still normalized during `predictInternal()`. Here, I've commented out code and skip that calculation. Then `predict()`  checks to see if `inputMin` and `inputMax` have been computed before applying the normalization.

Maybe a better solution would be to track a "normalized" flag?

I also discovered what the problem is when data *is normalized* and the training process results in a loss of `NaN`. This has to do with this calculation in the following two code snippets.

```javascript
 normVal = (val - inputMin[valIndex]) / (inputMax[valIndex] - inputMin[valIndex]);
```

```javascript
const normalizedInputs = inputTensor.sub(inputMin).div(inputMax.sub(inputMin));
const normalizedOutputs = outputTensor.sub(outputMin).div(outputMax.sub(outputMin));
```

If `inputMin == inputMax` or if `outputMin == outputMax` then the difference between the two is 0 . . which results in a divide by zero error! 

This pull  request does not include a fix for the above, but I'm happy to work on one. Will await feedback and thoughts from @joeyklee!


