### PR TITLE
fix single quote typo in nn reference

### DIFF
--- a/docs/reference/neural-network.md
+++ b/docs/reference/neural-network.md
@@ -87,7 +87,7 @@ The options that can be specified are:
     const options = {
       inputs: 1,
       outputs: 1,
-      type:'regression`
+      type:'regression'
     }
     const neuralNetwork = ml5.neuralNetwork(options)
     ```
@@ -97,7 +97,7 @@ The options that can be specified are:
       dataUrl: 'weather.csv'
       inputs: ['avg_temperature', 'humidity'],
       outputs: ['rained'],
-      type:'classification`
+      type:'classification'
     }
     const neuralNetwork = ml5.neuralNetwork(options, modelLoaded)
     ```
@@ -114,7 +114,7 @@ The options that can be specified are:
       dataUrl: 'weather.json'
       inputs: ['avg_temperature', 'humidity'],
       outputs: ['rained'],
-      type:'classification`
+      type:'classification'
     }
     const neuralNetwork = ml5.neuralNetwork(options, modelLoaded)
     ```
@@ -123,7 +123,7 @@ The options that can be specified are:
     const options = {
       inputs: ['x', 'y'],
       outputs: ['label'],
-      type:'classification`
+      type:'classification'
     }
     const neuralNetwork = ml5.neuralNetwork(options)
     ```


### PR DESCRIPTION
Dear ml5 community, 

I'm making a Pull Request(PR). Please see the details below.

## Branch

Release

## Description

Correcting small typos where a backquote was mistakenly used to close a single quoted string.

example mistake, note the final character: 
```
'regression`
```

example fix: 
```
'regression'
```


