### PR TITLE
Fix ~250 lint problems from the prefer-const rule

### DIFF
--- a/examples/assets/sketch.js
+++ b/examples/assets/sketch.js
@@ -1,8 +1,8 @@
 
 const s = ( sketch ) => {
 
-  let x = 100;
-  let y = 100;
+  const x = 100;
+  const y = 100;
   let canvas;
 
   sketch.setup = () => {
@@ -37,7 +37,7 @@ async function init(){
   createSections(data);
 
   // p5 sketch
-  let myp5 = new p5(s, 'myCanvas');
+  const myp5 = new p5(s, 'myCanvas');
 }
 
 init();
@@ -90,7 +90,7 @@ function createSections(data){
 $search.addEventListener('keyup', (e) =>{
   const val = e.target.value;
   
-  let dataCopy = Object.assign({}, data);
+  const dataCopy = Object.assign({}, data);
   if(val.trim() === ""){
     createSections(dataCopy);
   } else {

--- a/examples/javascript/BodyPix/BodyPix_Image/sketch.js
+++ b/examples/javascript/BodyPix/BodyPix_Image/sketch.js
@@ -3,8 +3,8 @@ let segmentation;
 let img;
 let canvas;
 let ctx;
-let width = 480;
-let height = 560;
+const width = 480;
+const height = 560;
 
 async function make() {
   img = new Image();
@@ -18,7 +18,7 @@ async function make() {
 
   ctx.drawImage(img, 0,0);
 
-  let maskedBackground = await imageDataToCanvas(segmentation.raw.backgroundMask.data, segmentation.raw.backgroundMask.width, segmentation.raw.backgroundMask.height)
+  const maskedBackground = await imageDataToCanvas(segmentation.raw.backgroundMask.data, segmentation.raw.backgroundMask.width, segmentation.raw.backgroundMask.height)
   ctx.drawImage(maskedBackground, 0, 0);
 
 }

--- a/examples/javascript/BodyPix/BodyPix_Webcam/sketch.js
+++ b/examples/javascript/BodyPix/BodyPix_Webcam/sketch.js
@@ -2,8 +2,8 @@ let bodypix;
 let segmentation;
 let video;
 let canvas, ctx;
-let width = 480;
-let height = 360;
+const width = 480;
+const height = 360;
 
 const options = {
   outputStride: 8, // 8, 16, or 32, default is 16
@@ -35,7 +35,7 @@ function gotImage(err, result){
   }
   segmentation = result;
   ctx.drawImage(video, 0, 0, width, height);
-  let maskBackground = imageDataToCanvas(result.raw.backgroundMask.data, result.raw.backgroundMask.width, result.raw.backgroundMask.height)
+  const maskBackground = imageDataToCanvas(result.raw.backgroundMask.data, result.raw.backgroundMask.width, result.raw.backgroundMask.height)
   ctx.drawImage(maskBackground, 0, 0, width, height);
     
   bodypix.segment(video, gotImage, options);

--- a/examples/javascript/BodyPix/BodyPix_Webcam_Parts/sketch.js
+++ b/examples/javascript/BodyPix/BodyPix_Webcam_Parts/sketch.js
@@ -2,8 +2,8 @@ let bodypix;
 let segmentation;
 let video;
 let canvas, ctx;
-let width = 480;
-let height = 360;
+const width = 480;
+const height = 360;
 
 const options = {
   outputStride: 8, // 8, 16, or 32, default is 16
@@ -35,7 +35,7 @@ function gotImage(err, result){
   segmentation = result;
   ctx.drawImage(video, 0, 0, width, height);
 
-  let parts = imageDataToCanvas(result.raw.partMask.data, result.raw.partMask.width, result.raw.partMask.height)
+  const parts = imageDataToCanvas(result.raw.partMask.data, result.raw.partMask.width, result.raw.partMask.height)
   ctx.drawImage(parts, 0, 0, width, height);
 
   bodypix.segmentWithParts(gotImage, options);

--- a/examples/javascript/CVAE/CVAE_QuickDraw/sketch.js
+++ b/examples/javascript/CVAE/CVAE_QuickDraw/sketch.js
@@ -12,8 +12,8 @@ let img;
 let button;
 let dropdown;
 let canvas, ctx;
-let width = 200;
-let height = 200;
+const width = 200;
+const height = 200;
 
 async function make() {
   canvas = createCanvas(width, height);
@@ -29,7 +29,7 @@ async function make() {
 }
 
 function generateImage() {
-  let label = dropdown.value;
+  const label = dropdown.value;
   cvae.generate(label, gotImage);
 }
 
@@ -52,7 +52,7 @@ function modelReady() {
   dropdown = document.createElement('select');
   document.body.appendChild(dropdown);
 
-  for (let label of cvae.labels) {
+  for (const label of cvae.labels) {
     const option = document.createElement("option");
     option.value = label;
     option.text = label;

--- a/examples/javascript/CharRNN/CharRNN_Interactive/sketch.js
+++ b/examples/javascript/CharRNN/CharRNN_Interactive/sketch.js
@@ -65,14 +65,14 @@ function generate() {
     temperatureText.innerHTML = tempSlider.value;
 
     // Grab the original text
-    let original = textInput.value;
+    const original = textInput.value;
     // Make it to lower case
-    let txt = original.toLowerCase();
+    const txt = original.toLowerCase();
 
     // Check if there's something
     if (txt.length > 0) {
       // Here is the data for the LSTM generator
-      let data = {
+      const data = {
         seed: txt,
         temperature: tempSlider.value,
         length: lengthSlider.value

--- a/examples/javascript/CharRNN/CharRNN_Text/sketch.js
+++ b/examples/javascript/CharRNN/CharRNN_Text/sketch.js
@@ -68,16 +68,16 @@ function generate() {
     status.innerHTML = 'Generating...';
 
     // Grab the original text
-    let original = textInput.value;
+    const original = textInput.value;
     // Make it to lower case
-    let txt = original.toLowerCase();
+    const txt = original.toLowerCase();
 
     // Check if there's something to send
     if (txt.length > 0) {
       // This is what the LSTM generator needs
       // Seed text, temperature, length to outputs
       // TODO: What are the defaults?
-      let data = {
+      const data = {
         seed: txt,
         temperature: tempSlider.value,
         length: lengthSlider.value

--- a/examples/javascript/CharRNN/CharRNN_Text_Stateful/sketch.js
+++ b/examples/javascript/CharRNN/CharRNN_Text_Stateful/sketch.js
@@ -80,8 +80,8 @@ async function loopRNN() {
 }
 
 async function predict() {
-  let temperature = Number(tempSlider.value);
-  let next = await charRNN.predict( Number(temperature) );
+  const temperature = Number(tempSlider.value);
+  const next = await charRNN.predict( Number(temperature) );
   await charRNN.feed(next.sample);
   resultText.innerHTML +=  next.sample;
 }

--- a/examples/javascript/FaceApi/FaceApi_Image_Landmarks/sketch.js
+++ b/examples/javascript/FaceApi/FaceApi_Image_Landmarks/sketch.js
@@ -1,8 +1,8 @@
 let faceapi;
 let img;
 let detections;
-let width = 200;
-let height = 200;
+const width = 200;
+const height = 200;
 let canvas, ctx;
 
 // by default all options are set to true

--- a/examples/javascript/FaceApi/FaceApi_Video_Landmarks/sketch.js
+++ b/examples/javascript/FaceApi/FaceApi_Video_Landmarks/sketch.js
@@ -1,8 +1,8 @@
 let faceapi;
 let video;
 let detections;
-let width = 360;
-let height = 280;
+const width = 360;
+const height = 280;
 let canvas, ctx;
 
 // by default all options are set to true

--- a/examples/javascript/FaceApi/FaceApi_Video_Landmarks_LocalModels/sketch.js
+++ b/examples/javascript/FaceApi/FaceApi_Video_Landmarks_LocalModels/sketch.js
@@ -1,8 +1,8 @@
 let faceapi;
 let video;
 let detections;
-let width = 360;
-let height = 280;
+const width = 360;
+const height = 280;
 let canvas, ctx;
 
 // relative path to your models from window.location.pathname

--- a/examples/javascript/FeatureExtractor/FeatureExtractor_Image_Classification/sketch.js
+++ b/examples/javascript/FeatureExtractor/FeatureExtractor_Image_Classification/sketch.js
@@ -42,11 +42,6 @@ const featureExtractor = ml5.featureExtractor('MobileNet', modelLoaded);
 // Create a new classifier using those features
 const classifier = featureExtractor.classification(video, videoReady);
 
-// Predict the current frame.
-function predict() {
-  classifier.predict(gotResults);
-}
-
 // A function to be called when the video is finished loading
 function videoReady() {
   videoStatus.innerText = 'Video ready!';

--- a/examples/javascript/FeatureExtractor/FeatureExtractor_Image_Regression/sketch.js
+++ b/examples/javascript/FeatureExtractor/FeatureExtractor_Image_Regression/sketch.js
@@ -15,8 +15,8 @@ let loss;
 let slider;
 let samples = 0;
 let ctx;
-let width = 640;
-let height = 480;
+const width = 640;
+const height = 480;
 let positionX = width/2;
 
 function map(n, start1, stop1, start2, stop2) {

--- a/examples/javascript/ImageClassification/ImageClassification_DoodleNet_Canvas/sketch.js
+++ b/examples/javascript/ImageClassification/ImageClassification_DoodleNet_Canvas/sketch.js
@@ -22,8 +22,8 @@ let canvas, ctx;
 let label;
 let confidence;
 let button
-let width = 280;
-let height = 280;
+const width = 280;
+const height = 280;
 
 let pX = null;
 let pY = null;

--- a/examples/javascript/ImageClassification/ImageClassification_DoodleNet_Video/sketch.js
+++ b/examples/javascript/ImageClassification/ImageClassification_DoodleNet_Video/sketch.js
@@ -21,8 +21,8 @@ let confidence;
 let canvas;
 let ctx;
 
-let width = 280;
-let height = 280;
+const width = 280;
+const height = 280;
 
 async function setup() {
   // Create a 'label' and 'confidence' div to hold results

--- a/examples/javascript/ImageClassification/ImageClassification_MultipleImages/sketch.js
+++ b/examples/javascript/ImageClassification/ImageClassification_MultipleImages/sketch.js
@@ -12,9 +12,9 @@ Multiple Image classification using MobileNet
 let classifier;
 
 let img;
-let currentIndex = 0;
+const currentIndex = 0;
 let allImages = [];
-let predictions = [];
+const predictions = [];
 let results;
 
 async function setup() {
@@ -44,7 +44,7 @@ setup();
 
 
 function appendImages(arr) {
-  let output = [];
+  const output = [];
   for (i = 0; i < arr.length; i++) {
     imgPath = arr[i];
     output.push('images/dataset/' + imgPath);
@@ -53,7 +53,7 @@ function appendImages(arr) {
 }
 
 async function loadImage(imgPath, idx) {
-  let imgEl = new Image();
+  const imgEl = new Image();
   imgEl.src = imgPath;
 
   imgEl.onload = async function () {
@@ -64,7 +64,7 @@ async function loadImage(imgPath, idx) {
         console.log(err, idx);
         return;
       }
-      let information = {
+      const information = {
         name: imgPath,
         result: res
       };

--- a/examples/javascript/ImageClassification/ImageClassification_VideoScavengerHunt/sketch.js
+++ b/examples/javascript/ImageClassification/ImageClassification_VideoScavengerHunt/sketch.js
@@ -15,8 +15,8 @@ let currentWord;
 let currentIndex = 0;
 let isPlaying = false;
 const words = ['banana', 'watch', 'shoe', 'book', 'cellphone', 'keyboard', 'shirt', 'pants', 'cup'];
-let width = 640;
-let height= 480;
+const width = 640;
+const height= 480;
 let result;
 
 // adapted from https://github.com/IDMNYU/p5.js-speech/blob/master/lib/p5.speech.js

--- a/examples/javascript/ImageClassification/ImageClassification_VideoSound/sketch.js
+++ b/examples/javascript/ImageClassification/ImageClassification_VideoSound/sketch.js
@@ -11,8 +11,8 @@ This example uses a callback pattern to create the classifier
 
 let classifier;
 let video;
-let width= 640;
-let height=480;
+const width= 640;
+const height=480;
 
 // adapted from https://github.com/IDMNYU/p5.js-speech/blob/master/lib/p5.speech.js
 class MySpeech {

--- a/examples/javascript/KNNClassification/KNNClassification_PoseNet/sketch.js
+++ b/examples/javascript/KNNClassification/KNNClassification_PoseNet/sketch.js
@@ -13,8 +13,8 @@ const knnClassifier = ml5.KNNClassifier();
 let poseNet;
 let poses = [];
 let canvas;
-let width = 640;
-let height = 480;
+const width = 640;
+const height = 480;
 let ctx;
 
 async function setup() {
@@ -163,10 +163,10 @@ function drawKeypoints()  {
   // Loop through all the poses detected
   for (let i = 0; i < poses.length; i++) {
     // For each pose detected, loop through all the keypoints
-    let pose = poses[i].pose;
+    const pose = poses[i].pose;
     for (let j = 0; j < pose.keypoints.length; j++) {
       // A keypoint is an object describing a body part (like rightArm or leftShoulder)
-      let keypoint = pose.keypoints[j];
+      const keypoint = pose.keypoints[j];
       // Only draw an ellipse is the pose probability is bigger than 0.2
       if (keypoint.score > 0.2) {
         ctx.fillStyle = 'rgb(213, 0, 143)';
@@ -183,11 +183,11 @@ function drawKeypoints()  {
 function drawSkeleton() {
   // Loop through all the skeletons detected
   for (let i = 0; i < poses.length; i++) {
-    let skeleton = poses[i].skeleton;
+    const skeleton = poses[i].skeleton;
     // For every skeleton, loop through all body connections
     for (let j = 0; j < skeleton.length; j++) {
-      let partA = skeleton[j][0];
-      let partB = skeleton[j][1];
+      const partA = skeleton[j][0];
+      const partB = skeleton[j][1];
       ctx.beginPath();
       ctx.moveTo(partA.position.x, partA.position.y);
       ctx.lineTo(partB.position.x, partB.position.y);

--- a/examples/javascript/KNNClassification/KNNClassification_VideoSound/sketch.js
+++ b/examples/javascript/KNNClassification/KNNClassification_VideoSound/sketch.js
@@ -15,8 +15,8 @@ let featureExtractor;
 let currentWord;
 let myVoice;
 let canvas, ctx;
-let width = 640;
-let height = 480;
+const width = 640;
+const height = 480;
 
 // adapted from https://github.com/IDMNYU/p5.js-speech/blob/master/lib/p5.speech.js
 class MySpeech {

--- a/examples/javascript/KNNClassification/KNNClassification_VideoSquare/sketch.js
+++ b/examples/javascript/KNNClassification/KNNClassification_VideoSquare/sketch.js
@@ -14,8 +14,8 @@ const squareSize = 100;
 // Create a KNN classifier
 const knnClassifier = ml5.KNNClassifier();
 let featureExtractor;
-let width = 640;
-let height = 480;
+const width = 640;
+const height = 480;
 let canvas, ctx;
 
 async function setup() {

--- a/examples/javascript/ObjectDetector/COCOSSD_single_image/sketch.js
+++ b/examples/javascript/ObjectDetector/COCOSSD_single_image/sketch.js
@@ -12,8 +12,8 @@ let objectDetector;
 let status;
 let objects = [];
 let canvas, ctx;
-let width = 640;
-let height = 420;
+const width = 640;
+const height = 420;
 
 async function make() {
   img = new Image();

--- a/examples/javascript/ObjectDetector/COCOSSD_webcam/sketch.js
+++ b/examples/javascript/ObjectDetector/COCOSSD_webcam/sketch.js
@@ -13,8 +13,8 @@ let status;
 let objects = [];
 let video;
 let canvas, ctx;
-let width = 480;
-let height = 360;
+const width = 480;
+const height = 360;
 
 async function make() {
   // get the video

--- a/examples/javascript/ObjectDetector/YOLO_single_image/sketch.js
+++ b/examples/javascript/ObjectDetector/YOLO_single_image/sketch.js
@@ -12,8 +12,8 @@ let objectDetector;
 let status;
 let objects = [];
 let canvas, ctx;
-let width = 640;
-let height = 420;
+const width = 640;
+const height = 420;
 
 async function make() {
   img = new Image();

--- a/examples/javascript/ObjectDetector/YOLO_webcam/sketch.js
+++ b/examples/javascript/ObjectDetector/YOLO_webcam/sketch.js
@@ -13,8 +13,8 @@ let status;
 let objects = [];
 let video;
 let canvas, ctx;
-let width = 480;
-let height = 360;
+const width = 480;
+const height = 360;
 
 async function make() {
   // get the video

--- a/examples/javascript/PitchDetection/PitchDetection_Game/sketch.js
+++ b/examples/javascript/PitchDetection/PitchDetection_Game/sketch.js
@@ -15,17 +15,17 @@ const voiceHigh = 500;
 let audioStream;
 let stream;
 
-let width = 410;
-let height = 320;
+const width = 410;
+const height = 320;
 
 // Circle variables
-let circleSize = 42;
+const circleSize = 42;
 const scale = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
 
 // Text variables
 let goalNote = 0;
 let currentNote = '';
-let currentText = '';
+const currentText = '';
 let textCoordinates;
 let canvas;
 
@@ -70,7 +70,7 @@ function modelLoaded() {
 function getPitch() {
   pitch.getPitch(function (err, frequency) {
     if (frequency) {
-      let midiNum = freqToMidi(frequency);
+      const midiNum = freqToMidi(frequency);
       currentNote = scale[midiNum % 12];
       document.querySelector('#currentNote').textContent = currentNote;
     }

--- a/examples/javascript/PitchDetection/PitchDetection_Piano/sketch.js
+++ b/examples/javascript/PitchDetection/PitchDetection_Piano/sketch.js
@@ -23,8 +23,8 @@ let currentNote = '';
 
 let canvas, ctx;
 
-let width = 640;
-let height = 480;
+const width = 640;
+const height = 480;
 
 // taken from p5.Sound
 function freqToMidi(f) {
@@ -67,7 +67,7 @@ function modelLoaded() {
 function getPitch() {
   pitch.getPitch(function(err, frequency) {
     if (frequency) {
-      let midiNum = freqToMidi(frequency);
+      const midiNum = freqToMidi(frequency);
       currentNote = scale[midiNum % 12];
     }
     getPitch();

--- a/examples/javascript/Pix2Pix/Pix2Pix_callback/sketch.js
+++ b/examples/javascript/Pix2Pix/Pix2Pix_callback/sketch.js
@@ -14,7 +14,7 @@ For more models see: https://github.com/ml5js/ml5-data-and-training/tree/master/
 // So the input images can only be 256x256 or 512x512, or multiple of 256
 const SIZE = 256;
 let inputImg, canvas, outputContainer, statusMsg, pix2pix, clearBtn, transferBtn, modelReady = false, isTransfering = false;
-let mouseIsPressed = false;
+const mouseIsPressed = false;
 let outputImg;
 
 let pX = null;
@@ -136,7 +136,7 @@ function transfer() {
   statusMsg.textContent = 'Applying Style Transfer...!';
 
   // Apply pix2pix transformation
-  let canvasEl = document.querySelector('canvas');
+  const canvasEl = document.querySelector('canvas');
   pix2pix.transfer(canvasEl, function(err, result) {
     if (err) {
       console.log(err);

--- a/examples/javascript/Pix2Pix/Pix2Pix_promise/sketch.js
+++ b/examples/javascript/Pix2Pix/Pix2Pix_promise/sketch.js
@@ -14,7 +14,7 @@ For more models see: https://github.com/ml5js/ml5-data-and-training/tree/master/
 // So the input images can only be 256x256 or 512x512, or multiple of 256
 const SIZE = 256;
 let inputImg, canvas, outputContainer, statusMsg, pix2pix, clearBtn, transferBtn, modelReady = false, isTransfering = false;
-let mouseIsPressed = false;
+const mouseIsPressed = false;
 let outputImg;
 
 let pX = null;

--- a/examples/javascript/PoseNet/PoseNet_image_single/sketch.js
+++ b/examples/javascript/PoseNet/PoseNet_image_single/sketch.js
@@ -64,7 +64,7 @@ function drawKeypoints()  {
   for (let i = 0; i < poses.length; i++) {
     // For each pose detected, loop through all the keypoints
     for (let j = 0; j < poses[i].pose.keypoints.length; j++) {
-      let keypoint = poses[i].pose.keypoints[j];
+      const keypoint = poses[i].pose.keypoints[j];
       // Only draw an ellipse is the pose probability is bigger than 0.2
       if (keypoint.score > 0.2) {
         ctx.fillStyle = '#FFFFFF'
@@ -84,8 +84,8 @@ function drawSkeleton() {
   for (let i = 0; i < poses.length; i++) {
     // For every skeleton, loop through all body connections
     for (let j = 0; j < poses[i].skeleton.length; j++) {
-      let partA = poses[i].skeleton[j][0];
-      let partB = poses[i].skeleton[j][1];
+      const partA = poses[i].skeleton[j][0];
+      const partB = poses[i].skeleton[j][1];
       ctx.beginPath();
       ctx.moveTo(partA.position.x, partA.position.y);
       ctx.lineTo(partB.position.x, partB.position.y);

--- a/examples/javascript/PoseNet/PoseNet_part_selection/sketch.js
+++ b/examples/javascript/PoseNet/PoseNet_part_selection/sketch.js
@@ -52,10 +52,10 @@ function draw() {
 
   // For one pose only (use a for loop for multiple poses!)
   if (poses.length > 0) {
-    let pose = poses[0].pose;
+    const pose = poses[0].pose;
 
     // Create a pink ellipse for the nose
-    let nose = pose['nose'];
+    const nose = pose['nose'];
     ctx.fillStyle = 'rgb(213, 0, 143)';
     ctx.beginPath();
     ctx.arc(nose.x, nose.y, 10, 0, 2 * Math.PI);
@@ -63,7 +63,7 @@ function draw() {
     ctx.stroke(); 
 
     // Create a yellow ellipse for the right eye
-    let rightEye = pose['rightEye'];
+    const rightEye = pose['rightEye'];
     ctx.fillStyle = 'rgb(255, 215, 0)'
     ctx.beginPath();
     ctx.arc(rightEye.x, rightEye.y, 10, 0, 2 * Math.PI);
@@ -71,7 +71,7 @@ function draw() {
     ctx.stroke(); 
 
     // Create a yellow ellipse for the right eye
-    let leftEye = pose['leftEye'];
+    const leftEye = pose['leftEye'];
     ctx.fillStyle = 'rgb(255, 215, 0)'
     ctx.beginPath();
     ctx.arc(leftEye.x, leftEye.y, 10, 0, 2 * Math.PI);

--- a/examples/javascript/SketchRNN/SketchRNN_basic/sketch.js
+++ b/examples/javascript/SketchRNN/SketchRNN_basic/sketch.js
@@ -20,8 +20,8 @@ let button;
 
 let canvas, ctx;
 
-let width = 640;
-let height = 480;
+const width = 640;
+const height = 480;
 
 
 async function setup() {

--- a/examples/javascript/SketchRNN/SketchRNN_interactive/sketch.js
+++ b/examples/javascript/SketchRNN/SketchRNN_interactive/sketch.js
@@ -26,8 +26,8 @@ let button;
 // Storing a reference to the canvas
 let canvas, ctx;
 
-let width = 640;
-let height = 480;
+const width = 640;
+const height = 480;
 
 let mouseDown = false;
 
@@ -99,7 +99,7 @@ function draw() {
 
 
     // Create a "stroke path" with dx, dy, and pen
-    let userStroke = {
+    const userStroke = {
       dx: mouseX - pX,
       dy: mouseY - pY,
       pen: 'down'

--- a/examples/javascript/StyleTransfer/StyleTransfer_Video/sketch.js
+++ b/examples/javascript/StyleTransfer/StyleTransfer_Video/sketch.js
@@ -15,8 +15,8 @@ let isTransferring = false;
 let resultImg;
 let canvas, ctx;
 let toggleButton;
-let width = 320;
-let height = 240;
+const width = 320;
+const height = 240;
 
 async function setup() {
   canvas = createCanvas(width, height);

--- a/examples/javascript/UNET/UNET_webcam/sketch.js
+++ b/examples/javascript/UNET/UNET_webcam/sketch.js
@@ -11,8 +11,8 @@ UNET example using p5.js
 let video;
 let uNet;
 let segmentationImage;
-let width = 320;
-let height = 240;
+const width = 320;
+const height = 240;
 let request;
 let canvas, ctx;
 
@@ -59,7 +59,7 @@ function draw() {
 
   if(segmentationImage.hasOwnProperty('raw')){
     // UNET image is 128x128
-    let im = imageDataToCanvas(segmentationImage.raw.backgroundMask, 128, 128)
+    const im = imageDataToCanvas(segmentationImage.raw.backgroundMask, 128, 128)
     ctx.drawImage(im, 0, 0, width, height);
   }
   

--- a/examples/javascript/Word2Vec/Word2Vec_Interactive/sketch.js
+++ b/examples/javascript/Word2Vec/Word2Vec_Interactive/sketch.js
@@ -20,24 +20,24 @@ function setup() {
   word2Vec = ml5.word2vec('data/wordvecs10000.json', modelLoaded);
 
   // Select all the DOM elements
-  let nearWordInput = document.querySelector('#nearword');
-  let nearButton = document.querySelector('#submit');
-  let nearResults = document.querySelector('#results');
+  const nearWordInput = document.querySelector('#nearword');
+  const nearButton = document.querySelector('#submit');
+  const nearResults = document.querySelector('#results');
 
-  let betweenWordInput1 = document.querySelector("#between1");
-  let betweenWordInput2 = document.querySelector("#between2");
-  let betweenButton = document.querySelector("#submit2");
-  let betweenResults = document.querySelector("#results2");
+  const betweenWordInput1 = document.querySelector("#between1");
+  const betweenWordInput2 = document.querySelector("#between2");
+  const betweenButton = document.querySelector("#submit2");
+  const betweenResults = document.querySelector("#results2");
 
-  let addInput1 = document.querySelector("#isto1");
-  let addInput2 = document.querySelector("#isto2");
-  let addInput3 = document.querySelector("#isto3");
-  let addButton = document.querySelector("#submit3");
-  let addResults = document.querySelector("#results3");
+  const addInput1 = document.querySelector("#isto1");
+  const addInput2 = document.querySelector("#isto2");
+  const addInput3 = document.querySelector("#isto3");
+  const addButton = document.querySelector("#submit3");
+  const addResults = document.querySelector("#results3");
 
   // Finding the nearest words
   nearButton.addEventListener('click', () => {
-    let word = nearWordInput.value;
+    const word = nearWordInput.value;
     word2Vec.nearest(word, (err, result) => {
       let output = '';
       if (result) {
@@ -53,8 +53,8 @@ function setup() {
 
   // Finding the average of two words
   betweenButton.addEventListener('click',() => {
-    let word1 = betweenWordInput1.value;
-    let word2 = betweenWordInput2.value;
+    const word1 = betweenWordInput1.value;
+    const word2 = betweenWordInput2.value;
     word2Vec.average([word1, word2], 4, (err, average) => {
       betweenResults.innerHTML = average[0].word;
     })
@@ -62,9 +62,9 @@ function setup() {
 
   // Adding two words together to "solve" an analogy
   addButton.addEventListener('click',() => {
-    let is1 = addInput1.value;
-    let to1 = addInput2.value;
-    let is2 = addInput3.value;
+    const is1 = addInput1.value;
+    const to1 = addInput2.value;
+    const is2 = addInput3.value;
     word2Vec.subtract([to1, is1])
       .then(difference => word2Vec.add([is2, difference[0].word]))
       .then(result => { addResults.innerHTML = result[0].word })

--- a/examples/javascript/YOLO/YOLO_single_image/sketch.js
+++ b/examples/javascript/YOLO/YOLO_single_image/sketch.js
@@ -12,8 +12,8 @@ let yolo;
 let status;
 let objects = [];
 let canvas, ctx;
-let width = 640;
-let height = 420;
+const width = 640;
+const height = 420;
 
 async function make() {
   img = new Image();

--- a/examples/javascript/YOLO/YOLO_webcam/sketch.js
+++ b/examples/javascript/YOLO/YOLO_webcam/sketch.js
@@ -13,8 +13,8 @@ let status;
 let objects = [];
 let video;
 let canvas, ctx;
-let width = 480;
-let height = 360;
+const width = 480;
+const height = 360;
 
 async function make() {
   // get the video

--- a/examples/p5js/BodyPix/BodyPix_Webcam_Parts/sketch.js
+++ b/examples/p5js/BodyPix/BodyPix_Webcam_Parts/sketch.js
@@ -66,7 +66,7 @@ function createHSBPalette() {
     });
 }
 
-function createHSBPalette() {
+function createRGBPalette() {
     colorMode(RGB);
     options.palette = bodypix.config.palette;
     Object.keys(options.palette).forEach(part => {

--- a/examples/p5js/BodyPix/BodyPix_p5Instance/sketch.js
+++ b/examples/p5js/BodyPix/BodyPix_p5Instance/sketch.js
@@ -43,4 +43,4 @@ const s = (sketch) => {
   }
 }
 
-let myp5 = new p5(s, document.getElementById('p5sketch'));
+const myp5 = new p5(s, document.getElementById('p5sketch'));

--- a/examples/p5js/CVAE/CVAE_QuickDraw/sketch.js
+++ b/examples/p5js/CVAE/CVAE_QuickDraw/sketch.js
@@ -33,12 +33,12 @@ function gotImage(error, result) {
 function modelReady() {
   // Create dropdown with all possible labels
   dropdown = createSelect();
-  for (let label of cvae.labels) {
+  for (const label of cvae.labels) {
     dropdown.option(label);
   }
 }
 
 function generateImage() {
-  let label = dropdown.value();
+  const label = dropdown.value();
   cvae.generate(label, gotImage);
 }

--- a/examples/p5js/CharRNN/CharRNN_Interactive/sketch.js
+++ b/examples/p5js/CharRNN/CharRNN_Interactive/sketch.js
@@ -51,14 +51,14 @@ function generate() {
     select('#temperature').html(tempSlider.value());
 
     // Grab the original text
-    let original = textInput.value();
+    const original = textInput.value();
     // Make it to lower case
-    let txt = original.toLowerCase();
+    const txt = original.toLowerCase();
 
     // Check if there's something
     if (txt.length > 0) {
       // Here is the data for the LSTM generator
-      let data = {
+      const data = {
         seed: txt,
         temperature: tempSlider.value(),
         length: lengthSlider.value()

--- a/examples/p5js/CharRNN/CharRNN_Text/sketch.js
+++ b/examples/p5js/CharRNN/CharRNN_Text/sketch.js
@@ -56,16 +56,16 @@ function generate() {
     select('#status').html('Generating...');
 
     // Grab the original text
-    let original = textInput.value();
+    const original = textInput.value();
     // Make it to lower case
-    let txt = original.toLowerCase();
+    const txt = original.toLowerCase();
 
     // Check if there's something to send
     if (txt.length > 0) {
       // This is what the LSTM generator needs
       // Seed text, temperature, length to outputs
       // TODO: What are the defaults?
-      let data = {
+      const data = {
         seed: txt,
         temperature: tempSlider.value(),
         length: lengthSlider.value()

--- a/examples/p5js/CharRNN/CharRNN_Text_Stateful/sketch.js
+++ b/examples/p5js/CharRNN/CharRNN_Text_Stateful/sketch.js
@@ -18,7 +18,7 @@ let resetBtn;
 let singleBtn;
 let generating = false;
 
-let canvasHeight = 100;
+const canvasHeight = 100;
 
 function setup() {
   noCanvas();
@@ -77,9 +77,9 @@ async function loopRNN() {
 }
 
 async function predict() {
-  let par = select('#result');
-  let temperature = tempSlider.value();
-  let next = await charRNN.predict(temperature);
+  const par = select('#result');
+  const temperature = tempSlider.value();
+  const next = await charRNN.predict(temperature);
   await charRNN.feed(next.sample);
   par.html(par.html() + next.sample);
 }

--- a/examples/p5js/DCGAN/DCGAN_LatentVector_RandomWalk/sketch.js
+++ b/examples/p5js/DCGAN/DCGAN_LatentVector_RandomWalk/sketch.js
@@ -10,7 +10,7 @@ DCGAN example
 
 let dcgan;
 
-let vector = [];
+const vector = [];
 
 function preload() {
   dcgan = ml5.DCGAN('model/geo/manifest.json');

--- a/examples/p5js/DCGAN/DCGAN_LatentVector_Slider/sketch.js
+++ b/examples/p5js/DCGAN/DCGAN_LatentVector_Slider/sketch.js
@@ -11,11 +11,11 @@ DCGAN example
 let dcgan;
 
 // vector 1
-let a = [];
+const a = [];
 // vector 2
-let b = [];
+const b = [];
 // vector to interpolate between 1 and 2
-let c = [];
+const c = [];
 
 let slider;
 
@@ -40,7 +40,7 @@ function setup() {
 
 
 function generate() {
-  let amt = slider.value();
+  const amt = slider.value();
   // fill the latent vector with the interpolation between a and b
   for (let i = 0; i < 128; i++) {
     c[i] = lerp(a[i], b[i], amt);

--- a/examples/p5js/ImageClassification/ImageClassification_DoodleNet_Canvas/sketch.js
+++ b/examples/p5js/ImageClassification/ImageClassification_DoodleNet_Canvas/sketch.js
@@ -32,7 +32,7 @@ function setup() {
   // Whenever mouseReleased event happens on canvas, call "classifyCanvas" function
   canvas.mouseReleased(classifyCanvas);
   // Create a clear canvas button
-  let button = createButton('Clear Canvas');
+  const button = createButton('Clear Canvas');
   button.position(7, 44);
   button.mousePressed(clearCanvas);
   // Create 'label' and 'confidence' div to hold results

--- a/examples/p5js/ImageClassification/ImageClassification_MultipleImages/sketch.js
+++ b/examples/p5js/ImageClassification/ImageClassification_MultipleImages/sketch.js
@@ -13,8 +13,8 @@ let classifier;
 
 let img;
 let currentIndex = 0;
-let allImages = [];
-let predictions = [];
+const allImages = [];
+const predictions = [];
 
 function preload() {
   classifier = ml5.imageClassifier('MobileNet');

--- a/examples/p5js/KMeans/KMeans_imageSegmentation/sketch.js
+++ b/examples/p5js/KMeans/KMeans_imageSegmentation/sketch.js
@@ -1,6 +1,6 @@
 let kmeans;
 let baseImage;
-let data = [];
+const data = [];
 
 const imgSize = 30;
 const colorDict = {
@@ -33,7 +33,7 @@ function setup() {
   // data to be sent to kmeans
   for (let x = 0; x < imgSize; x++) {
     for (let y = 0; y < imgSize; y++) {
-      let off = (y * imgSize + x) * 4;
+      const off = (y * imgSize + x) * 4;
       const r = img.pixels[off];
       const g = img.pixels[off + 1];
       const b = img.pixels[off + 2];
@@ -60,14 +60,14 @@ function modelReady() {
   console.log('ready!')
   const dataset = kmeans.dataset;
 
-  let segmented = createImage(imgSize, imgSize);
+  const segmented = createImage(imgSize, imgSize);
   segmented.loadPixels();
 
   // redraw the image using the color dictionary above
   // use the .centroid value to apply the color
   for (let x = 0; x < segmented.width; x++) {
     for (let y = 0; y < segmented.height; y++) {
-      let off = (x * imgSize + y);
+      const off = (x * imgSize + y);
       const c = colorDict[dataset[off].centroid]
       segmented.set(x, y, color(c));
     }

--- a/examples/p5js/KNNClassification/KNNClassification_PoseNet/sketch.js
+++ b/examples/p5js/KNNClassification/KNNClassification_PoseNet/sketch.js
@@ -154,10 +154,10 @@ function drawKeypoints()  {
   // Loop through all the poses detected
   for (let i = 0; i < poses.length; i++) {
     // For each pose detected, loop through all the keypoints
-    let pose = poses[i].pose;
+    const pose = poses[i].pose;
     for (let j = 0; j < pose.keypoints.length; j++) {
       // A keypoint is an object describing a body part (like rightArm or leftShoulder)
-      let keypoint = pose.keypoints[j];
+      const keypoint = pose.keypoints[j];
       // Only draw an ellipse is the pose probability is bigger than 0.2
       if (keypoint.score > 0.2) {
         fill(255, 0, 0);
@@ -172,11 +172,11 @@ function drawKeypoints()  {
 function drawSkeleton() {
   // Loop through all the skeletons detected
   for (let i = 0; i < poses.length; i++) {
-    let skeleton = poses[i].skeleton;
+    const skeleton = poses[i].skeleton;
     // For every skeleton, loop through all body connections
     for (let j = 0; j < skeleton.length; j++) {
-      let partA = skeleton[j][0];
-      let partB = skeleton[j][1];
+      const partA = skeleton[j][0];
+      const partB = skeleton[j][1];
       stroke(255, 0, 0);
       line(partA.position.x, partA.position.y, partB.position.x, partB.position.y);
     }

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_Interactive_Regression/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_Interactive_Regression/sketch.js
@@ -1,4 +1,4 @@
-let trainData = [];
+const trainData = [];
 let neuralNetwork;
 
 // selectors for inputs and button

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_Simple_Regression/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_Simple_Regression/sketch.js
@@ -43,9 +43,9 @@ function finishedTraining(){
         return;
       }
       console.log(results[0]);
-      let prediction = results[0]
-      let x = counter;
-      let y = prediction.value
+      const prediction = results[0]
+      const x = counter;
+      const y = prediction.value
       fill(255, 0, 0);
       rectMode(CENTER);
       rect(x, y, 10, 10);
@@ -62,7 +62,7 @@ function createTrainingData(){
     const iters = floor(random(5, 20))
     const spread = 50;
     for(let j = 0; j < iters; j++){
-      let data = [i, height - i + floor(random(-spread, spread))]
+      const data = [i, height - i + floor(random(-spread, spread))]
       fill(0, 0, 255);
       ellipse(data[0], data[1], 10, 10)
       nn.addData([data[0]], [data[1]])

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_XOR/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_XOR/sketch.js
@@ -2,7 +2,7 @@
 // https://youtu.be/N3ZnNa01BPM
 
 let model;
-let resolution = 20;
+const resolution = 20;
 let cols;
 let rows;
 
@@ -14,7 +14,7 @@ function setup() {
   let index = 0;
   for (let i = 0; i < cols; i++) {
     for (let j = 0; j < rows; j++) {
-      let br = 255; //y_values[index] * 255
+      const br = 255; //y_values[index] * 255
       fill(br);
       rect(i * resolution, j * resolution, resolution, resolution);
       fill(255 - br);
@@ -26,7 +26,7 @@ function setup() {
     }
   }
 
-  let options = {
+  const options = {
     inputs: 2,
     outputs: 1,
     learningRate: 0.25,
@@ -55,11 +55,11 @@ function whileTraining(epoch, logs) {
 function finishedTraining() {
   // console.log('done!');
   // TODO: Support prediction on multiple rows of input data
-  let xs = [];
+  const xs = [];
   for (let i = 0; i < cols; i++) {
     for (let j = 0; j < rows; j++) {
-      let x1 = i / cols;
-      let x2 = j / rows;
+      const x1 = i / cols;
+      const x2 = j / rows;
       xs.push([x1, x2]);
     }
   }
@@ -77,7 +77,7 @@ function gotResults(error, results) {
   let index = 0;
   for (let i = 0; i < cols; i++) {
     for (let j = 0; j < rows; j++) {
-      let br = results[index][0].value * 255; //y_values[index] * 255
+      const br = results[index][0].value * 255; //y_values[index] * 255
       fill(br);
       rect(i * resolution, j * resolution, resolution, resolution);
       fill(255 - br);

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_basics/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_basics/sketch.js
@@ -22,28 +22,28 @@ function setup() {
   trainModel();
 
   // Train the model
-  let trainBtn = createButton('Train Model');
+  const trainBtn = createButton('Train Model');
   trainBtn.position(10, 50);
   trainBtn.mousePressed(function () {
     trainModel();
   });
 
   // Predict
-  let predictBtn = createButton('Predict');
+  const predictBtn = createButton('Predict');
   predictBtn.position(10, 70);
   predictBtn.mousePressed(function () {
     predict();
   });
 
   // Save and download the model
-  let saveBtn = createButton('Save Model');
+  const saveBtn = createButton('Save Model');
   saveBtn.position(10, 90);
   saveBtn.mousePressed(function () {
     nn.save();
   });
 
   // Load the model from local files
-  let loadLocalBtn = createButton('Load the model from local files');
+  const loadLocalBtn = createButton('Load the model from local files');
   loadLocalBtn.position(10, 110);
   loadLocalBtn.mousePressed(function () {
     nn.load('model/model.json', function () {
@@ -52,7 +52,7 @@ function setup() {
   });
 
   // Load model
-  let loadBtn = select('#load');
+  const loadBtn = select('#load');
   loadBtn.changed(function () {
     nn.load(loadBtn.elt.files, function () {
       console.log('Model Loaded!');

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_color_classifier/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_color_classifier/sketch.js
@@ -17,7 +17,7 @@ function setup() {
   gSlider = createSlider(0, 255, 0);
   bSlider = createSlider(0, 255, 255);
 
-  let nnOptions = {
+  const nnOptions = {
     dataUrl: 'data/colorData.json',
     inputs: ['r', 'g', 'b'],
     outputs: ['label'],
@@ -48,7 +48,7 @@ function finishedTraining(anything) {
 }
 
 function classify() {
-  let inputs = {
+  const inputs = {
     r: rSlider.value(),
     g: gSlider.value(),
     b: bSlider.value()

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_load_model/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_load_model/sketch.js
@@ -17,7 +17,7 @@ function setup() {
   gSlider = createSlider(0, 255, 0);
   bSlider = createSlider(0, 255, 255);
 
-  let nnOptions = {
+  const nnOptions = {
     task: 'classification',
     debug: true
   };
@@ -42,7 +42,7 @@ function modelReady() {
 
 
 function classify() {
-  let inputs = {
+  const inputs = {
     r: rSlider.value(),
     g: gSlider.value(),
     b: bSlider.value()

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_load_saved_data/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_load_saved_data/sketch.js
@@ -26,7 +26,7 @@ function setup() {
   resultsText = select('#results');
 
   // Train the model
-  let trainBtn = select('#trainBtn');
+  const trainBtn = select('#trainBtn');
   // trainBtn.position(10, 50);
   trainBtn.mousePressed(function () {
     trainModel();
@@ -49,7 +49,7 @@ function setup() {
   // });
 
   // Load Data
-  let loadBtn = select('#load');
+  const loadBtn = select('#load');
   loadBtn.changed(function () {
     nn.loadData(loadBtn.elt.files, function () {
       console.log('Data Loaded!');

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_lowres_pixels/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_lowres_pixels/sketch.js
@@ -4,15 +4,15 @@ let pixelBrain;
 // The video and pixel scale
 let video;
 let ready = false;
-let videoSize = 10;
+const videoSize = 10;
 
 // For sound synthesis
-let playing = false;
+const playing = false;
 let frequency;
 let osc;
 
 // Going to normalize the data myself here
-let freqMax = 800;
+const freqMax = 800;
 
 function setup() {
   createCanvas(200, 200);
@@ -22,7 +22,7 @@ function setup() {
   video.hide();
 
   // Inputs are total pixels times 3 (RGB)
-  let totalPixels = videoSize * videoSize * 3;
+  const totalPixels = videoSize * videoSize * 3;
   const options = {
     inputs: totalPixels,
     outputs: 1,
@@ -47,14 +47,14 @@ function draw() {
   background(0);
   if (ready) {
     // Render the low-res image
-    let w = width / videoSize;
+    const w = width / videoSize;
     video.loadPixels();
     for (let x = 0; x < video.width; x++) {
       for (let y = 0; y < video.height; y++) {
-        let index = (x + y * video.width) * 4;
-        let r = video.pixels[index + 0];
-        let g = video.pixels[index + 1];
-        let b = video.pixels[index + 2];
+        const index = (x + y * video.width) * 4;
+        const r = video.pixels[index + 0];
+        const g = video.pixels[index + 1];
+        const b = video.pixels[index + 2];
         noStroke();
         fill(r, g, b);
         rect(x * w, y * w, w, w);
@@ -68,9 +68,9 @@ function draw() {
 function getInputs() {
   video.loadPixels();
   // Create an array
-  let inputs = [];
+  const inputs = [];
   for (let i = 0; i < video.width * video.height; i++) {
-    let index = i * 4;
+    const index = i * 4;
     // Manual normalization
     inputs.push(video.pixels[index + 0] / 255);
     inputs.push(video.pixels[index + 1] / 255);
@@ -82,9 +82,9 @@ function getInputs() {
 
 // Add an example
 function addExample() {
-  let freq = parseFloat(select('#frequency').value());
+  const freq = parseFloat(select('#frequency').value());
   video.loadPixels();
-  let inputs = getInputs();
+  const inputs = getInputs();
   // Manual normalization of frequency
   pixelBrain.addData(inputs, [freq / freqMax]);
 }
@@ -112,7 +112,7 @@ function finishedTraining() {
 }
 
 function predict() {
-  let inputs = getInputs();
+  const inputs = getInputs();
   pixelBrain.predict(inputs, gotFrequency);
 }
 

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_musical_face/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_musical_face/sketch.js
@@ -11,10 +11,10 @@ let faceBrain;
 
 //  Sound
 let osc;
-let freqMax = 800;
+const freqMax = 800;
 
 // Keeping track of state
-let trained = false;
+const trained = false;
 let collecting = false;
 
 function setup() {
@@ -67,7 +67,7 @@ function draw() {
 
   // Just look at the first face and draw all the points
   if (detections.length > 0) {
-    let points = detections[0].landmarks.positions;
+    const points = detections[0].landmarks.positions;
     for (let i = 0; i < points.length; i++) {
       stroke(161, 95, 251);
       strokeWeight(4);
@@ -78,12 +78,12 @@ function draw() {
   // If Collecting  data
   if (collecting) {
     // Get slider frequency value
-    let freq = parseFloat(select('#frequency_slider').value());
+    const freq = parseFloat(select('#frequency_slider').value());
     select('#training_freq').html(freq);
     osc.freq(freq);
 
     // Get face inputs
-    let inputs = getInputs();
+    const inputs = getInputs();
     if (inputs) {
       // Normalize frequency value
       faceBrain.addData(inputs, [freq]);
@@ -95,8 +95,8 @@ function getInputs() {
   // If there is a face, flatten all the positions into
   // a normalized array.
   if (detections.length > 0) {
-    let points = detections[0].landmarks.positions;
-    let inputs = [];
+    const points = detections[0].landmarks.positions;
+    const inputs = [];
     for (let i = 0; i < points.length; i++) {
       inputs.push(points[i]._x);
       inputs.push(points[i]._y);
@@ -133,7 +133,7 @@ function finishedTraining() {
 
 // Predict a frequency
 function predict() {
-  let inputs = getInputs();
+  const inputs = getInputs();
   faceBrain.predict(inputs, gotFrequency);
 }
 

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_musical_mouse/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_musical_mouse/sketch.js
@@ -2,12 +2,12 @@
 let brain;
 
 // Variables to track p5 oscillator
-let playing = false;
+const playing = false;
 let frequency;
 let osc;
 
 function setup() {
-  let canvas = createCanvas(400, 400);
+  const canvas = createCanvas(400, 400);
   // Only when clicking on the canvas
   canvas.mousePressed(addData);
 
@@ -29,7 +29,7 @@ function setup() {
 // Add a data record
 function addData() {
   // Get frequency
-  let target = parseFloat(select('#frequency').value());
+  const target = parseFloat(select('#frequency').value());
   // TODO: support notePlayer.data.addData({x: mouseX, y: mouseY}, {frequency: target});
   // Add data
   brain.addData({x:mouseX, y:mouseY}, {freq:target});

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_pose_classifier/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_pose_classifier/sketch.js
@@ -42,7 +42,7 @@ function setup() {
   trainButton.mousePressed(trainModel);
 
   // Create the model
-  let options = {
+  const options = {
     inputs: 34,
     outputs: 2,
     task: 'classification',
@@ -54,7 +54,7 @@ function setup() {
 // Train the model
 function trainModel() {
   brain.normalizeData();
-  let options = {
+  const options = {
     epochs: 25
   }
   brain.train(options, finishedTraining);
@@ -68,7 +68,7 @@ function finishedTraining() {
 // Classify
 function classify() {
   if (poses.length > 0) {
-    let inputs = getInputs();
+    const inputs = getInputs();
     brain.classify(inputs, gotResults);
   }
 }
@@ -82,8 +82,8 @@ function gotResults(error, results) {
 }
 
 function getInputs() {
-  let keypoints = poses[0].pose.keypoints;
-  let inputs = [];
+  const keypoints = poses[0].pose.keypoints;
+  const inputs = [];
   for (let i = 0; i < keypoints.length; i++) {
     inputs.push(keypoints[i].position.x);
     inputs.push(keypoints[i].position.y);
@@ -94,8 +94,8 @@ function getInputs() {
 //  Add a training example
 function addExample() {
   if (poses.length > 0) {
-    let inputs = getInputs();
-    let target = dataLabel.value();
+    const inputs = getInputs();
+    const target = dataLabel.value();
     brain.addData(inputs, [target]);
   }
 }
@@ -111,7 +111,7 @@ function draw() {
   strokeWeight(2);
   // For one pose only (use a for loop for multiple poses!)
   if (poses.length > 0) {
-    let pose = poses[0].pose;
+    const pose = poses[0].pose;
     for (let i = 0; i < pose.keypoints.length; i++) {
       fill(213, 0, 143);
       noStroke();

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_titanic/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_titanic/sketch.js
@@ -4,7 +4,7 @@ let submitButton;
 function setup() {
   noCanvas();
 
-  let nnOptions = {
+  const nnOptions = {
     dataUrl: 'data/titanic_cleaned.csv',
     inputs: ['fare_class','sex', 'age', 'fare'],
     outputs: ['survived'],
@@ -35,10 +35,10 @@ function finishedTraining() {
 
 // TODO: normalize and encode values going into predict?
 function classify() {
-  let age = parseInt(select('#age').value());
-  let fare = parseInt(select('#fare').value());
-  let fare_class = select('#fare_class').value();
-  let sex = select('#sex').value();
+  const age = parseInt(select('#age').value());
+  const fare = parseInt(select('#fare').value());
+  const fare_class = select('#fare_class').value();
+  const sex = select('#sex').value();
 
   // let inputs = {
   //   age: age,
@@ -47,7 +47,7 @@ function classify() {
   //   sex: sex
   // };
 
-  let inputs = [fare_class, sex, age, fare];
+  const inputs = [fare_class, sex, age, fare];
   neuralNetwork.classify(inputs, gotResults);
 }
 

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_xy_classifier/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_xy_classifier/sketch.js
@@ -2,7 +2,7 @@
 let brain;
 
 function setup() {
-  let canvas = createCanvas(400, 400);
+  const canvas = createCanvas(400, 400);
   // Only when clicking on the canvas
   canvas.mousePressed(addData);
 
@@ -24,7 +24,7 @@ function setup() {
 // Add a data record
 function addData() {
   // Get frequency
-  let label = select('#label').value();
+  const label = select('#label').value();
   // Add data
   brain.addData({x:mouseX, y:mouseY}, {label});
 

--- a/examples/p5js/NeuralNetwork/NeuroEvolution_FlappyBird/bird.js
+++ b/examples/p5js/NeuralNetwork/NeuroEvolution_FlappyBird/bird.js
@@ -51,7 +51,7 @@ class Bird {
     let closest = null;
     let closestD = Infinity;
     for (let i = 0; i < pipes.length; i++) {
-      let d = pipes[i].x + pipes[i].w - this.x;
+      const d = pipes[i].x + pipes[i].w - this.x;
       if (d < closestD && d > 0) {
         closest = pipes[i];
         closestD = d;
@@ -59,7 +59,7 @@ class Bird {
     }
 
     // Normalize 5 inputs
-    let inputs = [];
+    const inputs = [];
     inputs[0] = this.y / height;
     inputs[1] = closest.top / height;
     inputs[2] = closest.bottom / height;

--- a/examples/p5js/NeuralNetwork/NeuroEvolution_FlappyBird/ga.js
+++ b/examples/p5js/NeuralNetwork/NeuroEvolution_FlappyBird/ga.js
@@ -25,9 +25,9 @@ function nextGeneration() {
 
 // Create a child bird from two parents 
 function reproduce() {
-  let brainA = pickOne();
-  let brainB = pickOne();
-  let childBrain = brainA.crossover(brainB);
+  const brainA = pickOne();
+  const brainB = pickOne();
+  const childBrain = brainA.crossover(brainB);
   childBrain.mutate(0.1);
   return new Bird(childBrain);
 }
@@ -41,17 +41,17 @@ function pickOne() {
     index++;
   }
   index--;
-  let bird = savedBirds[index];
+  const bird = savedBirds[index];
   return bird.brain;
 }
 
 // Normalize all fitness values
 function calculateFitness() {
   let sum = 0;
-  for (let bird of savedBirds) {
+  for (const bird of savedBirds) {
     sum += bird.score;
   }
-  for (let bird of savedBirds) {
+  for (const bird of savedBirds) {
     bird.fitness = bird.score / sum;
   }
 }

--- a/examples/p5js/NeuralNetwork/NeuroEvolution_FlappyBird/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuroEvolution_FlappyBird/sketch.js
@@ -3,9 +3,9 @@
 
 const TOTAL = 100;
 // Current birds
-let birds = [];
+const birds = [];
 // Save any birds that die
-let savedBirds = [];
+const savedBirds = [];
 let pipes = [];
 let counter = 0;
 let slider;
@@ -58,7 +58,7 @@ function draw() {
     }
 
     // Run all birds
-    for (let bird of birds) {
+    for (const bird of birds) {
       bird.think(pipes);
       bird.update();
     }
@@ -74,11 +74,11 @@ function draw() {
   // All the drawing stuff
   background(0);
 
-  for (let bird of birds) {
+  for (const bird of birds) {
     bird.show();
   }
 
-  for (let pipe of pipes) {
+  for (const pipe of pipes) {
     pipe.show();
   }
 }

--- a/examples/p5js/NeuralNetwork/NeuroEvolution_Path/particle.js
+++ b/examples/p5js/NeuralNetwork/NeuroEvolution_Path/particle.js
@@ -28,7 +28,7 @@ class Particle {
 
   // fitness = one divided by distance squared
   calcFitness() {
-    let d = p5.Vector.dist(this.position, target);
+    const d = p5.Vector.dist(this.position, target);
     this.fitness = pow(1 / d, 2);
     return this.fitness;
   }
@@ -40,10 +40,10 @@ class Particle {
   // Run in relation to all the obstacles
   // If I'm stuck, don't bother updating or checking for intersection
   think() {
-    let inputs = [];
+    const inputs = [];
     inputs[0] = this.position.x / width;
     inputs[1] = this.position.y / height;
-    let outputs = this.brain.predictSync(inputs);
+    const outputs = this.brain.predictSync(inputs);
     this.velocity = p5.Vector.fromAngle(outputs[0].value * TWO_PI);
     this.velocity.mult(outputs[1].value * 5);
 

--- a/examples/p5js/NeuralNetwork/NeuroEvolution_Path/population.js
+++ b/examples/p5js/NeuralNetwork/NeuroEvolution_Path/population.js
@@ -15,22 +15,22 @@ class Population {
   }
 
   update() {
-    for (let p of this.population) {
+    for (const p of this.population) {
       p.think();
       p.update();
     }
   }
 
   show() {
-    for (let p of this.population) {
+    for (const p of this.population) {
       p.show();
     }
   }
 
   reproduce() {
-    let brainA = this.pickOne();
-    let brainB = this.pickOne();
-    let childBrain = brainA.crossover(brainB);
+    const brainA = this.pickOne();
+    const brainB = this.pickOne();
+    const childBrain = brainA.crossover(brainB);
     // 1% mutation rate
     childBrain.mutate(0.01);
     return new Particle(childBrain);
@@ -51,17 +51,17 @@ class Population {
   // Normalize all fitness values
   calculateFitness() {
     let sum = 0;
-    for (let p of this.population) {
+    for (const p of this.population) {
       sum += p.calcFitness();
     }
-    for (let p of this.population) {
+    for (const p of this.population) {
       p.fitness = p.fitness / sum;
     }
   }
 
   // Making the next generation
   reproduction() {
-    let nextPopulation = [];
+    const nextPopulation = [];
     // Refill the population with children from the mating pool
     for (let i = 0; i < this.population.length; i++) {
       nextPopulation[i] = this.reproduce();

--- a/examples/p5js/NeuralNetwork/NeuroEvolution_Path/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuroEvolution_Path/sketch.js
@@ -18,7 +18,7 @@ let info;
 let slider;
 
 function setup() {
-  let canvas = createCanvas(600, 600);
+  const canvas = createCanvas(600, 600);
 
   // Move the target if you click on the canvas
   canvas.mousePressed(function() {

--- a/examples/p5js/PitchDetection/PitchDetection_Game/sketch.js
+++ b/examples/p5js/PitchDetection/PitchDetection_Game/sketch.js
@@ -15,13 +15,13 @@ const voiceHigh = 500;
 let audioStream;
 
 // Circle variables
-let circleSize = 42;
+const circleSize = 42;
 const scale = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
 
 // Text variables
 let goalNote = 0;
 let currentNote = '';
-let currentText = '';
+const currentText = '';
 let textCoordinates;
 
 function setup() {
@@ -45,7 +45,7 @@ function modelLoaded() {
 function getPitch() {
   pitch.getPitch(function(err, frequency) {
     if (frequency) {
-      let midiNum = freqToMidi(frequency);
+      const midiNum = freqToMidi(frequency);
       currentNote = scale[midiNum % 12];
       select('#currentNote').html(currentNote);
     }

--- a/examples/p5js/PitchDetection/PitchDetection_Piano/sketch.js
+++ b/examples/p5js/PitchDetection/PitchDetection_Piano/sketch.js
@@ -40,7 +40,7 @@ function modelLoaded() {
 function getPitch() {
   pitch.getPitch(function(err, frequency) {
     if (frequency) {
-      let midiNum = freqToMidi(frequency);
+      const midiNum = freqToMidi(frequency);
       currentNote = scale[midiNum % 12];
     }
     getPitch();

--- a/examples/p5js/PoseNet/PoseNet_image_single/sketch.js
+++ b/examples/p5js/PoseNet/PoseNet_image_single/sketch.js
@@ -19,7 +19,7 @@ function setup() {
 function imageReady(){
 
   // set some options
-  let options = {
+  const options = {
     minConfidence: 0.1,
     inputResolution: { "width": width, "height": height }
   }
@@ -59,10 +59,10 @@ function drawKeypoints() {
   // Loop through all the poses detected
   for (let i = 0; i < poses.length; i++) {
     // For each pose detected, loop through all the keypoints
-    let pose = poses[i].pose;
+    const pose = poses[i].pose;
     for (let j = 0; j < pose.keypoints.length; j++) {
       // A keypoint is an object describing a body part (like rightArm or leftShoulder)
-      let keypoint = pose.keypoints[j];
+      const keypoint = pose.keypoints[j];
       // Only draw an ellipse is the pose probability is bigger than 0.2
       if (keypoint.score > 0.2) {
         fill(255);
@@ -78,11 +78,11 @@ function drawKeypoints() {
 function drawSkeleton() {
   // Loop through all the skeletons detected
   for (let i = 0; i < poses.length; i++) {
-    let skeleton = poses[i].skeleton;
+    const skeleton = poses[i].skeleton;
     // For every skeleton, loop through all body connections
     for (let j = 0; j < skeleton.length; j++) {
-      let partA = skeleton[j][0];
-      let partB = skeleton[j][1];
+      const partA = skeleton[j][0];
+      const partB = skeleton[j][1];
       stroke(255);
       strokeWeight(1);
       line(partA.position.x, partA.position.y, partB.position.x, partB.position.y);

--- a/examples/p5js/PoseNet/PoseNet_part_selection/sketch.js
+++ b/examples/p5js/PoseNet/PoseNet_part_selection/sketch.js
@@ -42,21 +42,21 @@ function draw() {
 
   // For one pose only (use a for loop for multiple poses!)
   if (poses.length > 0) {
-    let pose = poses[0].pose;
+    const pose = poses[0].pose;
 
     // Create a pink ellipse for the nose
     fill(213, 0, 143);
-    let nose = pose['nose'];
+    const nose = pose['nose'];
     ellipse(nose.x, nose.y, 20, 20);
 
     // Create a yellow ellipse for the right eye
     fill(255, 215, 0);
-    let rightEye = pose['rightEye'];
+    const rightEye = pose['rightEye'];
     ellipse(rightEye.x, rightEye.y, 20, 20);
 
     // Create a yellow ellipse for the right eye
     fill(255, 215, 0);
-    let leftEye = pose['leftEye'];
+    const leftEye = pose['leftEye'];
     ellipse(leftEye.x, leftEye.y, 20, 20);
   }
 }

--- a/examples/p5js/PoseNet/PoseNet_webcam/sketch.js
+++ b/examples/p5js/PoseNet/PoseNet_webcam/sketch.js
@@ -45,10 +45,10 @@ function drawKeypoints()  {
   // Loop through all the poses detected
   for (let i = 0; i < poses.length; i++) {
     // For each pose detected, loop through all the keypoints
-    let pose = poses[i].pose;
+    const pose = poses[i].pose;
     for (let j = 0; j < pose.keypoints.length; j++) {
       // A keypoint is an object describing a body part (like rightArm or leftShoulder)
-      let keypoint = pose.keypoints[j];
+      const keypoint = pose.keypoints[j];
       // Only draw an ellipse is the pose probability is bigger than 0.2
       if (keypoint.score > 0.2) {
         fill(255, 0, 0);
@@ -63,11 +63,11 @@ function drawKeypoints()  {
 function drawSkeleton() {
   // Loop through all the skeletons detected
   for (let i = 0; i < poses.length; i++) {
-    let skeleton = poses[i].skeleton;
+    const skeleton = poses[i].skeleton;
     // For every skeleton, loop through all body connections
     for (let j = 0; j < skeleton.length; j++) {
-      let partA = skeleton[j][0];
-      let partB = skeleton[j][1];
+      const partA = skeleton[j][0];
+      const partB = skeleton[j][1];
       stroke(255, 0, 0);
       line(partA.position.x, partA.position.y, partB.position.x, partB.position.y);
     }

--- a/examples/p5js/SketchRNN/SketchRNN_basic/sketch.js
+++ b/examples/p5js/SketchRNN/SketchRNN_basic/sketch.js
@@ -28,7 +28,7 @@ function setup() {
   background(220);
 
   // Button to reset drawing
-  let button = createButton('clear');
+  const button = createButton('clear');
   button.mousePressed(startDrawing);
   
   // run sketchRNN

--- a/examples/p5js/SketchRNN/SketchRNN_interactive/sketch.js
+++ b/examples/p5js/SketchRNN/SketchRNN_interactive/sketch.js
@@ -32,7 +32,7 @@ function setup() {
   model = ml5.sketchRNN('cat', modelReady);
 
   // Button to start drawing
-  let button = select('#clear');
+  const button = select('#clear');
   button.mousePressed(clearDrawing);
 }
 
@@ -70,7 +70,7 @@ function draw() {
     strokeWeight(3.0);
     line(pmouseX, pmouseY, mouseX, mouseY);
     // Create a "stroke path" with dx, dy, and pen
-    let userStroke = {
+    const userStroke = {
       dx: mouseX - pmouseX,
       dy: mouseY - pmouseY,
       pen: 'down'

--- a/examples/p5js/TeachableMachine/ImageModel_TM/sketch.js
+++ b/examples/p5js/TeachableMachine/ImageModel_TM/sketch.js
@@ -12,7 +12,7 @@ This example uses p5 preload function to create the classifier
 // Classifier Variable
 let classifier;
 // Model URL
-let imageModelURL = 'https://teachablemachine.withgoogle.com/models/bXy2kDNi/model.json';
+const imageModelURL = 'https://teachablemachine.withgoogle.com/models/bXy2kDNi/model.json';
 
 // Video
 let video;

--- a/examples/p5js/TeachableMachine/SoundModel_TM/sketch.js
+++ b/examples/p5js/TeachableMachine/SoundModel_TM/sketch.js
@@ -16,7 +16,7 @@ let classifier;
 let label = "listening";
 
 // Teachable Machine model URL:
-let soundModelURL = 'https://teachablemachine.withgoogle.com/models/h3p9R41J/model.json';
+const soundModelURL = 'https://teachablemachine.withgoogle.com/models/h3p9R41J/model.json';
 
 
 function preload() {

--- a/examples/p5js/Word2Vec/Word2Vec_Interactive/sketch.js
+++ b/examples/p5js/Word2Vec/Word2Vec_Interactive/sketch.js
@@ -22,24 +22,24 @@ function setup() {
   word2Vec = ml5.word2vec('data/wordvecs5000.json', modelLoaded);
 
   // Select all the DOM elements
-  let nearWordInput = select('#nearword');
-  let nearButton = select('#submit');
-  let nearResults = select('#results');
+  const nearWordInput = select('#nearword');
+  const nearButton = select('#submit');
+  const nearResults = select('#results');
 
-  let betweenWordInput1 = select("#between1");
-  let betweenWordInput2 = select("#between2");
-  let betweenButton = select("#submit2");
-  let betweenResults = select("#results2");
+  const betweenWordInput1 = select("#between1");
+  const betweenWordInput2 = select("#between2");
+  const betweenButton = select("#submit2");
+  const betweenResults = select("#results2");
 
-  let addInput1 = select("#isto1");
-  let addInput2 = select("#isto2");
-  let addInput3 = select("#isto3");
-  let addButton = select("#submit3");
-  let addResults = select("#results3");
+  const addInput1 = select("#isto1");
+  const addInput2 = select("#isto2");
+  const addInput3 = select("#isto3");
+  const addButton = select("#submit3");
+  const addResults = select("#results3");
 
   // Finding the nearest words
   nearButton.mousePressed(() => {
-    let word = nearWordInput.value();
+    const word = nearWordInput.value();
     word2Vec.nearest(word, (err, result) => {
       let output = '';
       if (result) {
@@ -55,8 +55,8 @@ function setup() {
 
   // Finding the average of two words
   betweenButton.mousePressed(() => {
-    let word1 = betweenWordInput1.value();
-    let word2 = betweenWordInput2.value();
+    const word1 = betweenWordInput1.value();
+    const word2 = betweenWordInput2.value();
     word2Vec.average([word1, word2], 4, (err, average) => {
       betweenResults.html(average[0].word);
     })
@@ -64,9 +64,9 @@ function setup() {
 
   // Adding two words together to "solve" an analogy
   addButton.mousePressed(() => {
-    let is1 = addInput1.value();
-    let to1 = addInput2.value();
-    let is2 = addInput3.value();
+    const is1 = addInput1.value();
+    const to1 = addInput2.value();
+    const is2 = addInput3.value();
     word2Vec.subtract([to1, is1])
       .then(difference => word2Vec.add([is2, difference[0].word]))
       .then(result => addResults.html(result[0].word))

--- a/package-lock.json
+++ b/package-lock.json
@@ -2578,7 +2578,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
       "requires": {
         "chalk": "^1.1.3",
         "esutils": "^2.0.2",
@@ -2588,20 +2587,17 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -2613,14 +2609,12 @@
         "js-tokens": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-          "dev": true
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
         },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2628,8 +2622,7 @@
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
@@ -4605,8 +4598,7 @@
     "chardet": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "dev": true
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
     },
     "chokidar": {
       "version": "3.3.1",
@@ -4797,8 +4789,7 @@
     "cli-width": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
-      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
-      "dev": true
+      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw=="
     },
     "clipboard": {
       "version": "2.0.6",
@@ -6160,8 +6151,7 @@
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "deepmerge": {
       "version": "4.2.2",
@@ -7342,8 +7332,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.14.1",
@@ -7704,6 +7693,85 @@
         "get-stdin": "^6.0.0"
       }
     },
+    "eslint-filtered-fix": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-filtered-fix/-/eslint-filtered-fix-0.1.1.tgz",
+      "integrity": "sha1-B+CKjHzeBZxtsAw7KwAfpHVst04=",
+      "requires": {
+        "optionator": "^0.8.2"
+      }
+    },
+    "eslint-formatter-friendly": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-formatter-friendly/-/eslint-formatter-friendly-6.0.0.tgz",
+      "integrity": "sha512-fOBwGn2r8BPQ1KSKyVzjXP8VFxJ2tWKxxn2lIF+k1ezN/pFB44HDlrn5kBm1vxbyyRa/LC+1vHJwc7WETUAZ2Q==",
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "chalk": "^2.0.1",
+        "extend": "^3.0.0",
+        "strip-ansi": "^4.0.0",
+        "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "eslint-import-resolver-node": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz",
@@ -7735,6 +7803,178 @@
       "requires": {
         "debug": "^2.6.9",
         "pkg-dir": "^2.0.0"
+      }
+    },
+    "eslint-nibble": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-nibble/-/eslint-nibble-5.1.0.tgz",
+      "integrity": "sha512-wgmhwlMaNBbaDHrxg8/Os0LCOOatfzy6IaU07HFk6/UirfsTCqD9XoH0+9UNk2V16uPZXgLSiUIwGBtxliXnHw==",
+      "requires": {
+        "chalk": "^2.4.1",
+        "eslint-filtered-fix": "^0.1.1",
+        "eslint-formatter-friendly": "^6.0.0",
+        "eslint-stats": "github:ianvs/eslint-stats#cb1ff8251b50c7f0cb431a2b395431ebfdeb10c8",
+        "eslint-summary": "^1.0.0",
+        "inquirer": "^6.2.0",
+        "optionator": "^0.8.2"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        },
+        "figures": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "inquirer": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+          "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+          "requires": {
+            "ansi-escapes": "^3.2.0",
+            "chalk": "^2.4.2",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^3.0.3",
+            "figures": "^2.0.0",
+            "lodash": "^4.17.12",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rxjs": "^6.4.0",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^5.1.0",
+            "through": "^2.3.6"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "requires": {
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+            }
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "eslint-plugin-import": {
@@ -7781,6 +8021,106 @@
       "requires": {
         "esrecurse": "^4.1.0",
         "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-stats": {
+      "version": "github:ianvs/eslint-stats#cb1ff8251b50c7f0cb431a2b395431ebfdeb10c8",
+      "from": "github:ianvs/eslint-stats#cb1ff8251b50c7f0cb431a2b395431ebfdeb10c8",
+      "requires": {
+        "chalk": "^2.4.1",
+        "lodash": "^4.17.4"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "eslint-summary": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-summary/-/eslint-summary-1.0.0.tgz",
+      "integrity": "sha1-uBHwBDcBayDA9vUjRHm9Y5W1eIY=",
+      "requires": {
+        "chalk": "^1.0.0",
+        "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        }
       }
     },
     "eslint-visitor-keys": {
@@ -7840,8 +8180,7 @@
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "etag": {
       "version": "1.8.1",
@@ -8132,8 +8471,7 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -8160,7 +8498,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
       "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "dev": true,
       "requires": {
         "chardet": "^0.7.0",
         "iconv-lite": "^0.4.24",
@@ -8291,8 +8628,7 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fast-safe-stringify": {
       "version": "2.0.7",
@@ -9485,7 +9821,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       },
@@ -9493,8 +9828,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         }
       }
     },
@@ -10854,8 +11188,7 @@
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "dev": true
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
     },
     "is-property": {
       "version": "1.0.2",
@@ -12452,7 +12785,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
@@ -14815,8 +15147,7 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash._baseclone": {
       "version": "4.5.7",
@@ -20848,7 +21179,6 @@
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
       "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-      "dev": true,
       "requires": {
         "deep-is": "~0.1.3",
         "fast-levenshtein": "~2.0.6",
@@ -20994,8 +21324,7 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "output-file-sync": {
       "version": "1.1.2",
@@ -21704,8 +22033,7 @@
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "prepend-http": {
       "version": "2.0.0",
@@ -22775,7 +23103,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
       "integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
-      "dev": true,
       "requires": {
         "is-promise": "^2.1.0"
       }
@@ -22825,7 +23152,6 @@
       "version": "6.5.5",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
       "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
-      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -23328,8 +23654,7 @@
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-      "dev": true
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "signale": {
       "version": "1.4.0",
@@ -24635,8 +24960,7 @@
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-      "dev": true
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
     "textextensions": {
       "version": "2.6.0",
@@ -24711,7 +25035,6 @@
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
       "requires": {
         "os-tmpdir": "~1.0.2"
       }
@@ -24877,7 +25200,6 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2"
       }
@@ -29332,8 +29654,7 @@
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
     },
     "wordwrap": {
       "version": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "develop": "npm-run-all --parallel start examples:serve examples:watch",
     "start": "webpack-dev-server --config webpack.dev.babel.js",
     "lint": "eslint . --ext .js; exit 0",
+    "lint:nibble": "npx eslint-nibble --ext .js .",
     "manual-test": "webpack-dev-server --open --config webpack.test.babel.js",
     "build": "webpack --config webpack.prod.babel.js --config-name ml5",
     "test": "./node_modules/karma/bin/karma start karma.conf.js",
@@ -121,6 +122,7 @@
     "@tensorflow-models/universal-sentence-encoder": "^1.2.2",
     "@tensorflow/tfjs": "^1.7.0",
     "@tensorflow/tfjs-vis": "^1.1.0",
+    "eslint-nibble": "^5.1.0",
     "events": "^3.0.0",
     "face-api.js": "~0.22.2",
     "onchange": "^6.1.0"

--- a/src/Word2vec/index_test.js
+++ b/src/Word2vec/index_test.js
@@ -58,7 +58,7 @@ describe('word2vec', () => {
           .then(word => word2vecInstance.nearest(word))
           .then((nearest) => {
             let currentDistance = 0;
-            for (let { word, distance: nextDistance } of nearest) {
+            for (const { word, distance: nextDistance } of nearest) {
               expect(typeof word).toEqual('string');
               expect(nextDistance).toBeGreaterThan(currentDistance);
               currentDistance = nextDistance;


### PR DESCRIPTION
This PR adds in this awesome tool called [eslint-nibble](https://www.npmjs.com/package/eslint-nibble) and uses it to begin fixes lint errors in smaller chunks. I'm starting with the prefer-const rule in this PR, so you should see a lot of `let`/`var` lines get switched to `const` if they are not redefined later in the file. Many of these errors are from our examples directory. 

This change should fix about 280 lint errors.

Before
```
✖ 2373 problems (2255 errors, 118 warnings)
  393 errors, 0 warnings potentially fixable with the `--fix` option.
```

After 
```
✖ 2122 problems (1999 errors, 123 warnings)
  129 errors, 0 warnings potentially fixable with the `--fix` option.
```