### PR TITLE
using whileTraining callback always when specified

### DIFF
--- a/src/NeuralNetwork/index.js
+++ b/src/NeuralNetwork/index.js
@@ -515,7 +515,7 @@ class DiyNeuralNetwork {
       options.whileTraining = [
         this.neuralNetworkVis.trainingVis(),
         {
-          onEpochEnd: null,
+          onEpochEnd: whileTrainingCb,
         },
       ];
     } else {


### PR DESCRIPTION
This is a small change related to how the training callbacks work in `ml5.neuralNetwork()`. 

Take the following:

```javascript
  const nnOptions = {
    dataUrl: 'data/colorData.json',
    inputs: ['r', 'g', 'b'],
    outputs: ['label'],
    task: 'classification',
    debug: true
  };
  neuralNetwork = ml5.neuralNetwork(nnOptions, modelReady);

function modelReady() {
  neuralNetwork.train({epochs: 20}, whileTraining, finishedTraining);
}
```

The "bug" here is that if with `debug: true` the `whileTraining()` callback is ignored. Now it is always called whether or not the visualization panel is active.


Ultimately the work from @joeyklee and @yining1023 in #967 will supercede this, but I thought this is a useful fix in the short-term!