### PR TITLE
Adding a video tutorial for ml5.neuralNetwork()

### DIFF
--- a/docs/reference/neural-network.md
+++ b/docs/reference/neural-network.md
@@ -478,7 +478,8 @@ No demos yet - contribute one today!
 
 ## Tutorials
 
-No tutorials yet - contribute one today!
+### ml5.js: Train Your Own Neural Network (Coding Train)
+<iframe width="560" height="315" src="https://www.youtube.com/embed/8HEgeAbYphA"  frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Acknowledgements
 


### PR DESCRIPTION
Dear ml5 community, 

I'm making a Pull Request(PR). Please see the details below.

I've completed a video tutorial about `ml5.neuralNetwork()`. The tutorial is currently unlisted on YouTube but will be made public soon once I've finished preparing captions for accessibility (by 11/22). More to come!

https://youtu.be/8HEgeAbYphA

@joeyklee have I done this in the right place?


