### PR TITLE
Remove duplicate SktechRNN link from sidebar

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -52,7 +52,6 @@
     * [CharRNN](/reference/charrnn.md)
     * [Sentiment](/reference/sentiment.md)
     * [Word2Vec](/reference/word2vec.md)
-    * [SketchRNN](/reference/sketchrnn.md)
 
 * **Contributing** 🏗 
 <div class="Sidebar__section-divider">&nbsp;</div>


### PR DESCRIPTION
Dear ml5 community, 

I'm making a Pull Request(PR). Please see the details below.

### → Step 1:  Which branch are you submitting to? 🌲
Development

### → Step 2: Describe your Pull Request 📝
* Documentation fix
* In the sidebar, SketchRNN was listed under image _and_ text.
* I removed the link under text.



