### PR TITLE
Unminified build of the ml5 library (in addition to the minified one)

### DIFF
--- a/webpack.common.babel.js
+++ b/webpack.common.babel.js
@@ -7,8 +7,10 @@ import { join, resolve } from 'path';
 
 const include = join(__dirname, 'src');
 
+export const indexEntryWithBabel = ['babel-polyfill', './src/index.js'];
+
 export default {
-  entry: ['babel-polyfill', './src/index.js'],
+  entry: indexEntryWithBabel,
   output: {
     path: resolve(__dirname, 'dist'),
     publicPath: '/',

--- a/webpack.prod.babel.js
+++ b/webpack.prod.babel.js
@@ -1,5 +1,5 @@
 // Copyright (c) 2018 ml5
-// 
+//
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
@@ -10,12 +10,20 @@ import UglifyJSPlugin from 'uglifyjs-webpack-plugin';
 export default merge(common, {
   mode: 'production',
   devtool: 'source-map',
-  output: {
-    filename: 'ml5.min.js'
+  entry: {
+    ml5: ["babel-polyfill", "./src/index.js"],
+    "ml5.min": ["babel-polyfill", "./src/index.js"],
   },
-  plugins: [
-    new UglifyJSPlugin({
-      sourceMap: true
-    })
-  ]
-})
+  output: {
+    filename: "[name].js",
+  },
+  optimization: {
+    minimize: true,
+    minimizer: [
+      new UglifyJSPlugin({
+        include: /\.min\.js$/,
+        sourceMap: true,
+      }),
+    ],
+  },
+});

--- a/webpack.prod.babel.js
+++ b/webpack.prod.babel.js
@@ -4,15 +4,15 @@
 // https://opensource.org/licenses/MIT
 
 import merge from 'webpack-merge';
-import common from './webpack.common.babel';
+import common, {indexEntryWithBabel} from './webpack.common.babel';
 import UglifyJSPlugin from 'uglifyjs-webpack-plugin';
 
 export default merge(common, {
   mode: 'production',
   devtool: 'source-map',
   entry: {
-    ml5: ["babel-polyfill", "./src/index.js"],
-    "ml5.min": ["babel-polyfill", "./src/index.js"],
+    ml5: indexEntryWithBabel,
+    "ml5.min": indexEntryWithBabel,
   },
   output: {
     filename: "[name].js",


### PR DESCRIPTION

This PR adds an unminified version of the library (with source map) to the distribution. This is useful for debugging purposes and has been requested in some issues (https://github.com/ml5js/ml5-library/issues/205).

Tested by copying the unminified distribution into an ml5-examples local repo and switching the script import for some of the examples to point to the unminified version. Observed that the example runs and that the source map helps the browser to interpret the original code locations:
![Screen Shot 2020-02-22 at 1 19 59 PM](https://user-images.githubusercontent.com/6589909/75097220-23012180-5576-11ea-9bda-a4831cdad7c2.png)

Note that there is no change in the bundle size of the ml5.min.js file between this branch and `development`.

Output of `npm run build`:
```
~/Desktop/code/ml5-library (bomani.unminified-dist ✔) ᐅ npm run build

> ml5@0.4.3 prebuild /Users/bomani/Desktop/code/ml5-library
> rimraf dist


> ml5@0.4.3 build /Users/bomani/Desktop/code/ml5-library
> webpack --config webpack.prod.babel.js

Hash: c60e19834528ec9ade9e
Version: webpack 4.1.1
Time: 40597ms
Built at: 2/22/2020 12:57:59 PM
         Asset      Size  Chunks                    Chunk Names
    ml5.min.js  2.54 MiB    0, 1  [emitted]  [big]  ml5.min
        ml5.js  5.34 MiB    1, 0  [emitted]  [big]  ml5
ml5.min.js.map  8.06 MiB    0, 1  [emitted]         ml5.min
    ml5.js.map  6.31 MiB    1, 0  [emitted]         ml5
Entrypoint ml5 [big] = ml5.js ml5.js.map
Entrypoint ml5.min [big] = ml5.min.js ml5.min.js.map
   [2] ./node_modules/@tensorflow/tfjs/dist/tf.esm.js + 1 modules 243 KiB {0} {1} [built]
       |    2 modules
  [27] (webpack)/buildin/global.js 509 bytes {0} {1} [built]
  [62] ./src/utils/imageUtilities.js 7.16 KiB {0} {1} [built]
 [108] ./src/utils/p5Utils.js 6.59 KiB {0} {1} [built]
 [261] ./package.json 3.36 KiB {0} {1} [built]
 [265] ./src/ObjectDetector/YOLO/index.js 16.7 KiB {0} {1} [built]
 [402] ./src/utils/community.js 1.03 KiB {0} {1} [built]
 [404] ./src/KMeans/index.js 9.63 KiB {0} {1} [built]
 [405] ./src/FaceApi/index.js 32.1 KiB {0} {1} [built]
 [411] ./src/NeuralNetwork/index.js 39.3 KiB {0} {1} [built]
 [414] ./src/BodyPix/index.js 37.9 KiB {0} {1} [built]
 [415] ./src/Sentiment/index.js 6.98 KiB {0} {1} [built]
 [416] ./src/utils/p5PreloadHelper.js 1.96 KiB {0} {1} [built]
 [766] ./src/index.js 4.48 KiB {0} {1} [built]
 [968] multi babel-polyfill ./src/index.js 40 bytes {0} {1} [built]
    + 979 hidden modules

WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
This can impact web performance.
Assets:
  ml5.min.js (2.54 MiB)
  ml5.js (5.34 MiB)

WARNING in entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.
Entrypoints:
  ml5 (5.34 MiB)
      ml5.js
  ml5.min (2.54 MiB)
      ml5.min.js


WARNING in webpack performance recommendations:
You can limit the size of your bundles by using import() or require.ensure to lazy load some parts of your application.
For more info visit https://webpack.js.org/guides/code-splitting/
```



