### PR TITLE
[UNET] adds fix for unet image return for p5

### DIFF
--- a/src/UNET/index.js
+++ b/src/UNET/index.js
@@ -11,6 +11,7 @@ import * as tf from '@tensorflow/tfjs';
 import callCallback from '../utils/callcallback';
 import { array3DToImage } from '../utils/imageUtilities';
 import Video from '../utils/Video';
+import p5Utils from '../utils/p5Utils';
 
 const URL = 'https://raw.githubusercontent.com/zaidalyafeai/HostedModels/master/unet-128/model.json';
 const imageSize = 128;
@@ -40,10 +41,10 @@ class UNET extends Video {
   }
 
   // check if p5js
-  static checkP5() {
-    if (typeof window !== 'undefined' && window.p5 && window.p5.Image && typeof window.p5.Image === 'function') return true;
-    return false;
-  }
+  // static checkP5() {
+  //   if (typeof window !== 'undefined' && window.p5 && window.p5.Image && typeof window.p5.Image === 'function') return true;
+  //   return false;
+  // }
 
   async segment(inputOrCallback, cb) {
     await this.ready;
@@ -108,8 +109,10 @@ class UNET extends Video {
     const raw = await tf.browser.toPixels(tensor);
     let image;
 
-    if (UNET.checkP5()) {
-      image = window.loadImage(dom.src);
+    if (p5Utils.checkP5()) {
+        const blob1 = await p5Utils.rawToBlob(raw, imageSize, imageSize);
+        const p5Image1 = await p5Utils.blobToP5Image(blob1);
+        image = p5Image1;
     }
 
     return {


### PR DESCRIPTION
<!--------------------------------------------
🌈DEAR BELOVED ML5 COMMUNITY MEMBER. WELCOME. 🌈
---------------------------------------------->

Dear ml5 community, 

I'm making a Pull Request(PR). Please see the details below.


**A good PR 🌟**

### → Step 1:  Which branch are you submitting to? 🌲
> Development (for new features or updates), Release (for bug fixes), or ___________?

* development


### → Step 2: Describe your Pull Request 📝
> Fixing a Bug? Adding an Update? Submitting a New Feature? Does it introduce a breaking change?

* fixing a bug
* adding an update

addresses issue mentioned in https://github.com/ml5js/ml5-library/issues/608#issue-504312913 
where UNET image cannot be rendered outside of `draw` loop. 

The issue was that the old implementation was using `window.loadImage()` which I suspect was loading the image async and therefore needed a callback(?). 

This fix takes the raw tensor, converts it to a blob, then turns the blob into a p5 image. 

