### PR TITLE
Update @tensorflow/tfjs to 1.7.0

### DIFF
--- a/local.log
+++ b/local.log
@@ -1,0 +1,8 @@
+
+
+Tue Mar 31 2020 01:22:42 GMT-0400 (EDT) -- [INFO] Started the BrowserStack Binary server on 45691, PID: 58817
+Tue Mar 31 2020 01:22:42 GMT-0400 (EDT) -- [SUCCESS] You can now access your local server(s) in our remote browser
+
+Tue Mar 31 2020 01:22:43 GMT-0400 (EDT) -- Press Ctrl-C to exit
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1071,32 +1071,31 @@
       "integrity": "sha512-MrMlDEDHkZPKuZawQb1E2Hof1m2ojZrOW1EAVnvZ1Jn+cPmDJz+X3hokYLC3P+UBUq+tAYq1vU0Byt9SbyGWbg=="
     },
     "@tensorflow/tfjs": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-1.2.2.tgz",
-      "integrity": "sha512-HfhSzL2eTWhlT0r/A5wmo+u3bHe+an16p5wsnFH3ujn21fQ8QtGpSfDHQZjWx1kVFaQnV6KBG+17MOrRHoHlLA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-1.7.0.tgz",
+      "integrity": "sha512-lN4wSCb/pFFa60R4Ii8Znn+3Q42Ad8bDrqrIPvsxFQYFXd9BSgXXIgizRoSkyMsLVzJokuLLuElHGggF2VNnug==",
       "requires": {
-        "@tensorflow/tfjs-converter": "1.2.2",
-        "@tensorflow/tfjs-core": "1.2.2",
-        "@tensorflow/tfjs-data": "1.2.2",
-        "@tensorflow/tfjs-layers": "1.2.2"
+        "@tensorflow/tfjs-converter": "1.7.0",
+        "@tensorflow/tfjs-core": "1.7.0",
+        "@tensorflow/tfjs-data": "1.7.0",
+        "@tensorflow/tfjs-layers": "1.7.0"
       }
     },
     "@tensorflow/tfjs-converter": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-1.2.2.tgz",
-      "integrity": "sha512-NM2NcPRHpCNeJdBxHcYpmW9ZHTQ2lJFJgmgGpQ8CxSC9CtQB05bFONs3SKcwMNDE/69QBRVom5DYqLCVUg+A+g=="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-1.7.0.tgz",
+      "integrity": "sha512-cFXLDKVEjEtFv/C0wETXpIeJNa25chC6nvFm06dB/ShvrGYZpDsGlWVNiCu4v5/VtrSZEQPZ2QdkpTpURbvAqQ=="
     },
     "@tensorflow/tfjs-core": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-1.2.2.tgz",
-      "integrity": "sha512-2hCHMKjh3UNpLEjbAEaurrTGJyj/KpLtMSAraWgHA1vGY0kmk50BBSbgCDmXWUVm7lyh/SkCq4/GrGDZktEs3g==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-1.7.0.tgz",
+      "integrity": "sha512-uwQdiklNjqBnHPeseOdG0sGxrI3+d6lybaKu2+ou3ajVeKdPEwpWbgqA6iHjq1iylnOGkgkbbnQ6r2lwkiIIHw==",
       "requires": {
         "@types/offscreencanvas": "~2019.3.0",
         "@types/seedrandom": "2.4.27",
         "@types/webgl-ext": "0.0.30",
         "@types/webgl2": "0.0.4",
         "node-fetch": "~2.1.2",
-        "rollup-plugin-visualizer": "~1.1.1",
         "seedrandom": "2.4.3"
       },
       "dependencies": {
@@ -1108,9 +1107,9 @@
       }
     },
     "@tensorflow/tfjs-data": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-1.2.2.tgz",
-      "integrity": "sha512-oHGBoGdnCl2RyouLKplQqo+iil0iJgPbi/aoHizhpO77UBuJXlKMblH8w5GbxVAw3hKxWlqzYpxPo6rVRgehNA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-1.7.0.tgz",
+      "integrity": "sha512-i3pPpCTN76cVArzQ1vby+YFDcxC7APOTW2NGcHr3VxWf9ZCMgjJv/s2z71U8OHoCzw/lTXYue8/l4j4q+D3PMg==",
       "requires": {
         "@types/node-fetch": "^2.1.2",
         "node-fetch": "~2.1.2"
@@ -1124,9 +1123,9 @@
       }
     },
     "@tensorflow/tfjs-layers": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-1.2.2.tgz",
-      "integrity": "sha512-yzWZaZrCVpEyTkSrzMe4OOP4aGUfaaROE/zR9fPsPGGF8wLlbLNZUJjeYUmjy3G3pXGaM0mQUbLR5Vd707CVtQ=="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-1.7.0.tgz",
+      "integrity": "sha512-sRdzuPc2CeLSxctqXdLTckvitSBjsjL8H6MSrvrbOfPEckKdAeNpojB0ayM+76Pc3AsS0/AI6F1R2lT9qoH9/g=="
     },
     "@tensorflow/tfjs-vis": {
       "version": "1.1.0",
@@ -1175,11 +1174,32 @@
       "integrity": "sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw=="
     },
     "@types/node-fetch": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.0.tgz",
-      "integrity": "sha512-TLFRywthBgL68auWj+ziWu+vnmmcHCDFC/sqCOQf1xTz4hRq8cu79z8CtHU9lncExGBsB8fXA4TiLDLt6xvMzw==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.5.tgz",
+      "integrity": "sha512-IWwjsyYjGw+em3xTvWVQi5MgYKbRs0du57klfTaZkv/B24AEQ/p/IopNeqIYNy3EsfHOpg8ieQSDomPcsYMHpA==",
       "requires": {
-        "@types/node": "*"
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "combined-stream": {
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+          "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        },
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "@types/normalize-package-data": {
@@ -1929,8 +1949,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
       "version": "2.1.2",
@@ -5499,8 +5518,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delegate": {
       "version": "3.2.0",
@@ -7232,19 +7250,18 @@
       "dev": true
     },
     "face-api.js": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/face-api.js/-/face-api.js-0.20.1.tgz",
-      "integrity": "sha512-ROpDlwdhnKphZFLDNEBFjgbQAVQBVIZbk3LjuxcWhIueoaZxz8cYuSYd650GT+v0GN1ZgSSB0W3xkywputhO0Q==",
+      "version": "0.22.2",
+      "resolved": "https://registry.npmjs.org/face-api.js/-/face-api.js-0.22.2.tgz",
+      "integrity": "sha512-9Bbv/yaBRTKCXjiDqzryeKhYxmgSjJ7ukvOvEBy6krA0Ah/vNBlsf7iBNfJljWiPA8Tys1/MnB3lyP2Hfmsuyw==",
       "requires": {
-        "@tensorflow/tfjs-core": "1.2.2",
-        "tfjs-image-recognition-base": "^0.6.1",
-        "tslib": "^1.10.0"
+        "@tensorflow/tfjs-core": "1.7.0",
+        "tslib": "^1.11.1"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
         }
       }
     },
@@ -10815,7 +10832,8 @@
     "is-wsl": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+      "dev": true
     },
     "isarray": {
       "version": "1.0.0",
@@ -12495,14 +12513,12 @@
     "mime-db": {
       "version": "1.37.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
-      "dev": true
+      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
     },
     "mime-types": {
       "version": "2.1.21",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
       "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
-      "dev": true,
       "requires": {
         "mime-db": "~1.37.0"
       }
@@ -12552,7 +12568,8 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
     },
     "minimist-options": {
       "version": "3.0.2",
@@ -12607,6 +12624,7 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -17048,6 +17066,7 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
       "integrity": "sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==",
+      "dev": true,
       "requires": {
         "is-wsl": "^1.1.0"
       }
@@ -18932,26 +18951,6 @@
         "inherits": "^2.0.1"
       }
     },
-    "rollup-plugin-visualizer": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-1.1.1.tgz",
-      "integrity": "sha512-7xkSKp+dyJmSC7jg2LXqViaHuOnF1VvIFCnsZEKjrgT5ZVyiLLSbeszxFcQSfNJILphqgAEmWAUz0Z4xYScrRw==",
-      "optional": true,
-      "requires": {
-        "mkdirp": "^0.5.1",
-        "opn": "^5.4.0",
-        "source-map": "^0.7.3",
-        "typeface-oswald": "0.0.54"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-          "optional": true
-        }
-      }
-    },
     "run-async": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
@@ -20623,22 +20622,6 @@
       "integrity": "sha512-qftQXnX1DzpSV8EddtHIT0eDDEiBF8ywhFYR2lI9xrGtxqKN+CvLXhACeCIGbCpQfxxERbrkZEFb8cZcDKbVZA==",
       "dev": true
     },
-    "tfjs-image-recognition-base": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/tfjs-image-recognition-base/-/tfjs-image-recognition-base-0.6.1.tgz",
-      "integrity": "sha512-4ibEGwR2MghHgghqAn6Cg8kbmoB7lxWuANcG3wAsqKSWKRBvJ1iqejUqKwCx7B0UHqxh8XZEl6fdvT4To6o9Cw==",
-      "requires": {
-        "@tensorflow/tfjs-core": "^1.2.2",
-        "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
-        }
-      }
-    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -20902,12 +20885,6 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
-    },
-    "typeface-oswald": {
-      "version": "0.0.54",
-      "resolved": "https://registry.npmjs.org/typeface-oswald/-/typeface-oswald-0.0.54.tgz",
-      "integrity": "sha512-U1WMNp4qfy4/3khIfHMVAIKnNu941MXUfs3+H9R8PFgnoz42Hh9pboSFztWr86zut0eXC8byalmVhfkiKON/8Q==",
-      "optional": true
     },
     "ua-parser-js": {
       "version": "0.7.20",

--- a/package.json
+++ b/package.json
@@ -103,9 +103,9 @@
     "@tensorflow-models/mobilenet": "2.0.3",
     "@tensorflow-models/posenet": "2.1.3",
     "@tensorflow-models/speech-commands": "0.3.9",
-    "@tensorflow/tfjs": "~1.2.1",
+    "@tensorflow/tfjs": "1.7.0",
     "@tensorflow/tfjs-vis": "^1.1.0",
     "events": "^3.0.0",
-    "face-api.js": "0.20.1"
+    "face-api.js": "~0.22.2"
   }
 }

--- a/src/utils/checkpointLoader.js
+++ b/src/utils/checkpointLoader.js
@@ -69,7 +69,7 @@ export default class CheckpointLoader {
           throw new Error(`Not found variable ${varName}`);
         }
         const values = new Float32Array(xhr.response);
-        const tensor = tf.Tensor.make(this.checkpointManifest[varName].shape, { values });
+        const tensor = tf.tensor(values, this.checkpointManifest[varName].shape);
         resolve(tensor);
       };
       xhr.onerror = (error) => {


### PR DESCRIPTION
This PR updates tfjs to the most recent minor version (1.7.0, though the patch 1.7.1 is out but not yet supported by FaceAPI). In addition, I needed to:
- Update the faceApi version number
- Update away from using Tf.Tensor.make to using the new Tensor creation syntax (https://js.tensorflow.org/api/latest/#tensor)

This will allow us to update the versions of some of our other models, but I'll save those changes for later PRs.

### Updated Build Sizes
```
Built at: 3/31/2020 1:26:48 AM
         Asset      Size  Chunks                    Chunk Names
    ml5.min.js  2.35 MiB    0, 1  [emitted]  [big]  ml5.min
        ml5.js  4.91 MiB    1, 0  [emitted]  [big]  ml5
ml5.min.js.map  7.37 MiB    0, 1  [emitted]         ml5.min
    ml5.js.map  5.79 MiB    1, 0  [emitted]         ml5
```

It looks like this caused some changes in build size. Comparison to current sizes in 0.5.0 (https://unpkg.com/browse/ml5@0.5.0/dist/)
ml5.min.js -> 2.67 MB
ml5.js -> 5.6 MB
ml5.min.js.map -> 8.45 MB
ml5.js.map -> 6.62 MB

**This cuts our minified distribution down by 0.32MB!**

### Testing Process
- Ran `yarn test-travis` and saw no errors
- Manually test the CharRNN and FaceApi examples to ensure they were still functioning.


