### PR TITLE
Add docs for Handpose model

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -38,6 +38,7 @@
     * [PoseNet](/reference/posenet.md)
     * [BodyPix](/reference/bodypix.md)
     * [UNET](/reference/unet.md)
+    * [Handpose](/reference/handpose.md)
     * [Facemesh](/reference/facemesh.md)
     * [FaceApi](/reference/face-api.md)
     * [StyleTransfer](/reference/style-transfer.md)

--- a/docs/reference/facemesh.md
+++ b/docs/reference/facemesh.md
@@ -50,8 +50,8 @@ const facemesh = ml5.facemesh(?video, ?options, ?callback);
   maxContinuousChecks: 5, // How many frames to go without running the bounding box detector. Only relevant if maxFaces > 1. Defaults to 5.
   detectionConfidence: 0.9, // Threshold for discarding a prediction. Defaults to 0.9.
   maxFaces: 10, // The maximum number of faces detected in the input. Should be set to the minimum number for performance. Defaults to 10.
+  scoreThreshold: 0.75, // A threshold for removing multiple (likely duplicate) detections based on a "non-maximum suppression" algorithm. Defaults to 0.75.
   iouThreshold: 0.3, // A float representing the threshold for deciding whether boxes overlap too much in non-maximum suppression. Must be between [0, 1]. Defaults to 0.3.
-  scoreThreshold: 0.75, // A threshold for deciding when to remove boxes based on score in non-maximum suppression. Defaults to 0.75
   }
   ```
 
@@ -175,6 +175,11 @@ No demos yet - contribute one today!
 ## Tutorials
 
 No tutorials yet - contribute one today!
+
+## Model and Data Provenance
+> A project started by [Ellen Nickles](https://github.com/ellennickles/)
+
+Coming soon!
 
 ## Acknowledgements
 

--- a/docs/reference/facemesh.md
+++ b/docs/reference/facemesh.md
@@ -2,7 +2,7 @@
 
 
 <center>
-    <img style="display:block; max-height:20rem" alt="A screenshot of a video video feed where a person sits at their chair inside of a bedroom while green dots are drawn over different locations on their face." src="_media/reference__header-facemesh.jpg">
+    <img style="display:block; max-height:20rem" alt="A screenshot of a video feed where a person sits at their chair inside of a bedroom while green dots are drawn over different locations on their face." src="_media/reference__header-facemesh.jpg">
 </center>
 
 
@@ -10,7 +10,7 @@
 
 Facemesh is a machine-learning model that allows for facial landmark detection in the browser. It can detect multiple faces at once and provides 486 3D facial landmarks that describe the geometry of each face. Facemesh works best when the faces in view take up a large percentage of the image or video frame and it may struggle with small/distant faces.
 
-The ml5.js Facemesh model is ported from the [TensorFlow.js Handpose implementation](https://github.com/tensorflow/tfjs-models/tree/master/facemesh#keypoints).
+The ml5.js Facemesh model is ported from the [TensorFlow.js Facemesh implementation](https://github.com/tensorflow/tfjs-models/tree/master/facemesh).
 
 ## Quickstart
 
@@ -51,7 +51,7 @@ const facemesh = ml5.facemesh(?video, ?options, ?callback);
   detectionConfidence: 0.9, // Threshold for discarding a prediction. Defaults to 0.9.
   maxFaces: 10, // The maximum number of faces detected in the input. Should be set to the minimum number for performance. Defaults to 10.
   iouThreshold: 0.3, // A float representing the threshold for deciding whether boxes overlap too much in non-maximum suppression. Must be between [0, 1]. Defaults to 0.3.
-  scoreThreshold: 0.75, // defaults to 0.75
+  scoreThreshold: 0.75, // A threshold for deciding when to remove boxes based on score in non-maximum suppression. Defaults to 0.75
   }
   ```
 
@@ -70,7 +70,7 @@ const facemesh = ml5.facemesh(?video, ?options, ?callback);
 
 ***
 #### .model
-> *Object*. The bodyPix model.
+> *Object*. The Facemesh model.
 ***
 
 ***
@@ -179,7 +179,7 @@ No tutorials yet - contribute one today!
 ## Acknowledgements
 
 **Contributors**:
-  * Ported to ml5.js by [Bomani Oseni McClendon](https://bomani.xyz/).
+  * Ported to ml5.js by [Bomani Oseni McClendon](https://bomani.rip/).
 
 ## Source Code
 

--- a/docs/reference/handpose.md
+++ b/docs/reference/handpose.md
@@ -1,0 +1,181 @@
+# Handpose
+
+
+<center>
+    <img style="display:block; max-height:20rem" alt="A GIF of a person waving their hand in front of a camera. Green dots are drawn over different locations on their palm and fingers–demonstrating the capabilities of the Handpose model." src="_media/reference__header-handpose.gif">
+</center>
+
+
+## Description
+
+Handpose is a machine-learning model that allows for palm detection and hand-skeleton finger tracking in the browser. It can detect a maximum of one hand at a time and provides 21 3D hand keypoints that describe important locations on the palm and fingers.
+
+The ml5.js Handpose model is ported from the [TensorFlow.js Handpose implementation](https://github.com/tensorflow/tfjs-models/tree/master/handpose).
+
+## Quickstart
+
+```js
+let predictions = [];
+const video = document.getElementById('video');
+
+// Create a new handpose method
+const handpose = ml5.handpose(video, modelLoaded);
+
+// When the model is loaded
+function modelLoaded() {
+  console.log('Model Loaded!');
+}
+
+// Listen to new 'predict' events
+handpose.on('predict', results => {
+  predictions = results;
+});
+```
+
+
+## Usage
+
+### Initialize
+You can initialize ml5.handpose with an optional `video`, configuration `options` object, or a `callback` function.
+```js
+const handpose = ml5.handpose(?video, ?options, ?callback);
+```
+
+#### Parameters
+* **video**: OPTIONAL. Optional HTMLVideoElement input to run predictions on.
+* **options**: OPTIONAL. A object that contains properties that effect the Handpose model accuracy, results, etc. See documentation on the available options in [TensorFlow's Handpose documentation](https://github.com/tensorflow/tfjs-models/tree/master/handpose#parameters-for-handposeload).
+```js
+const options = {
+    flipHorizontal: false, // boolean value for if the video should be flipped, defaults to false
+    maxContinuousChecks: Infinity, // How many frames to go without running the bounding box detector. Defaults to infinity, but try a lower value if the detector is consistently producing bad predictions.
+    detectionConfidence: 0.8, // Threshold for discarding a prediction. Defaults to 0.8.
+    iouThreshold: 0.3, // A float representing the threshold for deciding whether boxes overlap too much in non-maximum suppression. Must be between [0, 1]. Defaults to 0.3.
+    scoreThreshold: 0.75, // A threshold for deciding when to remove boxes based on score in non-maximum suppression. Defaults to 0.75
+}
+```
+
+* **callback**: OPTIONAL. A function that is called once the model has loaded.
+
+### Properties
+***
+#### .video
+> *Object*. HTMLVideoElement if given in the constructor. Otherwise it is null.
+***
+
+***
+#### .config
+> *Object*. containing all of the configuration options passed into the model.
+***
+
+***
+#### .model
+> *Object*. The Handpose model.
+***
+
+***
+#### .modelReady
+> *Boolean*. Truthy value indicating the model has loaded.
+***
+
+### Methods
+
+***
+#### .predict()
+> A function that returns the results of a single hand detection prediction.
+
+  ```js
+  handpose.predict(inputMedia, callback);
+  ```
+
+📥 **Inputs**
+* **inputMedia**: REQUIRED. An HMTL or p5.js image, video, or canvas element that you'd like to run a single prediction on.
+
+* **callback**: OPTIONAL.  A callback function to handle new hand detection predictions. For example:
+
+  ```js
+  handpose.predict(inputMedia, results => {
+    // do something with the results
+    console.log(results);
+  });
+  ```
+
+📤 **Outputs**
+
+* **Array**: Returns an array of objects describing each detected hand. You can see all of the supported annotation in [the Tensorflow source code](https://github.com/tensorflow/tfjs-models/blob/master/handpose/src/keypoints.ts).
+
+  ```js
+  [
+      {
+        handInViewConfidence: 1, // The probability of a hand being present.
+        boundingBox: { // The bounding box surrounding the hand.
+          topLeft: [162.91, -17.42],
+          bottomRight: [548.56, 368.23],
+        },
+        landmarks: [ // The 3D coordinates of each hand landmark.
+          [472.52, 298.59, 0.00],
+          [412.80, 315.64, -6.18],
+          ...
+        ],
+        annotations: { // Semantic groupings of the `landmarks` coordinates.
+          thumb: [
+            [412.80, 315.64, -6.18]
+            [350.02, 298.38, -7.14],
+            ...
+          ],
+          ...
+        }
+      }
+    ]
+  ```
+
+***
+
+#### .on('predict', ...)
+> An event listener that returns the results when a new hand detection prediction occurs.
+
+  ```js
+  handpose.on('predict', callback);
+  ```
+
+📥 **Inputs**
+
+* **callback**: REQUIRED.  A callback function to handle new hand detection predictions. For example:
+
+  ```js
+  handpose.on('predict', results => {
+    // do something with the results
+    console.log(results);
+  });
+  ```
+
+📤 **Outputs**
+
+* **Array**: Returns an array of objects describing each detected hand as an array of objects exactly like the output of the `.predict()` method described above.
+
+
+## Examples
+
+**p5.js**
+* [Handpose_Image](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/Handpose/Handpose_Image)
+* [Handpose_Webcam](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/Handpose/Handpose_Webcam)
+
+**p5 web editor**
+* [Handpose_Image](https://editor.p5js.org/ml5/sketches/Handpose_Image)
+* [Handpose_Webcam](https://editor.p5js.org/ml5/sketches/Handpose_Webcam)
+
+## Demo
+
+No demos yet - contribute one today!
+
+## Tutorials
+
+No tutorials yet - contribute one today!
+
+## Acknowledgements
+
+**Contributors**:
+  * Ported to ml5.js by [Bomani Oseni McClendon](https://bomani.rip/).
+
+## Source Code
+
+* [/src/Handpose](https://github.com/ml5js/ml5-library/tree/development/src/Handpose)

--- a/docs/reference/handpose.md
+++ b/docs/reference/handpose.md
@@ -46,11 +46,11 @@ const handpose = ml5.handpose(?video, ?options, ?callback);
 * **options**: OPTIONAL. A object that contains properties that effect the Handpose model accuracy, results, etc. See documentation on the available options in [TensorFlow's Handpose documentation](https://github.com/tensorflow/tfjs-models/tree/master/handpose#parameters-for-handposeload).
 ```js
 const options = {
-    flipHorizontal: false, // boolean value for if the video should be flipped, defaults to false
-    maxContinuousChecks: Infinity, // How many frames to go without running the bounding box detector. Defaults to infinity, but try a lower value if the detector is consistently producing bad predictions.
-    detectionConfidence: 0.8, // Threshold for discarding a prediction. Defaults to 0.8.
-    iouThreshold: 0.3, // A float representing the threshold for deciding whether boxes overlap too much in non-maximum suppression. Must be between [0, 1]. Defaults to 0.3.
-    scoreThreshold: 0.75, // A threshold for deciding when to remove boxes based on score in non-maximum suppression. Defaults to 0.75
+  flipHorizontal: false, // boolean value for if the video should be flipped, defaults to false
+  maxContinuousChecks: Infinity, // How many frames to go without running the bounding box detector. Defaults to infinity, but try a lower value if the detector is consistently producing bad predictions.
+  detectionConfidence: 0.8, // Threshold for discarding a prediction. Defaults to 0.8.
+  scoreThreshold: 0.75, // A threshold for removing multiple (likely duplicate) detections based on a "non-maximum suppression" algorithm. Defaults to 0.75
+  iouThreshold: 0.3, // A float representing the threshold for deciding whether boxes overlap too much in non-maximum suppression. Must be between [0, 1]. Defaults to 0.3.
 }
 ```
 
@@ -170,6 +170,11 @@ No demos yet - contribute one today!
 ## Tutorials
 
 No tutorials yet - contribute one today!
+
+## Model and Data Provenance
+> A project started by [Ellen Nickles](https://github.com/ellennickles/)
+
+Coming soon!
 
 ## Acknowledgements
 


### PR DESCRIPTION
This PR introduces a documentation page for the Handpose model. While here, I also made some fixes to the Facemesh documentation to correct some typos I had accidentally left in that documentation.

![Screen Shot 2020-09-30 at 2 44 45 PM (2)](https://user-images.githubusercontent.com/6589909/94726814-c2b43880-032b-11eb-9f23-5da7fb6ba7ce.png)
