### PR TITLE
[docs] Fix a few broken links in the documentation

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -6,7 +6,7 @@ Mostly.
 
 A number of the ml5 sketches don't currently work in the p5 web editor due to some of the ways that the editor handles data files and some of the network communication regarding making requests to external data (e.g. the big model files that allow ml5.js to run things like image detection, etc). 
 
-There are lots of developments in the p5 web editor as well as in ml5 to make sure these environments all play nicely together. If something doesn't work in the web editor, the best thing to do is to try and run things locally if possible. See [running a local web server tutorial](/docs/tutorials/local-web-server.md).
+There are lots of developments in the p5 web editor as well as in ml5 to make sure these environments all play nicely together. If something doesn't work in the web editor, the best thing to do is to try and run things locally if possible. See [running a local web server tutorial](/tutorials/local-web-server.md).
 
 Thanks!
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -84,10 +84,10 @@
       </a>
 
       <div class="Menu__Top__Menu">
-          <a class="Menu__Top__Menu__Item" href="https://ml5js.github.io/ml5-library/docs/#/"
+          <a class="Menu__Top__Menu__Item" href="https://learn.ml5js.org/#/"
           >Getting Started</a
         >
-        <a class="Menu__Top__Menu__Item" href="https://ml5js.github.io/ml5-library/docs/#/reference/index"
+        <a class="Menu__Top__Menu__Item" href="https://learn.ml5js.org/#/reference/index"
           >Reference</a
         >
         <a class="Menu__Top__Menu__Item" href="https://ml5js.org/community/">Community</a>

--- a/docs/tutorials/hello-ml5.md
+++ b/docs/tutorials/hello-ml5.md
@@ -13,11 +13,11 @@ This example showcases how you can use a [pre-trained model](https://youtu.be/yN
 
 <br/>
 
-ml5.js is growing every day, so be sure to see some of the other applications of ml5 in the [reference](/reference) section and their accompanying examples for the latest offerings.
+ml5.js is growing every day, so be sure to see some of the other applications of ml5 in the [reference](/reference/index) section and their accompanying examples for the latest offerings.
 
 ## Setup
 
-If you've arrived here, we assume you've checked out our [quickstart](/getting-started) page to get a simple ml5.js project set up. To get this to run, you'll need:
+If you've arrived here, we assume you've checked out our [quickstart](/) page to get a simple ml5.js project set up. To get this to run, you'll need:
 
 > + 📝 A text editor (e.g. [Atom](https://atom.io/), [VSCode](https://code.visualstudio.com/), [Sublimetext](https://www.sublimetext.com/))
 > + 💻 Your web browser: Chrome & Firefox preferred


### PR DESCRIPTION
This is a documentation fix for a couple of broken links in our documentation. 

cc @shiffman for visibility put taking this one to `development` directly since it's a small nit fix!