### PR TITLE
Switch the links for regression and classification p5 editor examples in Feature Extractor docs

### DIFF
--- a/docs/reference/feature-extractor.md
+++ b/docs/reference/feature-extractor.md
@@ -225,8 +225,8 @@ featureExtractor.predict(input, ?callback);
 * [FeatureExtractor_Image_Classification](https://github.com/ml5js/ml5-examples/tree/development/p5js/FeatureExtractor/FeatureExtractor_Image_Classification)
 
 **p5 web editor**
-* [FeatureExtractor_Image_Regression](https://editor.p5js.org/ml5/sketches/FeatureExtractor_Image_Classification)
-* [FeatureExtractor_Image_Classification](https://editor.p5js.org/ml5/sketches/FeatureExtractor_Image_Regression)
+* [FeatureExtractor_Image_Regression](https://editor.p5js.org/ml5/sketches/FeatureExtractor_Image_Regression)
+* [FeatureExtractor_Image_Classification](https://editor.p5js.org/ml5/sketches/FeatureExtractor_Image_Classification)
 
 
 **plain javascript**


### PR DESCRIPTION
Looks like they were accidentally placed out of order. You can see the issue by visiting https://learn.ml5js.org/docs/#/reference/feature-extractor?id=examples and trying to select either the classification or regression option from the subset underneath **p5 web editor**.



