### PR TITLE
[devops] disable webpack host check

### DIFF
--- a/webpack.dev.babel.js
+++ b/webpack.dev.babel.js
@@ -13,7 +13,8 @@ export default merge(common, {
   devtool: 'inline-source-map',
   devServer: {
     watchContentBase: true,
-    contentBase: join(__dirname, './dist')
+    contentBase: join(__dirname, './dist'),
+    disableHostCheck: true,
   },
   plugins: [
     new HtmlWebpackPlugin({


### PR DESCRIPTION
<!--------------------------------------------
🌈DEAR BELOVED ML5 COMMUNITY MEMBER. WELCOME. 🌈
---------------------------------------------->

Dear ml5 community, 

I'm making a Pull Request(PR). Please see the details below.


**A good PR 🌟**

### → Step 1:  Which branch are you submitting to? 🌲
> Development (for new features or updates), Release (for bug fixes), or ___________?

* development

### → Step 2: Describe your Pull Request 📝
> Fixing a Bug? Adding an Update? Submitting a New Feature? Does it introduce a breaking change?

* fixing a bug
* adding an update

Currently fixes an issue with webpack dev server that throws a warning in the browser that the host is invalid by setting `disableHostCheck: true,`

<img width="522" alt="Screen Shot 2019-10-16 at 10 25 16" src="https://user-images.githubusercontent.com/3622055/66928478-6dd6bf80-efff-11e9-8d73-0b9e960b635c.png">


