### PR TITLE
Fixed documentation: option parameter should be `task`

### DIFF
--- a/docs/reference/neural-network.md
+++ b/docs/reference/neural-network.md
@@ -87,7 +87,7 @@ The options that can be specified are:
     const options = {
       inputs: 1,
       outputs: 1,
-      type:'regression'
+      task:'regression'
     }
     const neuralNetwork = ml5.neuralNetwork(options)
     ```
@@ -97,7 +97,7 @@ The options that can be specified are:
       dataUrl: 'weather.csv'
       inputs: ['avg_temperature', 'humidity'],
       outputs: ['rained'],
-      type:'classification'
+      task:'classification'
     }
     const neuralNetwork = ml5.neuralNetwork(options, modelLoaded)
     ```
@@ -114,7 +114,7 @@ The options that can be specified are:
       dataUrl: 'weather.json'
       inputs: ['avg_temperature', 'humidity'],
       outputs: ['rained'],
-      type:'classification'
+      task:'classification'
     }
     const neuralNetwork = ml5.neuralNetwork(options, modelLoaded)
     ```
@@ -123,7 +123,7 @@ The options that can be specified are:
     const options = {
       inputs: ['x', 'y'],
       outputs: ['label'],
-      type:'classification'
+      task:'classification'
     }
     const neuralNetwork = ml5.neuralNetwork(options)
     ```


### PR DESCRIPTION
<!--------------------------------------------
🌈DEAR BELOVED ML5 COMMUNITY MEMBER. WELCOME. 🌈
---------------------------------------------->

Dear ml5 community, 

I'm making a Pull Request(PR). Please see the details below.



### → Step 1:  Which branch are you submitting to? 🌲
> gh-pages (for fixing a bug in the documentation [I'm not quite sure this is the right branch])



### → Step 2: Describe your Pull Request 📝
> Fixing examples in the documentation. The option `type` for ml5.neuralNetwork does not exist, instead, it should be `task` as you can see here: https://github.com/ml5js/ml5-library/blob/56470d49a442433590a834d63b4e0738499eb9da/src/NeuralNetwork/index.js#L32 or in this [example](https://github.com/ml5js/ml5-examples/blob/51738c81399e73dc20b62d1a8602e5258c143101/p5js/NeuralNetwork/NeuralNetwork_color_classifier/sketch.js#L24). 
This was discovered by @shiffman during the live stream https://youtu.be/gaWNmLyJiUk at 1 hour 48 Minutes.









<!-- 

BEFORE SUBMITTING YOUR PULL REQUEST PLEASE MAKE
SURE TO SUBMIT THE RELEVANT INFORMATION
TO THE SECTIONS LISTED BELOW. 
HELP US HELP YOU BY PROVIDING ALL THE HELPFUL
INFORMATION THAT WILL ALLOW THE ML5 COMMUNITY
TO UNDERSTAND WHAT YOUR PR IS ABOUT.
WE WILL PRIORITIZE WELL A DOCUMENTED PR.

THANK YOU! MERCI! ABRIGADO! GRACIAS! DANKE!
-->




