### PR TITLE
Emit warnings from ESLint rather than breaking builds

### DIFF
--- a/webpack.common.babel.js
+++ b/webpack.common.babel.js
@@ -27,6 +27,9 @@ export default {
         test: /\.js$/,
         exclude: /node_modules/,
         loader: 'eslint-loader',
+        options: {
+          emitWarning: true
+        },
       },
       {
         test: /\.js$/,


### PR DESCRIPTION
After running `npm run develop` introducing new lint errors into the code (for example, for testing) can prevent future rebuilds, which makes it harder to test things out as you're developing new things. This change updates Webpack to emit errors as warnings so that builds don't break during development.

Here's how errors will look after these changes:
![Screen Shot 2020-06-30 at 12 27 28 AM](https://user-images.githubusercontent.com/6589909/86083536-8a6d3780-ba68-11ea-9727-21d3b17a59ae.png)
