### PR TITLE
minor change for consistency with Teachable Machine

### DIFF
--- a/examples/p5js/TeachableMachine/ImageModel_TM/sketch.js
+++ b/examples/p5js/TeachableMachine/ImageModel_TM/sketch.js
@@ -22,6 +22,7 @@ let label = "";
 
 // Load the model first
 function preload() {
+  // eslint-disable-next-line prefer-template
   classifier = ml5.imageClassifier(imageModelURL + 'model.json');
 }
 

--- a/examples/p5js/TeachableMachine/ImageModel_TM/sketch.js
+++ b/examples/p5js/TeachableMachine/ImageModel_TM/sketch.js
@@ -12,7 +12,7 @@ This example uses p5 preload function to create the classifier
 // Classifier Variable
 let classifier;
 // Model URL
-const imageModelURL = 'https://teachablemachine.withgoogle.com/models/bXy2kDNi/model.json';
+const imageModelURL = 'https://teachablemachine.withgoogle.com/models/bXy2kDNi/';
 
 // Video
 let video;
@@ -22,7 +22,7 @@ let label = "";
 
 // Load the model first
 function preload() {
-  classifier = ml5.imageClassifier(imageModelURL);
+  classifier = ml5.imageClassifier(imageModelURL + 'model.json');
 }
 
 function setup() {


### PR DESCRIPTION
This is a tiny tweak of the example to match how the code is shown / explained on the Teachable Machine website itself. The URL that you are given to copy does not include `model.json`.

<img width="790" alt="Screen Shot 2020-09-08 at 5 16 13 PM" src="https://user-images.githubusercontent.com/191758/92528614-0ddc9f00-f1f7-11ea-86d9-686346337227.png">

<img width="798" alt="Screen Shot 2020-09-08 at 5 16 24 PM" src="https://user-images.githubusercontent.com/191758/92528622-10d78f80-f1f7-11ea-98c1-275ecb42909e.png">






