### PR TITLE
Added a nearestFromSet function to Word2vec

### DIFF
--- a/src/Word2vec/index.js
+++ b/src/Word2vec/index.js
@@ -109,6 +109,37 @@ class Word2Vec {
     return result;
   }
 
+  /* Given a set of your own words, find the nearest neighbors */
+  async nearestFromSet(input, set, maxOrCb, cb) {
+    const { max, callback } = Word2Vec.parser(maxOrCb, cb, 10);
+    await this.ready;
+    const vector = this.model[input];
+
+    // If the input vector isn't found, bail out early.
+    if (!vector) {
+      if(callback)  callback(undefined, null);
+      return null;
+    }
+
+    const miniModel = {};
+    set.forEach((word) => {
+      if (this.model[word])   miniModel[word] = this.model[word];
+    });
+
+    // If none of the words in the set are found, also bail out
+    if (!miniModel.length) {
+      if(callback)  callback(undefined, null);
+      return null;
+    }
+
+    let result = Word2Vec.nearest(miniModel, vector, 1, max + 1);
+
+    if (callback) {
+      callback(undefined, result);
+    }
+    return result;
+  }
+
   async getRandomWord(callback) {
     await this.ready;
     const words = Object.keys(this.model);

--- a/src/Word2vec/index_test.js
+++ b/src/Word2vec/index_test.js
@@ -75,6 +75,36 @@ describe('word2vec', () => {
       }
     });
   });
+
+  describe('nearestFromSet', () => {
+    it('should return null when input word is fake', () => {
+      word2vecInstance.nearestFromSet('asdfsda', ['cat', 'ape', 'lamp'])
+      .then((nearest) => {
+        expect(nearest).to.be.null;
+      });
+    });
+    it('should return null for an empty set', () => {
+      word2vecInstance.nearestFromSet('dog', [])
+      .then((nearest) => {
+        expect(nearest).to.be.null;
+      });
+    });
+    it('should return null when word set is fake', () => {
+      word2vecInstance.nearestFromSet('dog', ["lsdfjk", "slkjf"])
+      .then((nearest) => {
+        expect(nearest).to.be.null;
+      });
+    });
+    it('nearest to "human" in ["ape", "cat", "lamp"] is "ape", then "cat"', () => {
+      word2vecInstance.nearestFromSet('human', ['cat', 'ape', 'lamp'])
+        .then((nearest) => {
+          expect(nearest[0].word).toEqual('ape');
+          expect(nearest[1].word).toEqual('cat');
+          expect(nearest[1].word).toEqual('lamp');
+      });
+  });
+});
+
   describe('add', () => {
     it('cat + dog = horse', () => {
       word2vecInstance.add(['cat', 'dog'], 1)


### PR DESCRIPTION
This PR adds new functionality to the Word2vec library. Before, you could search for the nearest word vectors to a given word (i.e. what's the nearest word to "human"?). This adds a function, `nearestFromSet`, that allows you to find the nearest word in a set:

```
results = await word2vecInstance.nearestFromSet('human', ['cat', 'ape', 'lamp'], 1);

// results is {word: "cat", distance: 0.91829} 

```