### PR TITLE
Update BrowserStack tests to Mojave instead of High Sierra

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -67,7 +67,7 @@ module.exports = (config) => {
         browser: 'chrome',
         browser_version: 'latest',
         os: 'OS X',
-        os_version: 'High Sierra'
+        os_version: 'Mojave'
       },
     },
     reporters: ['mocha'],


### PR DESCRIPTION
A very small chage that updates the test to Mojave, since that's the latest reasonable (lol) operating system for MacOS. 

Verified by running the`yarn test-travis` command locally, which resulted in a successful run:

```
$ ./scripts/test-travis.sh
(node:34670) DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead
24 03 2020 17:42:30.199:WARN [watcher]: All files matched by "/Users/bomani/Desktop/code/ml5-library/src/**/**/*_test.js" were excluded or matched by prior matchers.
ℹ ｢wdm｣: wait until bundle finished: noop
⚠ ｢wdm｣:
ℹ ｢wdm｣: Compiled with warnings.
24 03 2020 17:42:52.024:INFO [karma]: Karma v2.0.0 server started at http://0.0.0.0:9876/
24 03 2020 17:42:52.024:INFO [launcher]: Launching browser bs_chrome_mac with unlimited concurrency
24 03 2020 17:42:52.057:INFO [launcher]: Starting browser chrome latest (OS X Mojave) on BrowserStack
24 03 2020 17:42:58.268:INFO [launcher.browserstack]: chrome latest (OS X Mojave) session at https://automate.browserstack.com/builds/2623bf6e4901d547991ee6060f13a586f23f213e/sessions/53bccb8d48ee37e57f7c60ac244ba578808746fb
24 03 2020 17:43:05.306:INFO [Chrome 80.0.3987 (Mac OS X 10.14.6)]: Connected on socket em1DI1wlLYJxlruuAAAA with id 86809188
Chrome 80.0.3987 (Mac OS X 10.14.6) LOG: '
🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈
🌟 Thank you for using ml5.js v0.5.0 🌟

Please read our community statement to ensure
that the use of this software reflects the values
of the ml5.js community:
↳ https://ml5js.org/about

Reporting:
↳ https://github.com/ml5js/ml5-library/issues
↳ Email: info@ml5js.org
🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈'
Chrome 80.0.3987 (Mac OS X 10.14.6) LOG: '
🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈
🌟 Thank you for using ml5.js v0.5.0 🌟

Please read our community statement to ensure
that the use of this software reflects the values
of the ml5.js community:
↳ https://ml5js.org/about

Reporting:
↳ https://github.com/ml5js/ml5-library/issues
↳ Email: info@ml5js.org
🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈'

 Chrome 80.0.3987 (Mac OS X 10.14.6): Executed 37 of 105 (skipped 57) SUCCESS (0 secs / 0 secs)
```