### PR TITLE
Update license specified on NPM from ISC to MIT

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "machine learning"
   ],
   "author": "NYU ITP <cvalenzuela@nyu.edu> (https://github.com/ml5js)",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/ml5js/ml5-library/issues"
   },


### PR DESCRIPTION
A small change! Currently, the package.json file specifies the ISC license, meaning that our repository is listed with the ISC license on NPM:
<img width="359" alt="Screen Shot 2020-03-15 at 5 59 40 PM" src="https://user-images.githubusercontent.com/6589909/76711524-4a678c00-66e7-11ea-92f7-dffe2fe1a3b0.png">


Our repository actually uses the MIT license at the moment: https://github.com/ml5js/ml5-library/blob/development/LICENSE. This PR simply updates the license detail.