### PR TITLE
[bodyPix] allows user to add video to .segment() and .segmentWithParts()

### DIFF
--- a/src/BodyPix/index.js
+++ b/src/BodyPix/index.js
@@ -257,17 +257,17 @@ class BodyPix {
             // clean the following conditional statement up!
         } else if (optionsOrCallback instanceof HTMLImageElement 
             || optionsOrCallback instanceof HTMLCanvasElement 
+            || optionsOrCallback instanceof HTMLVideoElement
             || optionsOrCallback instanceof ImageData) {
                 imgToSegment = optionsOrCallback;
         } else if (typeof optionsOrCallback === 'object' && (optionsOrCallback.elt instanceof HTMLImageElement 
             || optionsOrCallback.elt instanceof HTMLCanvasElement 
             || optionsOrCallback.elt instanceof ImageData)){
-                
-                if(optionsOrCallback.canvas instanceof HTMLCanvasElement){
-                    imgToSegment = optionsOrCallback.canvas; // Handle p5.js image
-                } else {
-                    imgToSegment = optionsOrCallback.elt; // Handle p5.js image
-                }
+            imgToSegment = optionsOrCallback.elt; // Handle p5.js image
+        } else if (typeof optionsOrCallback === 'object' && optionsOrCallback.canvas instanceof HTMLCanvasElement) {
+            imgToSegment = optionsOrCallback.canvas; // Handle p5.js image
+        } else if (typeof optionsOrCallback === 'object' && optionsOrCallback.elt instanceof HTMLVideoElement) {
+            imgToSegment = optionsOrCallback.elt; // Handle p5.js image
         } else if (!(this.video instanceof HTMLVideoElement)) {
             // Handle unsupported input
             throw new Error(
@@ -353,6 +353,7 @@ class BodyPix {
             // clean the following conditional statement up!
         } else if (optionsOrCallback instanceof HTMLImageElement 
             || optionsOrCallback instanceof HTMLCanvasElement 
+            || optionsOrCallback instanceof HTMLVideoElement
             || optionsOrCallback instanceof ImageData) {
                 imgToSegment = optionsOrCallback;
         } else if (typeof optionsOrCallback === 'object' && (optionsOrCallback.elt instanceof HTMLImageElement 
@@ -361,6 +362,8 @@ class BodyPix {
             imgToSegment = optionsOrCallback.elt; // Handle p5.js image
         } else if (typeof optionsOrCallback === 'object' && optionsOrCallback.canvas instanceof HTMLCanvasElement) {
             imgToSegment = optionsOrCallback.canvas; // Handle p5.js image
+        } else if (typeof optionsOrCallback === 'object' && optionsOrCallback.elt instanceof HTMLVideoElement) {
+            imgToSegment = optionsOrCallback.elt; // Handle p5.js image
         } else if (!(this.video instanceof HTMLVideoElement)) {
             // Handle unsupported input
             throw new Error(


### PR DESCRIPTION
<!--------------------------------------------
🌈DEAR BELOVED ML5 COMMUNITY MEMBER. WELCOME. 🌈
---------------------------------------------->

Dear ml5 community, 

I'm making a Pull Request(PR). Please see the details below.


**A good PR 🌟**

### → Step 1:  Which branch are you submitting to? 🌲
> Development (for new features or updates), Release (for bug fixes), or ___________?

* development

### → Step 2: Describe your Pull Request 📝
> Fixing a Bug? Adding an Update? Submitting a New Feature? Does it introduce a breaking change?

* adding an update

Allows users to add a `HTMLVideoElement` to the .segment() and .segmentWithParts() as requested in #608 



**A great PR 🌟🌟**

### → Step 3: Share a Relevant Example 🦄
> Here's some example code or a link to another PR in https://github.com/ml5js/ml5-examples OR in the https://editor.p5js.org or codepen/jsfiddle/etc...

Allows you to:

```js
function setup() {
    createCanvas(320, 240);

    // load up your video
    video = createCapture(VIDEO);
    video.size(width, height);
    // video.hide(); // Hide the video element, and just show the canvas
    bodypix = ml5.bodyPix(modelReady)
}

function modelReady() {
    console.log('ready!')
    bodypix.segment(video, options, gotResults)
}
```

