### PR TITLE
Fix unary operator lint errros

### DIFF
--- a/examples/javascript/CVAE/CVAE_QuickDraw/sketch.js
+++ b/examples/javascript/CVAE/CVAE_QuickDraw/sketch.js
@@ -11,21 +11,22 @@ let cvae;
 let img;
 let button;
 let dropdown;
-let canvas, ctx;
+let canvas;
+let ctx;
 const width = 200;
 const height = 200;
 
 async function make() {
   canvas = createCanvas(width, height);
-  ctx = canvas.getContext('2d');
+  ctx = canvas.getContext("2d");
   // Create a new instance with pretrained model
-  cvae = await ml5.CVAE('model/quick_draw/manifest.json', modelReady);
-  
+  cvae = await ml5.CVAE("model/quick_draw/manifest.json", modelReady);
+
   // Create a generate button
-  button = document.createElement('button');
+  button = document.createElement("button");
   button.innerHTML = "generate";
   document.body.appendChild(button);
-  button.addEventListener('click', generateImage);
+  button.addEventListener("click", generateImage);
 }
 
 function generateImage() {
@@ -34,22 +35,22 @@ function generateImage() {
 }
 
 function gotImage(error, result) {
-  if(error){
-    console.log(error)
-    return error
+  if (error) {
+    console.log(error);
+    return error;
   }
-  img = new ImageData(result.raws, 28, 28)
-  const canvasElement = document.createElement("canvas"); 
-  canvasElement.width  = 28;
+  img = new ImageData(result.raws, 28, 28);
+  const canvasElement = document.createElement("canvas");
+  canvasElement.width = 28;
   canvasElement.height = 28;
-  canvasElement_ctx = canvasElement.getContext('2d');
-  canvasElement_ctx.putImageData(img, 0, 0);
+  const canvasElementCtx = canvasElement.getContext("2d");
+  canvasElementCtx.putImageData(img, 0, 0);
   ctx.drawImage(canvasElement, 0, 0, 200, 200);
 }
 
 function modelReady() {
   // Create dropdown with all possible labels
-  dropdown = document.createElement('select');
+  dropdown = document.createElement("select");
   document.body.appendChild(dropdown);
 
   for (const label of cvae.labels) {
@@ -62,14 +63,14 @@ function modelReady() {
 }
 
 // call app.map.init() once the DOM is loaded
-window.addEventListener('DOMContentLoaded', function() {
+window.addEventListener("DOMContentLoaded", function() {
   make();
 });
 
 // Helper Functions
-function createCanvas(w, h){
-  const canvas = document.createElement("canvas"); 
-  canvas.width  = w;
+function createCanvas(w, h) {
+  canvas = document.createElement("canvas");
+  canvas.width = w;
   canvas.height = h;
   document.body.appendChild(canvas);
   return canvas;

--- a/examples/javascript/FaceApi/FaceApi_Video_Landmarks/sketch.js
+++ b/examples/javascript/FaceApi/FaceApi_Video_Landmarks/sketch.js
@@ -59,7 +59,7 @@ function gotResults(err, result) {
 
 function drawBox(detections){
     
-  for(let i = 0; i < detections.length; i++){
+  for(let i = 0; i < detections.length; i += 1){
     const alignedRect = detections[i].alignedRect;
     const x = alignedRect._box._x
     const y = alignedRect._box._y
@@ -78,7 +78,7 @@ function drawBox(detections){
 
 function drawLandmarks(detections){
 
-  for(let i = 0; i < detections.length; i++){
+  for(let i = 0; i < detections.length; i += 1){
     const mouth = detections[i].parts.mouth; 
     const nose = detections[i].parts.nose;
     const leftEye = detections[i].parts.leftEye;
@@ -100,7 +100,7 @@ function drawLandmarks(detections){
 function drawPart(feature, closed){
     
   ctx.beginPath();
-  for(let i = 0; i < feature.length; i++){
+  for(let i = 0; i < feature.length; i += 1){
     const x = feature[i]._x;
     const y = feature[i]._y;
         

--- a/examples/javascript/FaceApi/FaceApi_Video_Landmarks_LocalModels/sketch.js
+++ b/examples/javascript/FaceApi/FaceApi_Video_Landmarks_LocalModels/sketch.js
@@ -63,7 +63,7 @@ function gotResults(err, result) {
 
 function drawBox(detections){
     
-  for(let i = 0; i < detections.length; i++){
+  for(let i = 0; i < detections.length; i += 1){
     const alignedRect = detections[i].alignedRect;
     const x = alignedRect._box._x
     const y = alignedRect._box._y
@@ -82,7 +82,7 @@ function drawBox(detections){
 
 function drawLandmarks(detections){
 
-  for(let i = 0; i < detections.length; i++){
+  for(let i = 0; i < detections.length; i += 1){
     const mouth = detections[i].parts.mouth; 
     const nose = detections[i].parts.nose;
     const leftEye = detections[i].parts.leftEye;
@@ -104,7 +104,7 @@ function drawLandmarks(detections){
 function drawPart(feature, closed){
     
   ctx.beginPath();
-  for(let i = 0; i < feature.length; i++){
+  for(let i = 0; i < feature.length; i += 1){
     const x = feature[i]._x;
     const y = feature[i]._y;
         

--- a/examples/javascript/FeatureExtractor/FeatureExtractor_Image_Regression/sketch.js
+++ b/examples/javascript/FeatureExtractor/FeatureExtractor_Image_Regression/sketch.js
@@ -17,20 +17,20 @@ let samples = 0;
 let ctx;
 const width = 640;
 const height = 480;
-let positionX = width/2;
+let positionX = width / 2;
 
 function map(n, start1, stop1, start2, stop2) {
-  var newval = (n - start1) / (stop1 - start1) * (stop2 - start2) + start2;
+  var newval = ((n - start1) / (stop1 - start1)) * (stop2 - start2) + start2;
   return newval;
-};
+}
 
 async function setup() {
-  canvas = document.querySelector('#myCanvas');
-  ctx = canvas.getContext('2d');
+  canvas = document.querySelector("#myCanvas");
+  ctx = canvas.getContext("2d");
   // Create a video element
   video = await getVideo();
   // Extract the features from MobileNet
-  featureExtractor = ml5.featureExtractor('MobileNet', modelReady);
+  featureExtractor = ml5.featureExtractor("MobileNet", modelReady);
   // Create a new regressor using those features and give the video we want to use
   regressor = featureExtractor.regression(video, videoReady);
   // Create the UI buttons
@@ -41,9 +41,8 @@ setup();
 
 function draw() {
   requestAnimationFrame(draw);
-  
-  ctx.drawImage(video, 0, 0, width, height);
 
+  ctx.drawImage(video, 0, 0, width, height);
 
   ctx.beginPath();
   ctx.rect(positionX, 120, 100, 100);
@@ -53,12 +52,12 @@ function draw() {
 
 // A function to be called when the model has been loaded
 function modelReady() {
-  document.querySelector('#modelStatus').textContent = 'Model loaded!';
+  document.querySelector("#modelStatus").textContent = "Model loaded!";
 }
 
 // A function to be called when the video has loaded
 function videoReady() {
-  document.querySelector('#videoStatus').textContent ='Video ready!';
+  document.querySelector("#videoStatus").textContent = "Video ready!";
 }
 
 // Classify the current frame.
@@ -68,28 +67,28 @@ function predict() {
 
 // A util function to create UI buttons
 function setupButtons() {
-  slider = document.querySelector('#slider');
+  slider = document.querySelector("#slider");
   // When the Dog button is pressed, add the current frame
   // from the video with a label of "dog" to the classifier
-  document.querySelector('#addSample').addEventListener('click',function() {
+  document.querySelector("#addSample").addEventListener("click", function() {
     regressor.addImage(slider.value);
-    document.querySelector('#amountOfSamples').textContent = samples++;
+    document.querySelector("#amountOfSamples").textContent = samples += 1;
   });
 
   // Train Button
-  document.querySelector('#train').addEventListener('click', function() {
+  document.querySelector("#train").addEventListener("click", function() {
     regressor.train(function(lossValue) {
       if (lossValue) {
         loss = lossValue;
-        document.querySelector('#loss').textContent = 'Loss: ' + loss;
+        document.querySelector("#loss").textContent = "Loss: " + loss;
       } else {
-        document.querySelector('#loss').textContent = 'Done Training! Final Loss: ' + loss;
+        document.querySelector("#loss").textContent = "Done Training! Final Loss: " + loss;
       }
     });
   });
 
   // Predict Button
-  document.querySelector('#buttonPredict').addEventListener('click',predict);
+  document.querySelector("#buttonPredict").addEventListener("click", predict);
 }
 
 // Show the results
@@ -104,20 +103,19 @@ function gotResults(err, result) {
   }
 }
 
-
 // Helper Functions
-async function getVideo(){
+async function getVideo() {
   // Grab elements, create settings, etc.
-  const videoElement = document.createElement('video');
-  videoElement.setAttribute("style", "display: none;"); 
+  const videoElement = document.createElement("video");
+  videoElement.setAttribute("style", "display: none;");
   videoElement.width = width;
   videoElement.height = height;
   document.body.appendChild(videoElement);
 
   // Create a webcam capture
-  const capture = await navigator.mediaDevices.getUserMedia({ video: true })
+  const capture = await navigator.mediaDevices.getUserMedia({ video: true });
   videoElement.srcObject = capture;
   videoElement.play();
 
-  return videoElement
+  return videoElement;
 }

--- a/examples/javascript/ImageClassification/ImageClassification_MultipleImages/sketch.js
+++ b/examples/javascript/ImageClassification/ImageClassification_MultipleImages/sketch.js
@@ -45,7 +45,7 @@ setup();
 
 function appendImages(arr) {
   const output = [];
-  for (i = 0; i < arr.length; i++) {
+  for (i = 0; i < arr.length; i += 1) {
     imgPath = arr[i];
     output.push('images/dataset/' + imgPath);
   }

--- a/examples/javascript/ImageClassification/ImageClassification_VideoScavengerHunt/sketch.js
+++ b/examples/javascript/ImageClassification/ImageClassification_VideoScavengerHunt/sketch.js
@@ -14,14 +14,14 @@ let video;
 let currentWord;
 let currentIndex = 0;
 let isPlaying = false;
-const words = ['banana', 'watch', 'shoe', 'book', 'cellphone', 'keyboard', 'shirt', 'pants', 'cup'];
+const words = ["banana", "watch", "shoe", "book", "cellphone", "keyboard", "shirt", "pants", "cup"];
 const width = 640;
-const height= 480;
+const height = 480;
 let result;
 
 // adapted from https://github.com/IDMNYU/p5.js-speech/blob/master/lib/p5.speech.js
 class MySpeech {
-  constructor(){
+  constructor() {
     this.interrupt = false;
     // make an utterance to use with this synthesizer:
     this.utterance = new SpeechSynthesisUtterance();
@@ -31,17 +31,16 @@ class MySpeech {
     this.onEnd;
   }
 
-  speak(_phrase){
-    if(this.interrupt) this.synth.cancel();
+  speak(_phrase) {
+    if (this.interrupt) this.synth.cancel();
     this.utterance.text = _phrase;
 
     this.synth.speak(this.utterance);
   }
-  
+
   ended(_cb) {
     this.onEnd = _cb;
   }
-
 }
 
 let myVoice;
@@ -50,19 +49,19 @@ async function setup() {
   // Create a camera input
   video = await getVideo();
   // Initialize the Image Classifier method with MobileNet and the video as the second argument
-  classifier = ml5.imageClassifier('MobileNet', video, modelReady);
+  classifier = ml5.imageClassifier("MobileNet", video, modelReady);
 
   // Create a new p5.speech object
   // You can also control the Language, Rate, Pitch and Volumn of the voice
   // Read more at http://ability.nyu.edu/p5.js-speech/
   myVoice = new MySpeech();
 
-  document.querySelector('#start').addEventListener('click',function() {
+  document.querySelector("#start").addEventListener("click", function() {
     playNextWord();
   });
 
-  document.querySelector('#next').addEventListener('click',function() {
-    currentIndex++;
+  document.querySelector("#next").addEventListener("click", function() {
+    currentIndex += 1;
     if (currentIndex >= words.length) {
       currentIndex = 0;
     }
@@ -72,7 +71,6 @@ async function setup() {
   // speechEnded function will be called when an utterance is finished
   // Read more at p5.speech's onEnd property: http://ability.nyu.edu/p5.js-speech/
   myVoice.onEnd = speechEnded;
-
 }
 
 setup();
@@ -80,14 +78,14 @@ setup();
 function playNextWord() {
   isPlaying = true;
   currentWord = words[currentIndex];
-  document.querySelector('#instruction').textContent = `Go find ${currentWord}!`;
+  document.querySelector("#instruction").textContent = `Go find ${currentWord}!`;
   // Call the classifyVideo function to start classifying the video
   classifyVideo();
 }
 
 function modelReady() {
   // Change the status of the model once its ready
-  document.querySelector('#status').textContent = 'Model Loaded';
+  document.querySelector("#status").textContent = "Model Loaded";
 }
 
 // Get a prediction for the current video frame
@@ -101,43 +99,42 @@ function gotResult(err, results) {
   // Get the first result string
   result = results[0].label;
   // Split the first result string by coma and get the first word
-  const oneWordRes = result.split(',')[0];
+  const oneWordRes = result.split(",")[0];
   // Get the top 3 results as strings in an array
   // Read more about map function here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map
   const top3Res = results.map(r => r.label);
   // Find if any of the top 3 result strings includes the current word
   // Read more about find function here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find
-  const ifFound = top3Res.find(r => r.includes(currentWord))
+  const ifFound = top3Res.find(r => r.includes(currentWord));
   if (ifFound) {
     // If top 3 results includes the current word
     isPlaying = false;
-    document.querySelector('#message').textContent =`You found ${currentWord}!`;
+    document.querySelector("#message").textContent = `You found ${currentWord}!`;
     myVoice.speak(`You found ${currentWord}!`);
   } else {
-    document.querySelector('#message').textContent =`I see ${oneWordRes}`;
+    document.querySelector("#message").textContent = `I see ${oneWordRes}`;
     myVoice.speak(`I see ${oneWordRes}`);
   }
-  classifyVideo()
+  classifyVideo();
 }
 
 function speechEnded() {
   if (isPlaying) classifyVideo();
 }
 
-
 // Helper Functions
-async function getVideo(){
+async function getVideo() {
   // Grab elements, create settings, etc.
-  const videoElement = document.createElement('video');
-  // videoElement.setAttribute("style", "display: none;"); 
+  const videoElement = document.createElement("video");
+  // videoElement.setAttribute("style", "display: none;");
   videoElement.width = width;
   videoElement.height = height;
   document.body.appendChild(videoElement);
 
   // Create a webcam capture
-  const capture = await navigator.mediaDevices.getUserMedia({ video: true })
+  const capture = await navigator.mediaDevices.getUserMedia({ video: true });
   videoElement.srcObject = capture;
   videoElement.play();
 
-  return videoElement
+  return videoElement;
 }

--- a/examples/javascript/KNNClassification/KNNClassification_PoseNet/sketch.js
+++ b/examples/javascript/KNNClassification/KNNClassification_PoseNet/sketch.js
@@ -161,7 +161,7 @@ function clearAllLabels() {
 // A function to draw ellipses over the detected keypoints
 function drawKeypoints()  {
   // Loop through all the poses detected
-  for (let i = 0; i < poses.length; i++) {
+  for (let i = 0; i < poses.length; i += 1) {
     // For each pose detected, loop through all the keypoints
     const pose = poses[i].pose;
     for (let j = 0; j < pose.keypoints.length; j++) {
@@ -182,7 +182,7 @@ function drawKeypoints()  {
 // A function to draw the skeletons
 function drawSkeleton() {
   // Loop through all the skeletons detected
-  for (let i = 0; i < poses.length; i++) {
+  for (let i = 0; i < poses.length; i += 1) {
     const skeleton = poses[i].skeleton;
     // For every skeleton, loop through all body connections
     for (let j = 0; j < skeleton.length; j++) {

--- a/examples/javascript/KNNClassification/KNNClassification_PoseNet/sketch.js
+++ b/examples/javascript/KNNClassification/KNNClassification_PoseNet/sketch.js
@@ -19,10 +19,9 @@ let ctx;
 
 async function setup() {
   canvas = document.querySelector("#myCanvas");
-  ctx = canvas.getContext('2d');
-  
+  ctx = canvas.getContext("2d");
+
   video = await getVideo();
-  
 
   // Create the UI buttons
   createButtons();
@@ -31,27 +30,27 @@ async function setup() {
   poseNet = ml5.poseNet(video, modelReady);
   // This sets up an event that fills the global variable "poses"
   // with an array every time new poses are detected
-  poseNet.on('pose', function(results) {
+  poseNet.on("pose", function(results) {
     poses = results;
   });
-  
-  requestAnimationFrame(draw)
+
+  requestAnimationFrame(draw);
 }
 
 setup();
 
 function draw() {
-  requestAnimationFrame(draw)
+  requestAnimationFrame(draw);
 
-  ctx.drawImage(video, 0, 0, width, height)
+  ctx.drawImage(video, 0, 0, width, height);
 
   // We can call both functions to draw all keypoints and the skeletons
   drawKeypoints();
   drawSkeleton();
 }
 
-function modelReady(){
-  document.querySelector('#status').textContent = 'model Loaded'
+function modelReady() {
+  document.querySelector("#status").textContent = "model Loaded";
 }
 
 // Add the current frame from the video to the classifier
@@ -69,7 +68,7 @@ function classify() {
   // Get the total number of labels from knnClassifier
   const numLabels = knnClassifier.getNumLabels();
   if (numLabels <= 0) {
-    console.error('There is no examples in any label');
+    console.error("There is no examples in any label");
     return;
   }
   // Convert poses results to a 2d array [[score0, x0, y0],...,[score16, x16, y16]]
@@ -84,36 +83,36 @@ function classify() {
 function createButtons() {
   // When the A button is pressed, add the current frame
   // from the video with a label of "A" to the classifier
-  buttonA = document.querySelector('#addClassA');
-  buttonA.addEventListener('click', function() {
-    addExample('A');
+  buttonA = document.querySelector("#addClassA");
+  buttonA.addEventListener("click", function() {
+    addExample("A");
   });
 
   // When the B button is pressed, add the current frame
   // from the video with a label of "B" to the classifier
-  buttonB = document.querySelector('#addClassB');
-  buttonB.addEventListener('click',function() {
-    addExample('B');
+  buttonB = document.querySelector("#addClassB");
+  buttonB.addEventListener("click", function() {
+    addExample("B");
   });
 
   // Reset buttons
-  resetBtnA = document.querySelector('#resetA');
-  resetBtnA.addEventListener('click',function() {
-    clearLabel('A');
+  resetBtnA = document.querySelector("#resetA");
+  resetBtnA.addEventListener("click", function() {
+    clearLabel("A");
   });
-	
-  resetBtnB = document.querySelector('#resetB');
-  resetBtnB.addEventListener('click',function() {
-    clearLabel('B');
+
+  resetBtnB = document.querySelector("#resetB");
+  resetBtnB.addEventListener("click", function() {
+    clearLabel("B");
   });
 
   // Predict button
-  buttonPredict = document.querySelector('#buttonPredict');
-  buttonPredict.addEventListener('click',classify);
+  buttonPredict = document.querySelector("#buttonPredict");
+  buttonPredict.addEventListener("click", classify);
 
   // Clear all classes button
-  buttonClearAll = document.querySelector('#clearAll');
-  buttonClearAll.addEventListener('click',clearAllLabels);
+  buttonClearAll = document.querySelector("#clearAll");
+  buttonClearAll.addEventListener("click", clearAllLabels);
 }
 
 // Show the results
@@ -127,23 +126,27 @@ function gotResults(err, result) {
     const confidences = result.confidencesByLabel;
     // result.label is the label that has the highest confidence
     if (result.label) {
-      document.querySelector('#result').textContent = result.label;
-      document.querySelector('#confidence').textContent = `${confidences[result.label] * 100} %`;
+      document.querySelector("#result").textContent = result.label;
+      document.querySelector("#confidence").textContent = `${confidences[result.label] * 100} %`;
     }
 
-    document.querySelector('#confidenceA').textContent = `${confidences['A'] ? confidences['A'] * 100 : 0} %`;
-    document.querySelector('#confidenceB').textContent = `${confidences['B'] ? confidences['B'] * 100 : 0} %`;
+    document.querySelector("#confidenceA").textContent = `${
+      confidences["A"] ? confidences["A"] * 100 : 0
+    } %`;
+    document.querySelector("#confidenceB").textContent = `${
+      confidences["B"] ? confidences["B"] * 100 : 0
+    } %`;
   }
 
   classify();
 }
 
-// Update the example count for each label	
+// Update the example count for each label
 function updateCounts() {
   const counts = knnClassifier.getCountByLabel();
 
-  document.querySelector('#exampleA').textContent = counts['A'] || 0;
-  document.querySelector('#exampleB').textContent = counts['B'] || 0;
+  document.querySelector("#exampleA").textContent = counts["A"] || 0;
+  document.querySelector("#exampleB").textContent = counts["B"] || 0;
 }
 
 // Clear the examples in one label
@@ -159,21 +162,21 @@ function clearAllLabels() {
 }
 
 // A function to draw ellipses over the detected keypoints
-function drawKeypoints()  {
+function drawKeypoints() {
   // Loop through all the poses detected
   for (let i = 0; i < poses.length; i += 1) {
     // For each pose detected, loop through all the keypoints
     const pose = poses[i].pose;
-    for (let j = 0; j < pose.keypoints.length; j++) {
+    for (let j = 0; j < pose.keypoints.length; j += 1) {
       // A keypoint is an object describing a body part (like rightArm or leftShoulder)
       const keypoint = pose.keypoints[j];
       // Only draw an ellipse is the pose probability is bigger than 0.2
       if (keypoint.score > 0.2) {
-        ctx.fillStyle = 'rgb(213, 0, 143)';
+        ctx.fillStyle = "rgb(213, 0, 143)";
         ctx.beginPath();
         ctx.arc(keypoint.position.x, keypoint.position.y, 10, 0, 2 * Math.PI);
         ctx.fill();
-        ctx.stroke(); 
+        ctx.stroke();
       }
     }
   }
@@ -185,32 +188,31 @@ function drawSkeleton() {
   for (let i = 0; i < poses.length; i += 1) {
     const skeleton = poses[i].skeleton;
     // For every skeleton, loop through all body connections
-    for (let j = 0; j < skeleton.length; j++) {
+    for (let j = 0; j < skeleton.length; j += 1) {
       const partA = skeleton[j][0];
       const partB = skeleton[j][1];
       ctx.beginPath();
       ctx.moveTo(partA.position.x, partA.position.y);
       ctx.lineTo(partB.position.x, partB.position.y);
-      ctx.strokeStyle = '#FF0000'
+      ctx.strokeStyle = "#FF0000";
       ctx.stroke();
     }
   }
 }
 
-
 // Helper Functions
-async function getVideo(){
+async function getVideo() {
   // Grab elements, create settings, etc.
-  const videoElement = document.createElement('video');
-  videoElement.setAttribute("style", "display: none;"); 
+  const videoElement = document.createElement("video");
+  videoElement.setAttribute("style", "display: none;");
   videoElement.width = width;
   videoElement.height = height;
   document.body.appendChild(videoElement);
 
   // Create a webcam capture
-  const capture = await navigator.mediaDevices.getUserMedia({ video: true })
+  const capture = await navigator.mediaDevices.getUserMedia({ video: true });
   videoElement.srcObject = capture;
   videoElement.play();
 
-  return videoElement
+  return videoElement;
 }

--- a/examples/javascript/ObjectDetector/COCOSSD_single_image/sketch.js
+++ b/examples/javascript/ObjectDetector/COCOSSD_single_image/sketch.js
@@ -57,7 +57,7 @@ function draw() {
   ctx.fillRect(0, 0, width, height);
 
   ctx.drawImage(img, 0, 0);
-  for (let i = 0; i < objects.length; i++) {
+  for (let i = 0; i < objects.length; i += 1) {
 
     ctx.font = "16px Arial";
     ctx.fillStyle = "green";

--- a/examples/javascript/ObjectDetector/COCOSSD_webcam/sketch.js
+++ b/examples/javascript/ObjectDetector/COCOSSD_webcam/sketch.js
@@ -58,7 +58,7 @@ function draw(){
   ctx.fillRect(0,0, width, height);
 
   ctx.drawImage(video, 0, 0);
-  for (let i = 0; i < objects.length; i++) {
+  for (let i = 0; i < objects.length; i += 1) {
       
     ctx.font = "16px Arial";
     ctx.fillStyle = "green";

--- a/examples/javascript/ObjectDetector/YOLO_single_image/sketch.js
+++ b/examples/javascript/ObjectDetector/YOLO_single_image/sketch.js
@@ -57,7 +57,7 @@ function draw(){
   ctx.fillRect(0,0, width, height);
 
   ctx.drawImage(img, 0, 0);
-  for (let i = 0; i < objects.length; i++) {
+  for (let i = 0; i < objects.length; i += 1) {
       
     ctx.font = "16px Arial";
     ctx.fillStyle = "green";

--- a/examples/javascript/ObjectDetector/YOLO_webcam/sketch.js
+++ b/examples/javascript/ObjectDetector/YOLO_webcam/sketch.js
@@ -56,7 +56,7 @@ function draw(){
   ctx.fillRect(0,0, width, height);
 
   ctx.drawImage(video, 0, 0);
-  for (let i = 0; i < objects.length; i++) {
+  for (let i = 0; i < objects.length; i += 1) {
       
     ctx.font = "16px Arial";
     ctx.fillStyle = "green";

--- a/examples/javascript/PitchDetection/PitchDetection_Piano/sketch.js
+++ b/examples/javascript/PitchDetection/PitchDetection_Piano/sketch.js
@@ -93,7 +93,7 @@ function drawKeyboard() {
 
 
   // White keys
-  for (let i = 0; i < scale.length; i++) {
+  for (let i = 0; i < scale.length; i += 1) {
     if (scale[i].indexOf('#') == -1) {
       
 
@@ -113,7 +113,7 @@ function drawKeyboard() {
   whiteKeyCounter = 0;
 
   // Black keys
-  for (let i = 0; i < scale.length; i++) {
+  for (let i = 0; i < scale.length; i += 1) {
     if (scale[i].indexOf('#') > -1) {
       
       ctx.beginPath();

--- a/examples/javascript/PitchDetection/PitchDetection_Piano/sketch.js
+++ b/examples/javascript/PitchDetection/PitchDetection_Piano/sketch.js
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 ml5
-// 
+//
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
@@ -18,8 +18,8 @@ const cornerCoords = [10, 40];
 const rectWidth = 90;
 const rectHeight = 300;
 const keyRatio = 0.58;
-const scale = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
-let currentNote = '';
+const scale = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+let currentNote = "";
 
 let canvas, ctx;
 
@@ -31,36 +31,34 @@ function freqToMidi(f) {
   var mathlog2 = Math.log(f / 440) / Math.log(2);
   var m = Math.round(12 * mathlog2) + 69;
   return m;
-};
+}
 
 function map(n, start1, stop1, start2, stop2) {
-  var newval = (n - start1) / (stop1 - start1) * (stop2 - start2) + start2;
+  var newval = ((n - start1) / (stop1 - start1)) * (stop2 - start2) + start2;
   return newval;
-};
+}
 
 async function setup() {
-  canvas = document.querySelector('#myCanvas');
-  ctx = canvas.getContext('2d');
+  canvas = document.querySelector("#myCanvas");
+  ctx = canvas.getContext("2d");
 
   audioContext = new AudioContext();
   stream = await navigator.mediaDevices.getUserMedia({
     audio: true,
-    video: false
+    video: false,
   });
   startPitch(stream, audioContext);
 
   requestAnimationFrame(draw);
 }
-setup()
-
+setup();
 
 function startPitch(stream, audioContext) {
-  pitch = ml5.pitchDetection('./model/', audioContext, stream, modelLoaded);
+  pitch = ml5.pitchDetection("./model/", audioContext, stream, modelLoaded);
 }
 
-
 function modelLoaded() {
-  document.querySelector('#status').textContent = 'Model Loaded';
+  document.querySelector("#status").textContent = "Model Loaded";
   getPitch();
 }
 
@@ -71,7 +69,7 @@ function getPitch() {
       currentNote = scale[midiNum % 12];
     }
     getPitch();
-  })
+  });
 }
 
 function draw() {
@@ -83,49 +81,54 @@ function drawKeyboard() {
   let whiteKeyCounter = 0;
 
   ctx.beginPath();
-  ctx.rect(0,0, width, height);
+  ctx.rect(0, 0, width, height);
   ctx.fillStyle = "white";
   ctx.fill();
-  
+
   // background(255);
   // strokeWeight(2);
   // stroke(50);
 
-
   // White keys
   for (let i = 0; i < scale.length; i += 1) {
-    if (scale[i].indexOf('#') == -1) {
-      
-
+    if (scale[i].indexOf("#") === -1) {
       ctx.beginPath();
-      ctx.rect(cornerCoords[0] + (whiteKeyCounter * rectWidth), cornerCoords[1], rectWidth, rectHeight);
-      if (scale[i] == currentNote) {
+      ctx.rect(
+        cornerCoords[0] + whiteKeyCounter * rectWidth,
+        cornerCoords[1],
+        rectWidth,
+        rectHeight,
+      );
+      if (scale[i] === currentNote) {
         ctx.fillStyle = "rgb(50, 50, 50)";
-        
       } else {
         ctx.fillStyle = "rgb(250, 250, 250)";
       }
       ctx.fill();
-      
-      whiteKeyCounter++;
+
+      whiteKeyCounter += 1;
     }
   }
   whiteKeyCounter = 0;
 
   // Black keys
   for (let i = 0; i < scale.length; i += 1) {
-    if (scale[i].indexOf('#') > -1) {
-      
+    if (scale[i].indexOf("#") > -1) {
       ctx.beginPath();
-      ctx.rect(cornerCoords[0] + (whiteKeyCounter * rectWidth) - (rectWidth / 3), cornerCoords[1], rectWidth * keyRatio, rectHeight * keyRatio);
-      if (scale[i] == currentNote) {
+      ctx.rect(
+        cornerCoords[0] + whiteKeyCounter * rectWidth - rectWidth / 3,
+        cornerCoords[1],
+        rectWidth * keyRatio,
+        rectHeight * keyRatio,
+      );
+      if (scale[i] === currentNote) {
         ctx.fillStyle = "rgb(100, 100, 100)";
       } else {
         ctx.fillStyle = "rgb(0, 0, 0)";
       }
       ctx.fill();
     } else {
-      whiteKeyCounter++;
+      whiteKeyCounter += 1;
     }
   }
 }

--- a/examples/javascript/PoseNet/PoseNet_image_single/sketch.js
+++ b/examples/javascript/PoseNet/PoseNet_image_single/sketch.js
@@ -61,7 +61,7 @@ function draw() {
 // A function to draw ellipses over the detected keypoints
 function drawKeypoints()  {
   // Loop through all the poses detected
-  for (let i = 0; i < poses.length; i++) {
+  for (let i = 0; i < poses.length; i += 1) {
     // For each pose detected, loop through all the keypoints
     for (let j = 0; j < poses[i].pose.keypoints.length; j++) {
       const keypoint = poses[i].pose.keypoints[j];
@@ -81,7 +81,7 @@ function drawKeypoints()  {
 // A function to draw the skeletons
 function drawSkeleton() {
   // Loop through all the skeletons detected
-  for (let i = 0; i < poses.length; i++) {
+  for (let i = 0; i < poses.length; i += 1) {
     // For every skeleton, loop through all body connections
     for (let j = 0; j < poses[i].skeleton.length; j++) {
       const partA = poses[i].skeleton[j][0];

--- a/examples/javascript/PoseNet/PoseNet_image_single/sketch.js
+++ b/examples/javascript/PoseNet/PoseNet_image_single/sketch.js
@@ -17,79 +17,76 @@ let ctx;
 
 async function setup() {
   // Grab elements, create settings, etc.
-  img = document.getElementById('image');
+  img = document.getElementById("image");
 
-  canvas = document.getElementById('canvas');
+  canvas = document.getElementById("canvas");
   canvas.width = 640;
   canvas.height = 360;
-  ctx = canvas.getContext('2d');
+  ctx = canvas.getContext("2d");
 
   // Create a new poseNet method with a single detection
   poseNet = await ml5.poseNet(modelReady);
   // This sets up an event that fills the global variable "poses"
   // with an array every time new poses are detected
-  poseNet.on('pose', function(results) {
+  poseNet.on("pose", function(results) {
     poses = results;
   });
-  
+
   requestAnimationFrame(draw);
 }
 
 setup();
 
 function modelReady() {
-  console.log('model loaded!')
-  poseNet.singlePose(img)
+  console.log("model loaded!");
+  poseNet.singlePose(img);
 }
-
 
 function draw() {
   requestAnimationFrame(draw);
-  
-  
+
   ctx.drawImage(img, 0, 0, img.width, img.height);
   // We can call both functions to draw all keypoints and the skeletons
-  
 
   // For one pose only (use a for loop for multiple poses!)
   if (poses.length > 0) {
-    drawKeypoints()
-    drawSkeleton()
+    drawKeypoints();
+    drawSkeleton();
   }
 }
 
 // A function to draw ellipses over the detected keypoints
-function drawKeypoints()  {
+function drawKeypoints() {
   // Loop through all the poses detected
   for (let i = 0; i < poses.length; i += 1) {
     // For each pose detected, loop through all the keypoints
-    for (let j = 0; j < poses[i].pose.keypoints.length; j++) {
+    for (let j = 0; j < poses[i].pose.keypoints.length; j += 1) {
       const keypoint = poses[i].pose.keypoints[j];
       // Only draw an ellipse is the pose probability is bigger than 0.2
       if (keypoint.score > 0.2) {
-        ctx.fillStyle = '#FFFFFF'
+        ctx.fillStyle = "#FFFFFF";
         ctx.beginPath();
         ctx.arc(keypoint.position.x, keypoint.position.y, 6, 0, 2 * Math.PI);
         ctx.stroke();
-        ctx.strokeStyle = '#00FF00'
+        ctx.strokeStyle = "#00FF00";
         ctx.fill();
       }
     }
   }
 }
-  
+
 // A function to draw the skeletons
 function drawSkeleton() {
   // Loop through all the skeletons detected
   for (let i = 0; i < poses.length; i += 1) {
     // For every skeleton, loop through all body connections
-    for (let j = 0; j < poses[i].skeleton.length; j++) {
+    for (let j = 0; j < poses[i].skeleton.length; j += 1) {
       const partA = poses[i].skeleton[j][0];
       const partB = poses[i].skeleton[j][1];
       ctx.beginPath();
       ctx.moveTo(partA.position.x, partA.position.y);
       ctx.lineTo(partB.position.x, partB.position.y);
-      ctx.strokeStyle = '#FFFFFF'
+      ctx.strokeStyle = "#FFFFFF";
       ctx.stroke();
     }
   }

--- a/examples/javascript/PoseNet/PoseNet_webcam/sketch.js
+++ b/examples/javascript/PoseNet/PoseNet_webcam/sketch.js
@@ -10,9 +10,9 @@ PoseNet using p5.js
 /* eslint-disable */
 
 // Grab elements, create settings, etc.
-var video = document.getElementById('video');
-var canvas = document.getElementById('canvas');
-var ctx = canvas.getContext('2d');
+var video = document.getElementById("video");
+var canvas = document.getElementById("canvas");
+var ctx = canvas.getContext("2d");
 
 // The detected positions will be inside an array
 let poses = [];
@@ -20,14 +20,14 @@ let poses = [];
 // Create a webcam capture
 if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
   navigator.mediaDevices.getUserMedia({ video: true }).then(function(stream) {
-    video.srcObject=stream;
+    video.srcObject = stream;
     video.play();
   });
 }
 
 // A function to draw the video and poses into the canvas.
 // This function is independent of the result of posenet
-// This way the video will not seem slow if poseNet 
+// This way the video will not seem slow if poseNet
 // is not detecting a position
 function drawCameraIntoCanvas() {
   // Draw the video element into the canvas
@@ -42,7 +42,7 @@ drawCameraIntoCanvas();
 
 // Create a new poseNet method with a single detection
 const poseNet = ml5.poseNet(video, modelReady);
-poseNet.on('pose', gotPoses);
+poseNet.on("pose", gotPoses);
 
 // A function that gets called every time there's an update from the model
 function gotPoses(results) {
@@ -50,16 +50,16 @@ function gotPoses(results) {
 }
 
 function modelReady() {
-  console.log("model ready")
-  poseNet.multiPose(video)
+  console.log("model ready");
+  poseNet.multiPose(video);
 }
 
 // A function to draw ellipses over the detected keypoints
-function drawKeypoints()  {
+function drawKeypoints() {
   // Loop through all the poses detected
   for (let i = 0; i < poses.length; i += 1) {
     // For each pose detected, loop through all the keypoints
-    for (let j = 0; j < poses[i].pose.keypoints.length; j++) {
+    for (let j = 0; j < poses[i].pose.keypoints.length; j += 1) {
       let keypoint = poses[i].pose.keypoints[j];
       // Only draw an ellipse is the pose probability is bigger than 0.2
       if (keypoint.score > 0.2) {
@@ -76,7 +76,7 @@ function drawSkeleton() {
   // Loop through all the skeletons detected
   for (let i = 0; i < poses.length; i += 1) {
     // For every skeleton, loop through all body connections
-    for (let j = 0; j < poses[i].skeleton.length; j++) {
+    for (let j = 0; j < poses[i].skeleton.length; j += 1) {
       let partA = poses[i].skeleton[j][0];
       let partB = poses[i].skeleton[j][1];
       ctx.beginPath();

--- a/examples/javascript/PoseNet/PoseNet_webcam/sketch.js
+++ b/examples/javascript/PoseNet/PoseNet_webcam/sketch.js
@@ -57,7 +57,7 @@ function modelReady() {
 // A function to draw ellipses over the detected keypoints
 function drawKeypoints()  {
   // Loop through all the poses detected
-  for (let i = 0; i < poses.length; i++) {
+  for (let i = 0; i < poses.length; i += 1) {
     // For each pose detected, loop through all the keypoints
     for (let j = 0; j < poses[i].pose.keypoints.length; j++) {
       let keypoint = poses[i].pose.keypoints[j];
@@ -74,7 +74,7 @@ function drawKeypoints()  {
 // A function to draw the skeletons
 function drawSkeleton() {
   // Loop through all the skeletons detected
-  for (let i = 0; i < poses.length; i++) {
+  for (let i = 0; i < poses.length; i += 1) {
     // For every skeleton, loop through all body connections
     for (let j = 0; j < poses[i].skeleton.length; j++) {
       let partA = poses[i].skeleton[j][0];

--- a/examples/javascript/Word2Vec/Word2Vec_Interactive/sketch.js
+++ b/examples/javascript/Word2Vec/Word2Vec_Interactive/sketch.js
@@ -41,7 +41,7 @@ function setup() {
     word2Vec.nearest(word, (err, result) => {
       let output = '';
       if (result) {
-        for (let i = 0; i < result.length; i++) {
+        for (let i = 0; i < result.length; i += 1) {
           output += result[i].word + '<br/>';
         }
       } else {

--- a/examples/javascript/YOLO/YOLO_single_image/sketch.js
+++ b/examples/javascript/YOLO/YOLO_single_image/sketch.js
@@ -57,7 +57,7 @@ function draw(){
   ctx.fillRect(0,0, width, height);
 
   ctx.drawImage(img, 0, 0);
-  for (let i = 0; i < objects.length; i++) {
+  for (let i = 0; i < objects.length; i += 1) {
       
     ctx.font = "16px Arial";
     ctx.fillStyle = "green";

--- a/examples/javascript/YOLO/YOLO_webcam/sketch.js
+++ b/examples/javascript/YOLO/YOLO_webcam/sketch.js
@@ -56,7 +56,7 @@ function draw(){
   ctx.fillRect(0,0, width, height);
 
   ctx.drawImage(video, 0, 0);
-  for (let i = 0; i < objects.length; i++) {
+  for (let i = 0; i < objects.length; i += 1) {
       
     ctx.font = "16px Arial";
     ctx.fillStyle = "green";

--- a/examples/p5js/DCGAN/DCGAN_LatentVector_RandomWalk/sketch.js
+++ b/examples/p5js/DCGAN/DCGAN_LatentVector_RandomWalk/sketch.js
@@ -20,7 +20,7 @@ function setup() {
   createCanvas(600, 600);
 
   // start with random vector
-  for (let i = 0; i < 128; i++) {
+  for (let i = 0; i < 128; i += 1) {
     vector[i] = random(-1, 1);
   }
 
@@ -30,7 +30,7 @@ function setup() {
 
 
 function walk() {
-  for (let i = 0; i < 128; i++) {
+  for (let i = 0; i < 128; i += 1) {
     vector[i] += random(-0.01, 0.01);
   }
 }

--- a/examples/p5js/DCGAN/DCGAN_LatentVector_Slider/sketch.js
+++ b/examples/p5js/DCGAN/DCGAN_LatentVector_Slider/sketch.js
@@ -27,7 +27,7 @@ function setup() {
   createCanvas(600, 600);
 
   // create 2 arrays to hold random values for our latent vector
-  for (let i = 0; i < 128; i++) {
+  for (let i = 0; i < 128; i += 1) {
     a[i] = random(-1, 1);
     b[i] = random(-1, 1);
   }
@@ -42,7 +42,7 @@ function setup() {
 function generate() {
   const amt = slider.value();
   // fill the latent vector with the interpolation between a and b
-  for (let i = 0; i < 128; i++) {
+  for (let i = 0; i < 128; i += 1) {
     c[i] = lerp(a[i], b[i], amt);
   }
   dcgan.generate(displayImage, c);

--- a/examples/p5js/FaceApi/FaceApi_Video_Landmarks/sketch.js
+++ b/examples/p5js/FaceApi/FaceApi_Video_Landmarks/sketch.js
@@ -47,7 +47,7 @@ function gotResults(err, result) {
 }
 
 function drawBox(detections) {
-  for (let i = 0; i < detections.length; i++) {
+  for (let i = 0; i < detections.length; i += 1) {
     const alignedRect = detections[i].alignedRect;
     const x = alignedRect._box._x;
     const y = alignedRect._box._y;
@@ -66,7 +66,7 @@ function drawLandmarks(detections) {
   stroke(161, 95, 251);
   strokeWeight(2);
 
-  for (let i = 0; i < detections.length; i++) {
+  for (let i = 0; i < detections.length; i += 1) {
     const mouth = detections[i].parts.mouth;
     const nose = detections[i].parts.nose;
     const leftEye = detections[i].parts.leftEye;
@@ -85,7 +85,7 @@ function drawLandmarks(detections) {
 
 function drawPart(feature, closed) {
   beginShape();
-  for (let i = 0; i < feature.length; i++) {
+  for (let i = 0; i < feature.length; i += 1) {
     const x = feature[i]._x;
     const y = feature[i]._y;
     vertex(x, y);

--- a/examples/p5js/FaceApi/FaceApi_Video_Landmarks_LocalModels/sketch.js
+++ b/examples/p5js/FaceApi/FaceApi_Video_Landmarks_LocalModels/sketch.js
@@ -53,7 +53,7 @@ function gotResults(err, result) {
 }
 
 function drawBox(detections){
-  for(let i = 0; i < detections.length; i++){
+  for(let i = 0; i < detections.length; i += 1){
     const alignedRect = detections[i].alignedRect;
     const x = alignedRect._box._x
     const y = alignedRect._box._y
@@ -73,7 +73,7 @@ function drawLandmarks(detections){
   stroke(161, 95, 251)
   strokeWeight(2)
 
-  for(let i = 0; i < detections.length; i++){
+  for(let i = 0; i < detections.length; i += 1){
     const mouth = detections[i].parts.mouth; 
     const nose = detections[i].parts.nose;
     const leftEye = detections[i].parts.leftEye;
@@ -95,7 +95,7 @@ function drawLandmarks(detections){
 function drawPart(feature, closed){
     
   beginShape();
-  for(let i = 0; i < feature.length; i++){
+  for(let i = 0; i < feature.length; i += 1){
     const x = feature[i]._x
     const y = feature[i]._y
     vertex(x, y)

--- a/examples/p5js/FeatureExtractor/FeatureExtractor_Image_Classification/sketch.js
+++ b/examples/p5js/FeatureExtractor/FeatureExtractor_Image_Classification/sketch.js
@@ -21,11 +21,11 @@ function setup() {
   noCanvas();
   // Create a video element
   video = createCapture(VIDEO);
-  video.parent('videoContainer');
+  video.parent("videoContainer");
   video.size(320, 240);
 
   // Extract the already learned features from MobileNet
-  featureExtractor = ml5.featureExtractor('MobileNet', modelReady);
+  featureExtractor = ml5.featureExtractor("MobileNet", modelReady);
 
   // Create a new classifier using those features and give the video we want to use
   const options = { numLabels: 3 };
@@ -36,7 +36,7 @@ function setup() {
 
 // A function to be called when the model has been loaded
 function modelReady() {
-  select('#modelStatus').html('MobileNet Loaded!');
+  select("#modelStatus").html("MobileNet Loaded!");
   // If you want to load a pre-trained model at the start
   // classifier.load('./model/model.json', function() {
   //   select('#modelStatus').html('Custom Model Loaded!');
@@ -52,56 +52,56 @@ function classify() {
 function setupButtons() {
   // When the Cat button is pressed, add the current frame
   // from the video with a label of "cat" to the classifier
-  buttonA = select('#catButton');
+  buttonA = select("#catButton");
   buttonA.mousePressed(function() {
-    classifier.addImage('cat');
-    select('#amountOfCatImages').html(catImages++);
+    classifier.addImage("cat");
+    select("#amountOfCatImages").html((catImages += 1));
   });
 
   // When the Dog button is pressed, add the current frame
   // from the video with a label of "dog" to the classifier
-  buttonB = select('#dogButton');
+  buttonB = select("#dogButton");
   buttonB.mousePressed(function() {
-    classifier.addImage('dog');
-    select('#amountOfDogImages').html(dogImages++);
+    classifier.addImage("dog");
+    select("#amountOfDogImages").html((dogImages += 1));
   });
 
   // When the Dog button is pressed, add the current frame
   // from the video with a label of "dog" to the classifier
-  buttonC = select('#badgerButton');
+  buttonC = select("#badgerButton");
   buttonC.mousePressed(function() {
-    classifier.addImage('badger');
-    select('#amountOfBadgerImages').html(badgerImages++);
+    classifier.addImage("badger");
+    select("#amountOfBadgerImages").html((badgerImages += 1));
   });
 
   // Train Button
-  train = select('#train');
+  train = select("#train");
   train.mousePressed(function() {
     classifier.train(function(lossValue) {
       if (lossValue) {
         loss = lossValue;
-        select('#loss').html('Loss: ' + loss);
+        select("#loss").html("Loss: " + loss);
       } else {
-        select('#loss').html('Done Training! Final Loss: ' + loss);
+        select("#loss").html("Done Training! Final Loss: " + loss);
       }
     });
   });
 
   // Predict Button
-  buttonPredict = select('#buttonPredict');
+  buttonPredict = select("#buttonPredict");
   buttonPredict.mousePressed(classify);
 
   // Save model
-  saveBtn = select('#save');
+  saveBtn = select("#save");
   saveBtn.mousePressed(function() {
     classifier.save();
   });
 
   // Load model
-  loadBtn = select('#load');
+  loadBtn = select("#load");
   loadBtn.changed(function() {
     classifier.load(loadBtn.elt.files, function() {
-      select('#modelStatus').html('Custom Model Loaded!');
+      select("#modelStatus").html("Custom Model Loaded!");
     });
   });
 }
@@ -113,8 +113,8 @@ function gotResults(err, results) {
     console.error(err);
   }
   if (results && results[0]) {
-    select('#result').html(results[0].label);
-    select('#confidence').html(results[0].confidence.toFixed(2) * 100 + '%');
+    select("#result").html(results[0].label);
+    select("#confidence").html(results[0].confidence.toFixed(2) * 100 + "%");
     classify();
   }
 }

--- a/examples/p5js/FeatureExtractor/FeatureExtractor_Image_Regression/sketch.js
+++ b/examples/p5js/FeatureExtractor/FeatureExtractor_Image_Regression/sketch.js
@@ -23,7 +23,7 @@ function setup() {
   // Append it to the videoContainer DOM element
   video.hide();
   // Extract the features from MobileNet
-  featureExtractor = ml5.featureExtractor('MobileNet', modelReady);
+  featureExtractor = ml5.featureExtractor("MobileNet", modelReady);
   // Create a new regressor using those features and give the video we want to use
   regressor = featureExtractor.regression(video, videoReady);
   // Create the UI buttons
@@ -39,12 +39,12 @@ function draw() {
 
 // A function to be called when the model has been loaded
 function modelReady() {
-  select('#modelStatus').html('Model loaded!');
+  select("#modelStatus").html("Model loaded!");
 }
 
 // A function to be called when the video has loaded
 function videoReady() {
-  select('#videoStatus').html('Video ready!');
+  select("#videoStatus").html("Video ready!");
 }
 
 // Classify the current frame.
@@ -54,28 +54,28 @@ function predict() {
 
 // A util function to create UI buttons
 function setupButtons() {
-  slider = select('#slider');
+  slider = select("#slider");
   // When the Dog button is pressed, add the current frame
   // from the video with a label of "dog" to the classifier
-  select('#addSample').mousePressed(function() {
+  select("#addSample").mousePressed(function() {
     regressor.addImage(slider.value());
-    select('#amountOfSamples').html(samples++);
+    select("#amountOfSamples").html((samples += 1));
   });
 
   // Train Button
-  select('#train').mousePressed(function() {
+  select("#train").mousePressed(function() {
     regressor.train(function(lossValue) {
       if (lossValue) {
         loss = lossValue;
-        select('#loss').html('Loss: ' + loss);
+        select("#loss").html("Loss: " + loss);
       } else {
-        select('#loss').html('Done Training! Final Loss: ' + loss);
+        select("#loss").html("Done Training! Final Loss: " + loss);
       }
     });
   });
 
   // Predict Button
-  select('#buttonPredict').mousePressed(predict);
+  select("#buttonPredict").mousePressed(predict);
 }
 
 // Show the results

--- a/examples/p5js/ImageClassification/ImageClassification_MultipleImages/sketch.js
+++ b/examples/p5js/ImageClassification/ImageClassification_MultipleImages/sketch.js
@@ -17,8 +17,8 @@ const allImages = [];
 const predictions = [];
 
 function preload() {
-  classifier = ml5.imageClassifier('MobileNet');
-  data = loadJSON('assets/data.json');
+  classifier = ml5.imageClassifier("MobileNet");
+  data = loadJSON("assets/data.json");
 }
 
 function setup() {
@@ -31,7 +31,7 @@ function setup() {
 function appendImages() {
   for (i = 0; i < data.images.length; i += 1) {
     imgPath = data.images[i];
-    allImages.push('images/dataset/' + imgPath);
+    allImages.push("images/dataset/" + imgPath);
   }
 }
 
@@ -44,9 +44,9 @@ function imageReady(img) {
 
 function savePredictions() {
   predictionsJSON = {
-    predictions: predictions
+    predictions: predictions,
   };
-  saveJSON(predictionsJSON, 'predictions.json');
+  saveJSON(predictionsJSON, "predictions.json");
 }
 
 // When we get the results
@@ -58,13 +58,13 @@ function gotResult(err, results) {
 
   information = {
     name: allImages[currentIndex],
-    result: results
+    result: results,
   };
 
   predictions.push(information);
-  createDiv('Label: ' + results[0].label);
-  createDiv('Confidence: ' + nf(results[0].confidence, 0, 2));
-  currentIndex++;
+  createDiv("Label: " + results[0].label);
+  createDiv("Confidence: " + nf(results[0].confidence, 0, 2));
+  currentIndex += 1;
   if (currentIndex <= allImages.length - 1) {
     loadImage(allImages[currentIndex], imageReady);
   } else {

--- a/examples/p5js/ImageClassification/ImageClassification_MultipleImages/sketch.js
+++ b/examples/p5js/ImageClassification/ImageClassification_MultipleImages/sketch.js
@@ -29,7 +29,7 @@ function setup() {
 }
 
 function appendImages() {
-  for (i = 0; i < data.images.length; i++) {
+  for (i = 0; i < data.images.length; i += 1) {
     imgPath = data.images[i];
     allImages.push('images/dataset/' + imgPath);
   }

--- a/examples/p5js/ImageClassification/ImageClassification_VideoScavengerHunt/lib/p5.speech.js
+++ b/examples/p5js/ImageClassification/ImageClassification_VideoScavengerHunt/lib/p5.speech.js
@@ -126,7 +126,7 @@
   p5.Speech.prototype.listVoices = function() {
     if(this.isLoaded)
     {
-      for(var i = 0;i<this.voices.length;i++)
+      for(var i = 0;i<this.voices.length;i += 1)
       {
         console.log(this.voices[i].name);
       }

--- a/examples/p5js/ImageClassification/ImageClassification_VideoScavengerHunt/sketch.js
+++ b/examples/p5js/ImageClassification/ImageClassification_VideoScavengerHunt/sketch.js
@@ -14,7 +14,7 @@ let video;
 let currentWord;
 let currentIndex = 0;
 let isPlaying = false;
-const words = ['banana', 'watch', 'shoe', 'book', 'cellphone', 'keyboard', 'shirt', 'pants', 'cup'];
+const words = ["banana", "watch", "shoe", "book", "cellphone", "keyboard", "shirt", "pants", "cup"];
 // Create a new p5.speech object
 // You can also control the Language, Rate, Pitch and Volumn of the voice
 // Read more at http://ability.nyu.edu/p5.js-speech/
@@ -25,14 +25,14 @@ function setup() {
   // Create a camera input
   video = createCapture(VIDEO);
   // Initialize the Image Classifier method with MobileNet and the video as the second argument
-  classifier = ml5.imageClassifier('MobileNet', video, modelReady);
+  classifier = ml5.imageClassifier("MobileNet", video, modelReady);
 
-  select('#start').mousePressed(function() {
+  select("#start").mousePressed(function() {
     playNextWord();
   });
 
-  select('#next').mousePressed(function() {
-    currentIndex++;
+  select("#next").mousePressed(function() {
+    currentIndex += 1;
     if (currentIndex >= words.length) {
       currentIndex = 0;
     }
@@ -47,14 +47,14 @@ function setup() {
 function playNextWord() {
   isPlaying = true;
   currentWord = words[currentIndex];
-  select('#instruction').html(`Go find ${currentWord}!`);
+  select("#instruction").html(`Go find ${currentWord}!`);
   // Call the classifyVideo function to start classifying the video
   classifyVideo();
 }
 
 function modelReady() {
   // Change the status of the model once its ready
-  select('#status').html('Model Loaded');
+  select("#status").html("Model Loaded");
 }
 
 // Get a prediction for the current video frame
@@ -68,20 +68,20 @@ function gotResult(err, results) {
   // Get the first result string
   const result = results[0].label;
   // Split the first result string by coma and get the first word
-  const oneWordRes = result.split(',')[0];
+  const oneWordRes = result.split(",")[0];
   // Get the top 3 results as strings in an array
   // Read more about map function here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map
   const top3Res = results.map(r => r.label);
   // Find if any of the top 3 result strings includes the current word
   // Read more about find function here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find
-  const ifFound = top3Res.find(r => r.includes(currentWord))
+  const ifFound = top3Res.find(r => r.includes(currentWord));
   if (ifFound) {
     // If top 3 results includes the current word
     isPlaying = false;
-    select('#message').html(`You found ${currentWord}!`);
+    select("#message").html(`You found ${currentWord}!`);
     myVoice.speak(`You found ${currentWord}!`);
   } else {
-    select('#message').html(`I see ${oneWordRes}`);
+    select("#message").html(`I see ${oneWordRes}`);
     myVoice.speak(`I see ${oneWordRes}`);
   }
 }

--- a/examples/p5js/ImageClassification/ImageClassification_VideoSound/lib/p5.speech.js
+++ b/examples/p5js/ImageClassification/ImageClassification_VideoSound/lib/p5.speech.js
@@ -126,7 +126,7 @@
   p5.Speech.prototype.listVoices = function() {
     if(this.isLoaded)
     {
-      for(var i = 0;i<this.voices.length;i++)
+      for(var i = 0;i<this.voices.length;i += 1)
       {
         console.log(this.voices[i].name);
       }

--- a/examples/p5js/ImageClassification/ImageClassification_VideoSoundTranslate/lib/p5.speech.js
+++ b/examples/p5js/ImageClassification/ImageClassification_VideoSoundTranslate/lib/p5.speech.js
@@ -126,7 +126,7 @@
   p5.Speech.prototype.listVoices = function() {
     if(this.isLoaded)
     {
-      for(var i = 0;i<this.voices.length;i++)
+      for(var i = 0;i<this.voices.length;i += 1)
       {
         console.log(this.voices[i].name);
       }

--- a/examples/p5js/KMeans/KMeans_imageSegmentation/sketch.js
+++ b/examples/p5js/KMeans/KMeans_imageSegmentation/sketch.js
@@ -8,18 +8,18 @@ const colorDict = {
   1: [202, 207, 210], // grey
   2: [97, 106, 107], // dark grey
   3: [44, 62, 80], // navy
-  4: [249, 231, 159] // yellow
-}
+  4: [249, 231, 159], // yellow
+};
 
 const options = {
-  'k': 3,
-  'maxIter': 4,
-  'threshold': 0.5,
+  k: 3,
+  maxIter: 4,
+  threshold: 0.5,
 };
 
 function preload() {
   // img = loadImage('data/brooklyn-aerial.jpg')
-  img = loadImage('data/world.jpg')
+  img = loadImage("data/world.jpg");
 }
 
 function setup() {
@@ -31,8 +31,8 @@ function setup() {
 
   // walk through the pixels and pull them out as
   // data to be sent to kmeans
-  for (let x = 0; x < imgSize; x++) {
-    for (let y = 0; y < imgSize; y++) {
+  for (let x = 0; x < imgSize; x += 1) {
+    for (let y = 0; y < imgSize; y += 1) {
       const off = (y * imgSize + x) * 4;
       const r = img.pixels[off];
       const g = img.pixels[off + 1];
@@ -42,22 +42,22 @@ function setup() {
       data.push({
         r,
         g,
-        b
+        b,
       });
     }
   }
 
   // display the resized image on another canvas
-  baseImage = select('#baseImage');
-  baseImageCtx = baseImage.elt.getContext('2d');
+  baseImage = select("#baseImage");
+  baseImageCtx = baseImage.elt.getContext("2d");
   baseImageCtx.drawImage(img.canvas, 0, 0, width, height);
 
   // call kmeans on the data
-  kmeans = ml5.kmeans(data, options, modelReady)
+  kmeans = ml5.kmeans(data, options, modelReady);
 }
 
 function modelReady() {
-  console.log('ready!')
+  console.log("ready!");
   const dataset = kmeans.dataset;
 
   const segmented = createImage(imgSize, imgSize);
@@ -65,14 +65,13 @@ function modelReady() {
 
   // redraw the image using the color dictionary above
   // use the .centroid value to apply the color
-  for (let x = 0; x < segmented.width; x++) {
-    for (let y = 0; y < segmented.height; y++) {
-      const off = (x * imgSize + y);
-      const c = colorDict[dataset[off].centroid]
+  for (let x = 0; x < segmented.width; x += 1) {
+    for (let y = 0; y < segmented.height; y += 1) {
+      const off = x * imgSize + y;
+      const c = colorDict[dataset[off].centroid];
       segmented.set(x, y, color(c));
     }
   }
   segmented.updatePixels();
   image(segmented, 0, 0, width, height);
-
 }

--- a/examples/p5js/KNNClassification/KNNClassification_PoseNet/sketch.js
+++ b/examples/p5js/KNNClassification/KNNClassification_PoseNet/sketch.js
@@ -152,7 +152,7 @@ function clearAllLabels() {
 // A function to draw ellipses over the detected keypoints
 function drawKeypoints()  {
   // Loop through all the poses detected
-  for (let i = 0; i < poses.length; i++) {
+  for (let i = 0; i < poses.length; i += 1) {
     // For each pose detected, loop through all the keypoints
     const pose = poses[i].pose;
     for (let j = 0; j < pose.keypoints.length; j++) {
@@ -171,7 +171,7 @@ function drawKeypoints()  {
 // A function to draw the skeletons
 function drawSkeleton() {
   // Loop through all the skeletons detected
-  for (let i = 0; i < poses.length; i++) {
+  for (let i = 0; i < poses.length; i += 1) {
     const skeleton = poses[i].skeleton;
     // For every skeleton, loop through all body connections
     for (let j = 0; j < skeleton.length; j++) {

--- a/examples/p5js/KNNClassification/KNNClassification_PoseNet/sketch.js
+++ b/examples/p5js/KNNClassification/KNNClassification_PoseNet/sketch.js
@@ -15,7 +15,7 @@ let poses = [];
 
 function setup() {
   const canvas = createCanvas(640, 480);
-  canvas.parent('videoContainer');
+  canvas.parent("videoContainer");
   video = createCapture(VIDEO);
   video.size(width, height);
 
@@ -26,7 +26,7 @@ function setup() {
   poseNet = ml5.poseNet(video, modelReady);
   // This sets up an event that fills the global variable "poses"
   // with an array every time new poses are detected
-  poseNet.on('pose', function(results) {
+  poseNet.on("pose", function(results) {
     poses = results;
   });
   // Hide the video element, and just show the canvas
@@ -41,8 +41,8 @@ function draw() {
   drawSkeleton();
 }
 
-function modelReady(){
-  select('#status').html('model Loaded')
+function modelReady() {
+  select("#status").html("model Loaded");
 }
 
 // Add the current frame from the video to the classifier
@@ -60,7 +60,7 @@ function classify() {
   // Get the total number of labels from knnClassifier
   const numLabels = knnClassifier.getNumLabels();
   if (numLabels <= 0) {
-    console.error('There is no examples in any label');
+    console.error("There is no examples in any label");
     return;
   }
   // Convert poses results to a 2d array [[score0, x0, y0],...,[score16, x16, y16]]
@@ -75,35 +75,35 @@ function classify() {
 function createButtons() {
   // When the A button is pressed, add the current frame
   // from the video with a label of "A" to the classifier
-  buttonA = select('#addClassA');
+  buttonA = select("#addClassA");
   buttonA.mousePressed(function() {
-    addExample('A');
+    addExample("A");
   });
 
   // When the B button is pressed, add the current frame
   // from the video with a label of "B" to the classifier
-  buttonB = select('#addClassB');
+  buttonB = select("#addClassB");
   buttonB.mousePressed(function() {
-    addExample('B');
+    addExample("B");
   });
 
   // Reset buttons
-  resetBtnA = select('#resetA');
+  resetBtnA = select("#resetA");
   resetBtnA.mousePressed(function() {
-    clearLabel('A');
+    clearLabel("A");
   });
-	
-  resetBtnB = select('#resetB');
+
+  resetBtnB = select("#resetB");
   resetBtnB.mousePressed(function() {
-    clearLabel('B');
+    clearLabel("B");
   });
 
   // Predict button
-  buttonPredict = select('#buttonPredict');
+  buttonPredict = select("#buttonPredict");
   buttonPredict.mousePressed(classify);
 
   // Clear all classes button
-  buttonClearAll = select('#clearAll');
+  buttonClearAll = select("#clearAll");
   buttonClearAll.mousePressed(clearAllLabels);
 }
 
@@ -118,23 +118,23 @@ function gotResults(err, result) {
     const confidences = result.confidencesByLabel;
     // result.label is the label that has the highest confidence
     if (result.label) {
-      select('#result').html(result.label);
-      select('#confidence').html(`${confidences[result.label] * 100} %`);
+      select("#result").html(result.label);
+      select("#confidence").html(`${confidences[result.label] * 100} %`);
     }
 
-    select('#confidenceA').html(`${confidences['A'] ? confidences['A'] * 100 : 0} %`);
-    select('#confidenceB').html(`${confidences['B'] ? confidences['B'] * 100 : 0} %`);
+    select("#confidenceA").html(`${confidences["A"] ? confidences["A"] * 100 : 0} %`);
+    select("#confidenceB").html(`${confidences["B"] ? confidences["B"] * 100 : 0} %`);
   }
 
   classify();
 }
 
-// Update the example count for each label	
+// Update the example count for each label
 function updateCounts() {
   const counts = knnClassifier.getCountByLabel();
 
-  select('#exampleA').html(counts['A'] || 0);
-  select('#exampleB').html(counts['B'] || 0);
+  select("#exampleA").html(counts["A"] || 0);
+  select("#exampleB").html(counts["B"] || 0);
 }
 
 // Clear the examples in one label
@@ -150,12 +150,12 @@ function clearAllLabels() {
 }
 
 // A function to draw ellipses over the detected keypoints
-function drawKeypoints()  {
+function drawKeypoints() {
   // Loop through all the poses detected
   for (let i = 0; i < poses.length; i += 1) {
     // For each pose detected, loop through all the keypoints
     const pose = poses[i].pose;
-    for (let j = 0; j < pose.keypoints.length; j++) {
+    for (let j = 0; j < pose.keypoints.length; j += 1) {
       // A keypoint is an object describing a body part (like rightArm or leftShoulder)
       const keypoint = pose.keypoints[j];
       // Only draw an ellipse is the pose probability is bigger than 0.2
@@ -174,7 +174,7 @@ function drawSkeleton() {
   for (let i = 0; i < poses.length; i += 1) {
     const skeleton = poses[i].skeleton;
     // For every skeleton, loop through all body connections
-    for (let j = 0; j < skeleton.length; j++) {
+    for (let j = 0; j < skeleton.length; j += 1) {
       const partA = skeleton[j][0];
       const partB = skeleton[j][1];
       stroke(255, 0, 0);

--- a/examples/p5js/KNNClassification/KNNClassification_VideoSound/lib/p5.speech.js
+++ b/examples/p5js/KNNClassification/KNNClassification_VideoSound/lib/p5.speech.js
@@ -128,7 +128,7 @@
   p5.Speech.prototype.listVoices = function() {
     if(this.isLoaded)
     {
-      for(var i = 0;i<this.voices.length;i++)
+      for(var i = 0;i<this.voices.length;i += 1)
       {
         console.log(this.voices[i].name);
       }

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_ImageClassifier_Colors/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_ImageClassifier_Colors/sketch.js
@@ -68,7 +68,7 @@ function addData() {
   ]
 
   // method 1: adding data as objects
-  for(let i = 0; i < myData.length; i++){
+  for(let i = 0; i < myData.length; i += 1){
     const item = myData[i];
     const xInputObj = {
       pixelArray: item.value
@@ -86,7 +86,7 @@ function addData() {
     inputLabels: ['pixelArray'],
     outputLabels: ['label']
   }
-  for(let i = 0; i < myData.length; i++){
+  for(let i = 0; i < myData.length; i += 1){
     const item = myData[i]; 
     nn.addData([item.value], [item.label], labelsOptions)
   }

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_ImageClassifier_Letters/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_ImageClassifier_Letters/sketch.js
@@ -18,7 +18,7 @@ let testA;
 
 function preload() {
   images = [];
-  for (let i = 1; i < 7; i++) {
+  for (let i = 1; i < 7; i += 1) {
     const a = loadImage(`images/A_0${i}.png`)
     const b = loadImage(`images/B_0${i}.png`)
     images.push({
@@ -48,7 +48,7 @@ function setup() {
 
 
   // add data
-  for(let i = 0; i < images.length; i++){
+  for(let i = 0; i < images.length; i += 1){
     const item = images[i];
     // get back the image array
     item.image.loadPixels()

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_ImageClassifier_Letters2/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_ImageClassifier_Letters2/sketch.js
@@ -18,7 +18,7 @@ let testA;
 
 function preload() {
   images = [];
-  for (let i = 1; i < 7; i++) {
+  for (let i = 1; i < 7; i += 1) {
     const a = loadImage(`images/A_0${i}.png`);
     const b = loadImage(`images/B_0${i}.png`);
     images.push({
@@ -45,7 +45,7 @@ function setup() {
   nn = ml5.neuralNetwork(options);
 
   // add data
-  for (let i = 0; i < images.length; i++) {
+  for (let i = 0; i < images.length; i += 1) {
     const item = images[i];
     const labels = item.label;
     nn.addData({

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_Interactive_Regression/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_Interactive_Regression/sketch.js
@@ -60,7 +60,7 @@ function startTraining() {
   neuralNetwork = ml5.neuralNetwork(options);
 
   // add training data
-  for (let i = 0; i < trainData.length; i++) {
+  for (let i = 0; i < trainData.length; i += 1) {
     neuralNetwork.addData([trainData[i][0]], [trainData[i][1]]);
   }
 
@@ -81,7 +81,7 @@ function doneTraining() {
       console.log(error); 
     } else {
       console.log(results);
-      for (let i = 0; i < results.length; i++){
+      for (let i = 0; i < results.length; i += 1){
         x = xMany[i][0];
         y = results[i][0]['value'];
         circle(x, y, 1);

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_Interactive_Regression/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_Interactive_Regression/sketch.js
@@ -2,11 +2,11 @@ const trainData = [];
 let neuralNetwork;
 
 // selectors for inputs and button
-const inputNeuralNetworkLearningRate = document.getElementById('neuralNetworkLearningRate');
-const inputNeuralNetworkHiddenUnits = document.getElementById('neuralNetworkHiddenUnits');
-const inputTrainEpochs = document.getElementById('trainEpochs');
-const inputTrainBatchSize = document.getElementById('trainBatchSize');
-const buttonStartTrain = document.getElementById('startTraining');
+const inputNeuralNetworkLearningRate = document.getElementById("neuralNetworkLearningRate");
+const inputNeuralNetworkHiddenUnits = document.getElementById("neuralNetworkHiddenUnits");
+const inputTrainEpochs = document.getElementById("trainEpochs");
+const inputTrainBatchSize = document.getElementById("trainBatchSize");
+const buttonStartTrain = document.getElementById("startTraining");
 
 const canvasSize = 800;
 
@@ -15,17 +15,17 @@ const options = {
   inputs: 1,
   outputs: 1,
   debug: true,
-  task: 'regression',
+  task: "regression",
   learningRate: 0.25,
   hiddenUnits: 20,
-}
+};
 
 // training params
 const trainParams = {
   validationSplit: 0,
   epochs: 100,
   batchSize: 64,
-}
+};
 
 buttonStartTrain.addEventListener("click", () => {
   // get input data
@@ -53,7 +53,7 @@ function mouseClicked() {
 function startTraining() {
   // check if train data
   if (trainData.length == 0) {
-    alert('Please add some training data by clicking inside the canvas');
+    alert("Please add some training data by clicking inside the canvas");
     return;
   }
 
@@ -71,19 +71,19 @@ function startTraining() {
 function doneTraining() {
   // build x-bases to calculate corresponding y-values. We take every x-value possible of the canvas to make it look like a line
   xMany = [];
-  for (x = 0; x <= canvasSize; x++) {
+  for (x = 0; x <= canvasSize; x += 1) {
     xMany.push([x]);
   }
-  
+
   // predict corresponding y-values and show as circle
   neuralNetwork.predictMultiple(xMany, (error, results) => {
     if (error) {
-      console.log(error); 
+      console.log(error);
     } else {
       console.log(results);
-      for (let i = 0; i < results.length; i += 1){
+      for (let i = 0; i < results.length; i += 1) {
         x = xMany[i][0];
-        y = results[i][0]['value'];
+        y = results[i][0]["value"];
         circle(x, y, 1);
       }
     }

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_Simple_AorB/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_Simple_AorB/sketch.js
@@ -29,7 +29,7 @@ function setup() {
 }
 
 function addData() {
-  for (let i = 0; i < 500; i++) {
+  for (let i = 0; i < 500; i += 1) {
     let xVal, labelVal;
     if (i < 250) {
       xVal = i;

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_Simple_Classification/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_Simple_Classification/sketch.js
@@ -44,7 +44,7 @@ function finishedTraining(){
 }
 
 function createTrainingData(){
-  for(let i = 0; i < 400; i++){
+  for(let i = 0; i < 400; i += 1){
     if(i%2 === 0){
       const x = random(0, width/2);
       nn.addData( [x],  ['left'])

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_Simple_Regression/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_Simple_Regression/sketch.js
@@ -48,7 +48,7 @@ function finishedTraining() {
       rectMode(CENTER);
       rect(x, y, 10, 10);
 
-      counter++;
+      counter += 1;
       finishedTraining();
     });
   }

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_Simple_Regression/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_Simple_Regression/sketch.js
@@ -12,61 +12,57 @@ let nn;
 let counter = 0;
 
 const options = {
-  task:'regression',
-  debug: true
-}
+  task: "regression",
+  debug: true,
+};
 
-function setup(){
+function setup() {
   createCanvas(400, 400);
   nn = ml5.neuralNetwork(options);
 
-
-  console.log(nn)
+  console.log(nn);
   createTrainingData();
   nn.normalizeData();
 
-  const trainingOptions={
+  const trainingOptions = {
     batchSize: 24,
-    epochs: 10
-  }
-  
-  nn.train(trainingOptions,finishedTraining); // if you want to change the training options
+    epochs: 10,
+  };
+
+  nn.train(trainingOptions, finishedTraining); // if you want to change the training options
   // nn.train(finishedTraining); // use the default training options
 }
 
-function finishedTraining(){
-
-  if(counter < 400){
+function finishedTraining() {
+  if (counter < 400) {
     nn.predict([counter], (err, results) => {
-      if(err){
+      if (err) {
         console.log(err);
         return;
       }
       console.log(results[0]);
-      const prediction = results[0]
+      const prediction = results[0];
       const x = counter;
-      const y = prediction.value
+      const y = prediction.value;
       fill(255, 0, 0);
       rectMode(CENTER);
       rect(x, y, 10, 10);
 
       counter++;
       finishedTraining();
-    })
+    });
   }
-  
 }
 
-function createTrainingData(){
-  for(let i = 0; i < width; i+=10){
-    const iters = floor(random(5, 20))
+function createTrainingData() {
+  for (let i = 0; i < width; i += 10) {
+    const iters = floor(random(5, 20));
     const spread = 50;
-    for(let j = 0; j < iters; j++){
-      const data = [i, height - i + floor(random(-spread, spread))]
+    for (let j = 0; j < iters; j += 1) {
+      const data = [i, height - i + floor(random(-spread, spread))];
       fill(0, 0, 255);
-      ellipse(data[0], data[1], 10, 10)
-      nn.addData([data[0]], [data[1]])
+      ellipse(data[0], data[1], 10, 10);
+      nn.addData([data[0]], [data[1]]);
     }
-    
   }
 }

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_XOR/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_XOR/sketch.js
@@ -22,7 +22,7 @@ function setup() {
       textAlign(CENTER, CENTER);
       text(nf(0.5, 1, 2), i * resolution + resolution / 2, j * resolution + resolution / 2);
       // text(nf(y_values[index], 1, 2), i * resolution + resolution / 2, j * resolution + resolution / 2)
-      index++;
+      index += 1;
     }
   }
 
@@ -87,7 +87,7 @@ function gotResults(error, results) {
         i * resolution + resolution / 2,
         j * resolution + resolution / 2,
       );
-      index++;
+      index += 1;
     }
   }
 

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_XOR/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_XOR/sketch.js
@@ -13,14 +13,14 @@ function setup() {
 
   let index = 0;
   for (let i = 0; i < cols; i += 1) {
-    for (let j = 0; j < rows; j++) {
+    for (let j = 0; j < rows; j += 1) {
       const br = 255; // y_values[index] * 255
       fill(br);
       rect(i * resolution, j * resolution, resolution, resolution);
       fill(255 - br);
       textSize(8);
       textAlign(CENTER, CENTER);
-      text(nf(0.5, 1, 2), i * resolution + resolution / 2, j * resolution + resolution / 2)
+      text(nf(0.5, 1, 2), i * resolution + resolution / 2, j * resolution + resolution / 2);
       // text(nf(y_values[index], 1, 2), i * resolution + resolution / 2, j * resolution + resolution / 2)
       index++;
     }
@@ -30,10 +30,10 @@ function setup() {
     inputs: 2,
     outputs: 1,
     learningRate: 0.25,
-    task:'regression',
-    debug:true
+    task: "regression",
+    debug: true,
     // hiddenUnits: 2
-  }
+  };
   model = ml5.neuralNetwork(options);
 
   // model = ml5.neuralNetwork(2, 1);
@@ -44,9 +44,7 @@ function setup() {
 
   model.normalizeData();
   model.train({ epochs: 50 }, whileTraining, finishedTraining);
-
 }
-
 
 function whileTraining(epoch, logs) {
   console.log(`Epoch: ${epoch} - loss: ${logs.loss.toFixed(2)}`);
@@ -57,7 +55,7 @@ function finishedTraining() {
   // TODO: Support prediction on multiple rows of input data
   const xs = [];
   for (let i = 0; i < cols; i += 1) {
-    for (let j = 0; j < rows; j++) {
+    for (let j = 0; j < rows; j += 1) {
       const x1 = i / cols;
       const x2 = j / rows;
       xs.push([x1, x2]);
@@ -69,22 +67,26 @@ function finishedTraining() {
 
 function gotResults(error, results) {
   background(0);
-  if(error){
-    console.log(err)
-    return
+  if (error) {
+    console.log(err);
+    return;
   }
   // console.log(results);
   let index = 0;
   for (let i = 0; i < cols; i += 1) {
-    for (let j = 0; j < rows; j++) {
+    for (let j = 0; j < rows; j += 1) {
       const br = results[index][0].value * 255; // y_values[index] * 255
       fill(br);
       rect(i * resolution, j * resolution, resolution, resolution);
       fill(255 - br);
       textSize(8);
       textAlign(CENTER, CENTER);
-      text(nf(0.5, 1, 2), i * resolution + resolution / 2, j * resolution + resolution / 2)
-      text(nf(results[index][0].value, 1, 2), i * resolution + resolution / 2, j * resolution + resolution / 2)
+      text(nf(0.5, 1, 2), i * resolution + resolution / 2, j * resolution + resolution / 2);
+      text(
+        nf(results[index][0].value, 1, 2),
+        i * resolution + resolution / 2,
+        j * resolution + resolution / 2,
+      );
       index++;
     }
   }

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_XOR/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_XOR/sketch.js
@@ -14,14 +14,14 @@ function setup() {
   let index = 0;
   for (let i = 0; i < cols; i++) {
     for (let j = 0; j < rows; j++) {
-      const br = 255; //y_values[index] * 255
+      const br = 255; // y_values[index] * 255
       fill(br);
       rect(i * resolution, j * resolution, resolution, resolution);
       fill(255 - br);
       textSize(8);
       textAlign(CENTER, CENTER);
       text(nf(0.5, 1, 2), i * resolution + resolution / 2, j * resolution + resolution / 2)
-      //text(nf(y_values[index], 1, 2), i * resolution + resolution / 2, j * resolution + resolution / 2)
+      // text(nf(y_values[index], 1, 2), i * resolution + resolution / 2, j * resolution + resolution / 2)
       index++;
     }
   }
@@ -36,7 +36,7 @@ function setup() {
   }
   model = ml5.neuralNetwork(options);
 
-  //model = ml5.neuralNetwork(2, 1);
+  // model = ml5.neuralNetwork(2, 1);
   model.addData([0, 0], [0]);
   model.addData([1, 0], [1]);
   model.addData([0, 1], [1]);
@@ -77,7 +77,7 @@ function gotResults(error, results) {
   let index = 0;
   for (let i = 0; i < cols; i++) {
     for (let j = 0; j < rows; j++) {
-      const br = results[index][0].value * 255; //y_values[index] * 255
+      const br = results[index][0].value * 255; // y_values[index] * 255
       fill(br);
       rect(i * resolution, j * resolution, resolution, resolution);
       fill(255 - br);

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_XOR/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_XOR/sketch.js
@@ -12,7 +12,7 @@ function setup() {
   rows = height / resolution;
 
   let index = 0;
-  for (let i = 0; i < cols; i++) {
+  for (let i = 0; i < cols; i += 1) {
     for (let j = 0; j < rows; j++) {
       const br = 255; // y_values[index] * 255
       fill(br);
@@ -56,7 +56,7 @@ function finishedTraining() {
   // console.log('done!');
   // TODO: Support prediction on multiple rows of input data
   const xs = [];
-  for (let i = 0; i < cols; i++) {
+  for (let i = 0; i < cols; i += 1) {
     for (let j = 0; j < rows; j++) {
       const x1 = i / cols;
       const x2 = j / rows;
@@ -75,7 +75,7 @@ function gotResults(error, results) {
   }
   // console.log(results);
   let index = 0;
-  for (let i = 0; i < cols; i++) {
+  for (let i = 0; i < cols; i += 1) {
     for (let j = 0; j < rows; j++) {
       const br = results[index][0].value * 255; // y_values[index] * 255
       fill(br);

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_basics/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_basics/sketch.js
@@ -66,7 +66,7 @@ function trainModel() {
   // const training_target = [0.3, 0.9];
   let a, b, c;
   let training_target;
-  for (let i = 0; i < 500; i++) {
+  for (let i = 0; i < 500; i += 1) {
     if (i % 2) {
       a = Math.random(0, 0.16);
       b = Math.random(0.16, 0.32);

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_co2net/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_co2net/sketch.js
@@ -14,26 +14,16 @@ let nn;
 let data;
 
 let counter = 0;
-const testInputs = [
-  100,
-  50000,
-  100000,
-  500000,
-  2500000,
-  5000000,
-  10000000,
-  15000000,
-]
+const testInputs = [100, 50000, 100000, 500000, 2500000, 5000000, 10000000, 15000000];
 
 // Options for Neural Network
 const options = {
-  inputs: ['population_cdp'],
-  outputs: ['scope1_ghg_emissions_tons_co2e'],
-  dataUrl: 'data/co2stats.csv',
-  task: 'regression',
-  debug: true
+  inputs: ["population_cdp"],
+  outputs: ["scope1_ghg_emissions_tons_co2e"],
+  dataUrl: "data/co2stats.csv",
+  task: "regression",
+  debug: true,
 };
-
 
 function setup() {
   createCanvas(400, 400);
@@ -42,7 +32,6 @@ function setup() {
 
   // Step 1: Create Neural Network
   nn = ml5.neuralNetwork(options, modelLoaded);
-
 }
 
 function modelLoaded() {
@@ -50,37 +39,29 @@ function modelLoaded() {
 
   // visualize the training data
   nn.data.training.forEach(row => {
-    const {
-      xs,
-      ys
-    } = row;
+    const { xs, ys } = row;
     const x = map(xs.population_cdp, 0, 1, 0, width);
     const y = map(ys.scope1_ghg_emissions_tons_co2e, 0, 1, height, 0);
     ellipse(x, y, 2, 2);
-  })
+  });
 
   const trainingOptions = {
     epochs: 50,
-    batchSize: 12
-  }
-  nn.train(trainingOptions, finishedTraining)
+    batchSize: 12,
+  };
+  nn.train(trainingOptions, finishedTraining);
 }
 
 function finishedTraining() {
-
   if (counter < testInputs.length) {
-    const input = testInputs[counter]
+    const input = testInputs[counter];
     nn.predict([input], (err, result) => {
-
       if (err) {
         console.log(err);
         return;
       }
-      console.log(result)
-      const {
-        inputs,
-        outputs
-      } = nn.neuralNetworkData.meta;
+      console.log(result);
+      const { inputs, outputs } = nn.neuralNetworkData.meta;
 
       const inputMin = inputs.population_cdp.min;
       const inputMax = inputs.population_cdp.max;
@@ -92,13 +73,12 @@ function finishedTraining() {
 
       rectMode(CENTER);
       fill(255, 0, 0);
-      text(`pop:${input}`, x, y)
-      text(`tons_co2e:${result[0].value}`, x, y + 10)
+      text(`pop:${input}`, x, y);
+      text(`tons_co2e:${result[0].value}`, x, y + 10);
       rect(x, y, 6, 6);
 
-      counter++;
+      counter += 1;
       finishedTraining();
-    })
+    });
   }
-
 }

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_lowres_pixels/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_lowres_pixels/sketch.js
@@ -69,7 +69,7 @@ function getInputs() {
   video.loadPixels();
   // Create an array
   const inputs = [];
-  for (let i = 0; i < video.width * video.height; i++) {
+  for (let i = 0; i < video.width * video.height; i += 1) {
     const index = i * 4;
     // Manual normalization
     inputs.push(video.pixels[index + 0] / 255);

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_lowres_pixels/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_lowres_pixels/sketch.js
@@ -27,15 +27,15 @@ function setup() {
     inputs: totalPixels,
     outputs: 1,
     learningRate: 0.01,
-    task:'regression',
+    task: "regression",
     debug: true,
-  }
+  };
   // Create the model
   pixelBrain = ml5.neuralNetwork(options);
 
   // Buttons add trainin data and train model
-  select('#addExample').mousePressed(addExample);
-  select('#train').mousePressed(trainModel);
+  select("#addExample").mousePressed(addExample);
+  select("#train").mousePressed(trainModel);
 }
 
 // Video is ready!
@@ -49,8 +49,8 @@ function draw() {
     // Render the low-res image
     const w = width / videoSize;
     video.loadPixels();
-    for (let x = 0; x < video.width; x++) {
-      for (let y = 0; y < video.height; y++) {
+    for (let x = 0; x < video.width; x += 1) {
+      for (let y = 0; y < video.height; y += 1) {
         const index = (x + y * video.width) * 4;
         const r = video.pixels[index + 0];
         const g = video.pixels[index + 1];
@@ -61,7 +61,6 @@ function draw() {
       }
     }
   }
-
 }
 
 // Package the pixels as inputs to a neural network
@@ -79,10 +78,9 @@ function getInputs() {
   return inputs;
 }
 
-
 // Add an example
 function addExample() {
-  const freq = parseFloat(select('#frequency').value());
+  const freq = parseFloat(select("#frequency").value());
   video.loadPixels();
   const inputs = getInputs();
   // Manual normalization of frequency
@@ -97,11 +95,11 @@ function trainModel() {
 
 // Training is done!
 function finishedTraining() {
-  console.log('done');
+  console.log("done");
 
   // Start sound
   osc = new p5.Oscillator();
-  osc.setType('sine');
+  osc.setType("sine");
   osc.amp(0.5);
   osc.freq(440);
   osc.start();
@@ -125,7 +123,7 @@ function gotFrequency(error, results) {
   frequency = parseFloat(results[0].value) * freqMax;
 
   // Display frequency
-  select('#prediction').html(frequency.toFixed(2));
+  select("#prediction").html(frequency.toFixed(2));
   // Set frequency
   osc.freq(parseFloat(frequency));
   // Predict again

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_multiple_layers/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_multiple_layers/sketch.js
@@ -47,7 +47,7 @@ function setup() {
 }
 
 function addData() {
-  for (let i = 0; i < 500; i++) {
+  for (let i = 0; i < 500; i += 1) {
     let xVal, labelVal;
     if (i < 250) {
       xVal = i;

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_musical_face/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_musical_face/sketch.js
@@ -68,7 +68,7 @@ function draw() {
   // Just look at the first face and draw all the points
   if (detections.length > 0) {
     const points = detections[0].landmarks.positions;
-    for (let i = 0; i < points.length; i++) {
+    for (let i = 0; i < points.length; i += 1) {
       stroke(161, 95, 251);
       strokeWeight(4);
       point(points[i]._x, points[i]._y);
@@ -97,7 +97,7 @@ function getInputs() {
   if (detections.length > 0) {
     const points = detections[0].landmarks.positions;
     const inputs = [];
-    for (let i = 0; i < points.length; i++) {
+    for (let i = 0; i < points.length; i += 1) {
       inputs.push(points[i]._x);
       inputs.push(points[i]._y);
     }

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_pose_classifier/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_pose_classifier/sketch.js
@@ -84,7 +84,7 @@ function gotResults(error, results) {
 function getInputs() {
   const keypoints = poses[0].pose.keypoints;
   const inputs = [];
-  for (let i = 0; i < keypoints.length; i++) {
+  for (let i = 0; i < keypoints.length; i += 1) {
     inputs.push(keypoints[i].position.x);
     inputs.push(keypoints[i].position.y);
   }
@@ -112,7 +112,7 @@ function draw() {
   // For one pose only (use a for loop for multiple poses!)
   if (poses.length > 0) {
     const pose = poses[0].pose;
-    for (let i = 0; i < pose.keypoints.length; i++) {
+    for (let i = 0; i < pose.keypoints.length; i += 1) {
       fill(213, 0, 143);
       noStroke();
       ellipse(pose.keypoints[i].position.x, pose.keypoints[i].position.y, 8);

--- a/examples/p5js/NeuralNetwork/NeuroEvolution_FlappyBird/bird.js
+++ b/examples/p5js/NeuralNetwork/NeuroEvolution_FlappyBird/bird.js
@@ -50,7 +50,7 @@ class Bird {
     // Find the closest pipe
     let closest = null;
     let closestD = Infinity;
-    for (let i = 0; i < pipes.length; i++) {
+    for (let i = 0; i < pipes.length; i += 1) {
       const d = pipes[i].x + pipes[i].w - this.x;
       if (d < closestD && d > 0) {
         closest = pipes[i];

--- a/examples/p5js/NeuralNetwork/NeuroEvolution_FlappyBird/bird.js
+++ b/examples/p5js/NeuralNetwork/NeuroEvolution_FlappyBird/bird.js
@@ -22,10 +22,10 @@ class Bird {
       // Create a new neural network
       const options = {
         inputs: 5,
-        outputs: ['up', 'down'],
-        task: 'classification',
-        noTraining: true
-      }      
+        outputs: ["up", "down"],
+        task: "classification",
+        noTraining: true,
+      };
       this.brain = ml5.neuralNetwork(options);
     }
   }
@@ -68,7 +68,7 @@ class Bird {
 
     // Jump according to neural network output
     const results = this.brain.classifySync(inputs);
-    if (results[0].label === 'up') {
+    if (results[0].label === "up") {
       this.up();
     }
   }
@@ -79,7 +79,7 @@ class Bird {
 
   update() {
     // Score increases each frame
-    this.score++;
+    this.score += 1;
     this.velocity += this.gravity;
     this.y += this.velocity;
   }

--- a/examples/p5js/NeuralNetwork/NeuroEvolution_FlappyBird/ga.js
+++ b/examples/p5js/NeuralNetwork/NeuroEvolution_FlappyBird/ga.js
@@ -11,12 +11,12 @@ function nextGeneration() {
   calculateFitness();
   
   // Create new population of birds
-  for (let i = 0; i < TOTAL; i++) {
+  for (let i = 0; i < TOTAL; i += 1) {
     birds[i] = reproduce();
   }
 
   // Release all the memory
-  for (let i = 0; i < TOTAL; i++) {
+  for (let i = 0; i < TOTAL; i += 1) {
     savedBirds[i].brain.dispose();
   }
   // Clear the array

--- a/examples/p5js/NeuralNetwork/NeuroEvolution_FlappyBird/ga.js
+++ b/examples/p5js/NeuralNetwork/NeuroEvolution_FlappyBird/ga.js
@@ -6,10 +6,10 @@
 
 // Create the next generation
 function nextGeneration() {
-  console.log('next generation');
+  console.log("next generation");
   // Calculate fitness values
   calculateFitness();
-  
+
   // Create new population of birds
   for (let i = 0; i < TOTAL; i += 1) {
     birds[i] = reproduce();
@@ -23,7 +23,7 @@ function nextGeneration() {
   savedBirds = [];
 }
 
-// Create a child bird from two parents 
+// Create a child bird from two parents
 function reproduce() {
   const brainA = pickOne();
   const brainB = pickOne();
@@ -38,9 +38,9 @@ function pickOne() {
   let r = random(1);
   while (r > 0) {
     r = r - savedBirds[index].fitness;
-    index++;
+    index += 1;
   }
-  index--;
+  index -= 1;
   const bird = savedBirds[index];
   return bird.brain;
 }

--- a/examples/p5js/NeuralNetwork/NeuroEvolution_FlappyBird/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuroEvolution_FlappyBird/sketch.js
@@ -19,7 +19,7 @@ function setup() {
   slider = createSlider(1, 10, 1);
 
   // Create initial population of birds
-  for (let i = 0; i < TOTAL; i++) {
+  for (let i = 0; i < TOTAL; i += 1) {
     birds[i] = new Bird();
   }
 }

--- a/examples/p5js/NeuralNetwork/NeuroEvolution_FlappyBird/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuroEvolution_FlappyBird/sketch.js
@@ -13,7 +13,7 @@ let slider;
 function setup() {
   createCanvas(640, 480);
   // Improves performance for small neural networks and classifySync()
-  ml5.tf.setBackend('cpu');
+  ml5.tf.setBackend("cpu");
 
   // Slider for speeding up simulation
   slider = createSlider(1, 10, 1);
@@ -26,18 +26,18 @@ function setup() {
 
 function draw() {
   // Speed up simulation
-  for (let n = 0; n < slider.value(); n++) {
+  for (let n = 0; n < slider.value(); n += 1) {
     // new pipes every N frames
     if (counter % 75 == 0) {
       pipes.push(new Pipe());
     }
-    counter++;
+    counter += 1;
 
     // Run game
-    for (let i = pipes.length - 1; i >= 0; i--) {
+    for (let i = pipes.length - 1; i >= 0; i -= 1) {
       pipes[i].update();
 
-      for (let j = birds.length - 1; j >= 0; j--) {
+      for (let j = birds.length - 1; j >= 0; j -= 1) {
         if (pipes[i].hits(birds[j])) {
           // Save bird if it dies
           savedBirds.push(birds.splice(j, 1)[0]);
@@ -51,7 +51,7 @@ function draw() {
     }
 
     // Remove / save any birds that go offscreen
-    for (let i = birds.length - 1; i >= 0; i--) {
+    for (let i = birds.length - 1; i >= 0; i -= 1) {
       if (birds[i].offScreen()) {
         savedBirds.push(birds.splice(i, 1)[0]);
       }

--- a/examples/p5js/NeuralNetwork/NeuroEvolution_Path/population.js
+++ b/examples/p5js/NeuralNetwork/NeuroEvolution_Path/population.js
@@ -2,13 +2,12 @@
 // Daniel Shiffman
 // http://natureofcode.com
 
-
 // A class to describe a population of particles
 
 class Population {
   constructor(total) {
     this.population = [];
-    this.generations = 0;  // Number of generations
+    this.generations = 0; // Number of generations
     for (let i = 0; i < total; i += 1) {
       this.population[i] = new Particle();
     }
@@ -42,9 +41,9 @@ class Population {
     let r = random(1);
     while (r > 0) {
       r = r - this.population[index].fitness;
-      index++;
+      index += 1;
     }
-    index--;
+    index -= 1;
     return this.population[index].brain;
   }
 
@@ -67,6 +66,6 @@ class Population {
       nextPopulation[i] = this.reproduce();
     }
     this.population = nextPopulation;
-    this.generations++;
+    this.generations += 1;
   }
 }

--- a/examples/p5js/NeuralNetwork/NeuroEvolution_Path/population.js
+++ b/examples/p5js/NeuralNetwork/NeuroEvolution_Path/population.js
@@ -9,7 +9,7 @@ class Population {
   constructor(total) {
     this.population = [];
     this.generations = 0;  // Number of generations
-    for (let i = 0; i < total; i++) {
+    for (let i = 0; i < total; i += 1) {
       this.population[i] = new Particle();
     }
   }
@@ -63,7 +63,7 @@ class Population {
   reproduction() {
     const nextPopulation = [];
     // Refill the population with children from the mating pool
-    for (let i = 0; i < this.population.length; i++) {
+    for (let i = 0; i < this.population.length; i += 1) {
       nextPopulation[i] = this.reproduce();
     }
     this.population = nextPopulation;

--- a/examples/p5js/NeuralNetwork/NeuroEvolution_Path/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuroEvolution_Path/sketch.js
@@ -2,16 +2,15 @@
 // Daniel Shiffman
 // http://natureofcode.com
 
-
 // How long should each generation live
-let lifetime; 
+let lifetime;
 let lifeCounter;
 
 // Population
-let population;  
+let population;
 
 // Target position
-let target;      
+let target;
 
 // Interface
 let info;
@@ -23,16 +22,15 @@ function setup() {
   // Move the target if you click on the canvas
   canvas.mousePressed(function() {
     target.x = mouseX;
-    target.y = mouseY; 
+    target.y = mouseY;
   });
 
   // Improve performance for many small neural networks
-  ml5.tf.setBackend('cpu');
+  ml5.tf.setBackend("cpu");
 
   // The number of cycles we will allow a generation to live
   lifetime = 200;
   lifeCounter = 0;
-
 
   // Arbitrary starting target
   target = createVector(20, height / 2);
@@ -44,16 +42,14 @@ function setup() {
   info = createP("");
   // Slider for speeding up simulation
   slider = createSlider(1, 50, 1);
-
 }
 
 function draw() {
-
   // Update the population
-  for (let n = 0; n < slider.value(); n++) {
+  for (let n = 0; n < slider.value(); n += 1) {
     if (lifeCounter < lifetime) {
       population.update();
-      lifeCounter++;
+      lifeCounter += 1;
       // Otherwise a new generation
     } else {
       lifeCounter = 0;
@@ -61,7 +57,6 @@ function draw() {
       population.calculateFitness();
       population.reproduction();
     }
-
   }
 
   // Draw target
@@ -75,5 +70,5 @@ function draw() {
   population.show();
 
   // Display some info
-  info.html(`Generation # ${population.generations}<br>Cycles left: ${(lifetime - lifeCounter)}`);
+  info.html(`Generation # ${population.generations}<br>Cycles left: ${lifetime - lifeCounter}`);
 }

--- a/examples/p5js/ObjectDetector/ObjectDetector_COCOSSD_single_image/sketch.js
+++ b/examples/p5js/ObjectDetector/ObjectDetector_COCOSSD_single_image/sketch.js
@@ -39,7 +39,7 @@ function draw() {
   if (status != undefined) {
     image(img, 0, 0)
 
-    for (let i = 0; i < objects.length; i++) {
+    for (let i = 0; i < objects.length; i += 1) {
       noStroke();
       fill(0, 255, 0);
       text(objects[i].label + " " + nfc(objects[i].confidence * 100.0, 2) + "%", objects[i].x + 5, objects[i].y + 15);

--- a/examples/p5js/ObjectDetector/ObjectDetector_YOLO_single_image/sketch.js
+++ b/examples/p5js/ObjectDetector/ObjectDetector_YOLO_single_image/sketch.js
@@ -38,7 +38,7 @@ function draw() {
   if (status != undefined) {
     image(img, 0, 0)
 
-    for (let i = 0; i < objects.length; i++) {
+    for (let i = 0; i < objects.length; i += 1) {
       noStroke();
       fill(0, 255, 0);
       text(objects[i].label + " " + nfc(objects[i].confidence * 100.0, 2) + "%", objects[i].x + 5, objects[i].y + 15);

--- a/examples/p5js/PitchDetection/PitchDetection_Piano/sketch.js
+++ b/examples/p5js/PitchDetection/PitchDetection_Piano/sketch.js
@@ -57,7 +57,7 @@ function drawKeyboard() {
   strokeWeight(2);
   stroke(50);
   // White keys
-  for (let i = 0; i < scale.length; i++) {
+  for (let i = 0; i < scale.length; i += 1) {
     if (scale[i].indexOf('#') == -1) {
       if (scale[i] == currentNote) {
         fill(200);
@@ -71,7 +71,7 @@ function drawKeyboard() {
   whiteKeyCounter = 0;
 
   // Black keys
-  for (let i = 0; i < scale.length; i++) {
+  for (let i = 0; i < scale.length; i += 1) {
     if (scale[i].indexOf('#') > -1) {
       if (scale[i] == currentNote) {
         fill(100);

--- a/examples/p5js/PitchDetection/PitchDetection_Piano/sketch.js
+++ b/examples/p5js/PitchDetection/PitchDetection_Piano/sketch.js
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 ml5
-// 
+//
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
@@ -18,8 +18,8 @@ const cornerCoords = [10, 40];
 const rectWidth = 90;
 const rectHeight = 300;
 const keyRatio = 0.58;
-const scale = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
-let currentNote = '';
+const scale = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+let currentNote = "";
 
 function setup() {
   createCanvas(640, 520);
@@ -29,11 +29,11 @@ function setup() {
 }
 
 function startPitch() {
-  pitch = ml5.pitchDetection('./model/', audioContext , mic.stream, modelLoaded);
+  pitch = ml5.pitchDetection("./model/", audioContext, mic.stream, modelLoaded);
 }
 
 function modelLoaded() {
-  select('#status').html('Model Loaded');
+  select("#status").html("Model Loaded");
   getPitch();
 }
 
@@ -44,7 +44,7 @@ function getPitch() {
       currentNote = scale[midiNum % 12];
     }
     getPitch();
-  })
+  });
 }
 
 function draw() {
@@ -58,29 +58,34 @@ function drawKeyboard() {
   stroke(50);
   // White keys
   for (let i = 0; i < scale.length; i += 1) {
-    if (scale[i].indexOf('#') == -1) {
-      if (scale[i] == currentNote) {
+    if (scale[i].indexOf("#") === -1) {
+      if (scale[i] === currentNote) {
         fill(200);
       } else {
         fill(255);
       }
-      rect(cornerCoords[0] + (whiteKeyCounter * rectWidth), cornerCoords[1], rectWidth, rectHeight);
-      whiteKeyCounter++;
+      rect(cornerCoords[0] + whiteKeyCounter * rectWidth, cornerCoords[1], rectWidth, rectHeight);
+      whiteKeyCounter += 1;
     }
   }
   whiteKeyCounter = 0;
 
   // Black keys
   for (let i = 0; i < scale.length; i += 1) {
-    if (scale[i].indexOf('#') > -1) {
-      if (scale[i] == currentNote) {
+    if (scale[i].indexOf("#") > -1) {
+      if (scale[i] === currentNote) {
         fill(100);
       } else {
         fill(0);
       }
-      rect(cornerCoords[0] + (whiteKeyCounter * rectWidth) - (rectWidth / 3), cornerCoords[1], rectWidth * keyRatio, rectHeight * keyRatio);
+      rect(
+        cornerCoords[0] + whiteKeyCounter * rectWidth - rectWidth / 3,
+        cornerCoords[1],
+        rectWidth * keyRatio,
+        rectHeight * keyRatio,
+      );
     } else {
-      whiteKeyCounter++;
+      whiteKeyCounter += 1;
     }
   }
 }

--- a/examples/p5js/PoseNet/PoseNet_image_single/sketch.js
+++ b/examples/p5js/PoseNet/PoseNet_image_single/sketch.js
@@ -7,7 +7,7 @@ function setup() {
 
   // create an image using the p5 dom library
   // call modelReady() when it is loaded
-  img = createImg('data/runner.jpg', imageReady);
+  img = createImg("data/runner.jpg", imageReady);
   // set the image size to the size of the canvas
   img.size(width, height);
 
@@ -16,30 +16,29 @@ function setup() {
 }
 
 // when the image is ready, then load up poseNet
-function imageReady(){
-
+function imageReady() {
   // set some options
   const options = {
     minConfidence: 0.1,
-    inputResolution: { "width": width, "height": height }
-  }
-    
+    inputResolution: { width: width, height: height },
+  };
+
   // assign poseNet
   poseNet = ml5.poseNet(modelReady, options);
   // This sets up an event that listens to 'pose' events
-  poseNet.on('pose', function (results) {
+  poseNet.on("pose", function(results) {
     poses = results;
   });
 }
 
 // when poseNet is ready, do the detection
 function modelReady() {
-  select('#status').html('Model Loaded');
-     
+  select("#status").html("Model Loaded");
+
   // When the model is ready, run the singlePose() function...
-  // If/When a pose is detected, poseNet.on('pose', ...) will be listening for the detection results 
+  // If/When a pose is detected, poseNet.on('pose', ...) will be listening for the detection results
   // in the draw() loop, if there are any poses, then carry out the draw commands
-  poseNet.singlePose(img)
+  poseNet.singlePose(img);
 }
 
 // draw() will not show anything until poses are found
@@ -50,7 +49,6 @@ function draw() {
     drawKeypoints(poses);
     noLoop(); // stop looping when the poses are estimated
   }
-
 }
 
 // The following comes from https://ml5js.org/docs/posenet-webcam
@@ -60,7 +58,7 @@ function drawKeypoints() {
   for (let i = 0; i < poses.length; i += 1) {
     // For each pose detected, loop through all the keypoints
     const pose = poses[i].pose;
-    for (let j = 0; j < pose.keypoints.length; j++) {
+    for (let j = 0; j < pose.keypoints.length; j += 1) {
       // A keypoint is an object describing a body part (like rightArm or leftShoulder)
       const keypoint = pose.keypoints[j];
       // Only draw an ellipse is the pose probability is bigger than 0.2
@@ -80,7 +78,7 @@ function drawSkeleton() {
   for (let i = 0; i < poses.length; i += 1) {
     const skeleton = poses[i].skeleton;
     // For every skeleton, loop through all body connections
-    for (let j = 0; j < skeleton.length; j++) {
+    for (let j = 0; j < skeleton.length; j += 1) {
       const partA = skeleton[j][0];
       const partB = skeleton[j][1];
       stroke(255);

--- a/examples/p5js/PoseNet/PoseNet_image_single/sketch.js
+++ b/examples/p5js/PoseNet/PoseNet_image_single/sketch.js
@@ -57,7 +57,7 @@ function draw() {
 // A function to draw ellipses over the detected keypoints
 function drawKeypoints() {
   // Loop through all the poses detected
-  for (let i = 0; i < poses.length; i++) {
+  for (let i = 0; i < poses.length; i += 1) {
     // For each pose detected, loop through all the keypoints
     const pose = poses[i].pose;
     for (let j = 0; j < pose.keypoints.length; j++) {
@@ -77,7 +77,7 @@ function drawKeypoints() {
 // A function to draw the skeletons
 function drawSkeleton() {
   // Loop through all the skeletons detected
-  for (let i = 0; i < poses.length; i++) {
+  for (let i = 0; i < poses.length; i += 1) {
     const skeleton = poses[i].skeleton;
     // For every skeleton, loop through all body connections
     for (let j = 0; j < skeleton.length; j++) {

--- a/examples/p5js/PoseNet/PoseNet_webcam/sketch.js
+++ b/examples/p5js/PoseNet/PoseNet_webcam/sketch.js
@@ -21,7 +21,7 @@ function setup() {
   poseNet = ml5.poseNet(video, modelReady);
   // This sets up an event that fills the global variable "poses"
   // with an array every time new poses are detected
-  poseNet.on('pose', function(results) {
+  poseNet.on("pose", function(results) {
     poses = results;
   });
   // Hide the video element, and just show the canvas
@@ -29,7 +29,7 @@ function setup() {
 }
 
 function modelReady() {
-  select('#status').html('Model Loaded');
+  select("#status").html("Model Loaded");
 }
 
 function draw() {
@@ -41,12 +41,12 @@ function draw() {
 }
 
 // A function to draw ellipses over the detected keypoints
-function drawKeypoints()  {
+function drawKeypoints() {
   // Loop through all the poses detected
   for (let i = 0; i < poses.length; i += 1) {
     // For each pose detected, loop through all the keypoints
     const pose = poses[i].pose;
-    for (let j = 0; j < pose.keypoints.length; j++) {
+    for (let j = 0; j < pose.keypoints.length; j += 1) {
       // A keypoint is an object describing a body part (like rightArm or leftShoulder)
       const keypoint = pose.keypoints[j];
       // Only draw an ellipse is the pose probability is bigger than 0.2
@@ -65,7 +65,7 @@ function drawSkeleton() {
   for (let i = 0; i < poses.length; i += 1) {
     const skeleton = poses[i].skeleton;
     // For every skeleton, loop through all body connections
-    for (let j = 0; j < skeleton.length; j++) {
+    for (let j = 0; j < skeleton.length; j += 1) {
       const partA = skeleton[j][0];
       const partB = skeleton[j][1];
       stroke(255, 0, 0);

--- a/examples/p5js/PoseNet/PoseNet_webcam/sketch.js
+++ b/examples/p5js/PoseNet/PoseNet_webcam/sketch.js
@@ -43,7 +43,7 @@ function draw() {
 // A function to draw ellipses over the detected keypoints
 function drawKeypoints()  {
   // Loop through all the poses detected
-  for (let i = 0; i < poses.length; i++) {
+  for (let i = 0; i < poses.length; i += 1) {
     // For each pose detected, loop through all the keypoints
     const pose = poses[i].pose;
     for (let j = 0; j < pose.keypoints.length; j++) {
@@ -62,7 +62,7 @@ function drawKeypoints()  {
 // A function to draw the skeletons
 function drawSkeleton() {
   // Loop through all the skeletons detected
-  for (let i = 0; i < poses.length; i++) {
+  for (let i = 0; i < poses.length; i += 1) {
     const skeleton = poses[i].skeleton;
     // For every skeleton, loop through all body connections
     for (let j = 0; j < skeleton.length; j++) {

--- a/examples/p5js/Word2Vec/Word2Vec_Interactive/sketch.js
+++ b/examples/p5js/Word2Vec/Word2Vec_Interactive/sketch.js
@@ -43,7 +43,7 @@ function setup() {
     word2Vec.nearest(word, (err, result) => {
       let output = '';
       if (result) {
-        for (let i = 0; i < result.length; i++) {
+        for (let i = 0; i < result.length; i += 1) {
           output += result[i].word + '<br/>';
         }
       } else {

--- a/examples/p5js/YOLO/YOLO_single_image/sketch.js
+++ b/examples/p5js/YOLO/YOLO_single_image/sketch.js
@@ -7,22 +7,21 @@ let status;
 
 function setup() {
   createCanvas(640, 420);
-  img = createImg('images/cat2.JPG', imageReady);
+  img = createImg("images/cat2.JPG", imageReady);
   img.hide();
   img.size(640, 420);
-
 }
 
 // Change the status when the model loads.
 function modelReady() {
-  console.log("model Ready!")
+  console.log("model Ready!");
   status = true;
 }
 
 // When the image has been loaded,
 // get a prediction for that image
 function imageReady() {
-  console.log('Detecting') 
+  console.log("Detecting");
   yolo.detect(img, gotResult);
 }
 
@@ -31,24 +30,32 @@ function gotResult(err, results) {
   if (err) {
     console.log(err);
   }
-  console.log(results)
+  console.log(results);
   objects = results;
 }
 
-
 function draw() {
   // unless the model is loaded, do not draw anything to canvas
-  if (status != undefined) {
-    image(img, 0, 0)
+  if (status !== undefined) {
+    image(img, 0, 0);
 
-    for (let i = 0; i < objects.length; i++) {
+    for (let i = 0; i < objects.length; i += 1) {
       noStroke();
       fill(0, 255, 0);
-      text(objects[i].label + " " + nfc(objects[i].confidence * 100.0, 2) + "%", objects[i].x * width + 5, objects[i].y * height + 15);
+      text(
+        `${objects[i].label} ${nfc(objects[i].confidence * 100.0, 2)}%`,
+        objects[i].x * width + 5,
+        objects[i].y * height + 15,
+      );
       noFill();
       strokeWeight(4);
       stroke(0, 255, 0);
-      rect(objects[i].x * width, objects[i].y * height, objects[i].w * width, objects[i].h * height);
+      rect(
+        objects[i].x * width,
+        objects[i].y * height,
+        objects[i].w * width,
+        objects[i].h * height,
+      );
     }
   }
 }

--- a/examples/p5js/YOLO/YOLO_webcam/sketch.js
+++ b/examples/p5js/YOLO/YOLO_webcam/sketch.js
@@ -28,7 +28,7 @@ function setup() {
 
 function draw() {
   image(video, 0, 0, width, height);
-  for (let i = 0; i < objects.length; i++) {
+  for (let i = 0; i < objects.length; i += 1) {
     noStroke();
     fill(0, 255, 0);
     text(objects[i].label, objects[i].x * width, objects[i].y * height - 5);

--- a/src/CharRNN/index_test.js
+++ b/src/CharRNN/index_test.js
@@ -29,7 +29,7 @@ describe('charRnn', () => {
   let rnn;
 
   beforeAll(async () => {
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000; //set extra long interval due to issues with CharRNN generation time
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000; // set extra long interval due to issues with CharRNN generation time
     rnn  = await charRNN(RNN_MODEL_URL, undefined);
   });
 


### PR DESCRIPTION
These errors deal with doing things like `i++` and switches them to `i += 1`. ESLint prefers this approach because it's safer (https://eslint.org/docs/rules/no-plusplus). This PR also includes a lot of changes related to autoformatting on save in the files I touched.

After these changes, the lint output is:
```
✖ 1133 problems (1010 errors, 123 warnings)
  125 errors, 0 warnings potentially fixable with the `--fix` option.
```