### PR TITLE
Add no-use-before-define rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,16 @@ module.exports = {
         ml5: false,
         ...p5Globals,
       },
+      rules: {
+        "no-use-before-define": [
+          "error",
+          {
+            functions: false,
+            classes: true,
+            variables: true,
+          },
+        ],
+      },
     },
   ],
 };


### PR DESCRIPTION
### Redo of #958 (changes got lost in a merge conflict)

---

Here's a histogram showing lint errors in our codebase (from a tool I'm introducing in #957.
<img width="836" alt="Screen Shot 2020-05-09 at 11 15 35 AM" src="https://user-images.githubusercontent.com/6589909/81477779-8dc21080-91e7-11ea-858a-0b03211670f7.png">

It's clear that [`no-use-before-define`](https://eslint.org/docs/rules/no-use-before-define) errors are some of the most prominent in our codebase. This seems to be mostly an issue in the `examples/` directory because it seems ingrained into p5 styling to place custom functions after the setup() and draw() functions. Instead of forcing that part of our codebase to comply with these more general JS styles, I think it makes sense to allow functions to be defined in any order for the examples part of our codebase.

The rule I've added specifically only allows functions to slip past this `no-use-before-define` lint error. Classes and variables will still need to be defined before they are used. 

Before
```
✖ 2373 problems (2255 errors, 118 warnings)
  393 errors, 0 warnings potentially fixable with the `--fix` option.
```

After
```
✖ 1835 problems (1717 errors, 118 warnings)
  393 errors, 0 warnings potentially fixable with the `--fix` option.
```