### PR TITLE
Remove references to the development and main branches on the new main branch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,12 +9,7 @@ I'm making a Pull Request(PR). Please see the details below.
 
 **A good PR 🌟**
 
-### → Step 1:  Which branch are you submitting to? 🌲
-> Development (for new features or updates), Release (for bug fixes), or ___________?
-
-
-
-### → Step 2: Describe your Pull Request 📝
+### → Step 1: Describe your Pull Request 📝
 > Fixing a Bug? Adding an Update? Submitting a New Feature? Does it introduce a breaking change?
 
 
@@ -23,7 +18,7 @@ I'm making a Pull Request(PR). Please see the details below.
 
 **A great PR 🌟🌟**
 
-### → Step 3: Share a Relevant Example 🦄
+### → Step 2: Share a Relevant Example 🦄
 > Here's some example code or a demonstration of my feature as a part of this pull request, a separate pull request, in the https://editor.p5js.org, or codepen/jsfiddle/etc...
 
 
@@ -31,7 +26,7 @@ I'm making a Pull Request(PR). Please see the details below.
 
 **The best PR 🌟🌟🌟**
 
-### → Step 4: Screenshots or Relevant Documentation 🖼
+### → Step 3: Screenshots or Relevant Documentation 🖼
 > Here's some helpful screenshots and/or documentation of the new feature 
 
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -41,7 +41,7 @@ We like these hashtags: #noCodeSnobs (because we value community over efficiency
 
 Our community is always looking for enthusiasts to help in all different ways.
 
--  **Develop**. [GitHub](https://github.com/ml5js/ml5-library) is the main place where code is collected, issues are documented, and discussions about code are had. Check out the [contributing documentation to get started](https://github.com/ml5js/ml5-library/blob/development/CONTRIBUTING.md) with developing the library.
+-  **Develop**. [GitHub](https://github.com/ml5js/ml5-library) is the main place where code is collected, issues are documented, and discussions about code are had. Check out the [contributing documentation to get started](https://github.com/ml5js/ml5-library/blob/main/CONTRIBUTING.md) with developing the library.
 -  **Document**. Everyone loves documentation. Help is needed porting examples, and adding documentation, and creating tutorials.
 -  **Teach**. Teach a workshop, a class, a friend, a collaborator! Tag [@ml5js on Twitter](https://twitter.com/ml5js?lang=en) and we will do our best to share what you're doing.
 -  **Create**. ml5.js is looking for designers, artists, coders, programmers to bring your creative and amazing work to show and inspire other people. Submit your work to info@ml5js.org.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,8 +37,8 @@ Preamble: If you're interested in to contribute to the ml5 project, just know yo
 3. you make a comment on an existing issue or post your issue and indicate that you're curious to do your best to solve it 🔬
 4. you create a new branch on your `forked` copy of the ml5-library and call it something meaningful like `fix-detection-results`
 5. you jam on fixing the bug, commit your changes with meaningful commit messages, and push your changes to your bug fix branch (e.g. `fix-detection-results`)
-6. when ready, make a pull request to the `main` branch of ml5-library. Prepend "[NEEDS RELEASE]" to the title if the bug you found was in the current ml5 release - the version of ml5 which is on npm.
-7. the ml5 dev team will review your changes and quite likely correspond with you on your changes. When all looks good, your changes will be merged in. 🎉
+6. when ready, make a pull request to the `main` branch of ml5-library. Prepend "[NEEDS RELEASE]" to the title if the bug you found was in the current ml5 release - the version of ml5 which is on npm. 
+7. the ml5 dev team will review your changes and quite likely correspond with you on your changes. When all looks good, a `ready for release` label will be added to your PR and your changes will be merged in and release with the next public update to the library. 🎉
 8. hi-fives 👏 and hugs 🤗
 
 ### For new features or feature additions/updates

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Preamble: If you're interested in to contribute to the ml5 project, just know yo
 3. you make a comment on an existing issue or post your issue and indicate that you're curious to do your best to solve it 🔬
 4. you create a new branch on your `forked` copy of the ml5-library and call it something meaningful like `fix-detection-results`
 5. you jam on fixing the bug, commit your changes with meaningful commit messages, and push your changes to your bug fix branch (e.g. `fix-detection-results`)
-6. when ready, make a pull request to the `release` branch or `development` branch of ml5-library. Submit to the `release` branch if the bug you found was in the current ml5 release - the version of ml5 which is on npm. Submit to the `development` branch if the bug you found was in `development` branch of ml5-library.
+6. when ready, make a pull request to the `main` branch of ml5-library. Prepend "[NEEDS RELEASE]" to the title if the bug you found was in the current ml5 release - the version of ml5 which is on npm.
 7. the ml5 dev team will review your changes and quite likely correspond with you on your changes. When all looks good, your changes will be merged in. 🎉
 8. hi-fives 👏 and hugs 🤗
 
@@ -48,7 +48,7 @@ Preamble: If you're interested in to contribute to the ml5 project, just know yo
 4. you create a new branch on your `forked` copy of the ml5-library and call it something meaningful like `new-generative-model-x`
 5. you jam on your new feature, commit your changes with meaningful commit messages, and push your changes to your new feature branch (e.g. `new-generative-model-x`)
 6. you should also add an example of your new feature to the `examples/` directory so that other people can learn how to use your new feature.
-7. when ready, make a pull request to the `development` branch of ml5-library. Submit to the `development` since your feature is part of the new frontier of the ml5-library.
+7. when ready, make a pull request to the `main` branch of ml5-library.
 8. the ml5 dev team will review your changes and quite likely correspond with you on your changes. When all looks good, your changes will be merged in. 🎉
 9. hi-fives 👏 and hugs 🤗
 
@@ -251,6 +251,8 @@ This last one is case sensitive!
 
 
 ## Making Releases (For the ml5 core team)
+
+**NOTE: This section needs to be updated to align with the new `main` branch structure.**
 
 Work in progress - we are working on making a few scripts to make it easier to make releases and deployments. For now, to address the long-winded process noted in https://github.com/ml5js/ml5-library/issues/387, we are experimenting with some devOps scripts.
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ For example:
 
 - [Getting Started](https://ml5js.org/getting-started/)
 - [API Reference](https://ml5js.org/reference/)
-- [Examples](https://github.com/ml5js/ml5-library/tree/development/examples)
+- [Examples](https://github.com/ml5js/ml5-library/tree/main/examples)
 - [Community](https://ml5js.org/community)
 - [FAQ](https://ml5js.org/getting-started/faq/)
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -28,4 +28,4 @@ Please contact us at [@ml5js on twitter](https://twitter.com/ml5js), <a href="ma
 
 ### How can I contribute?
 
-Please refer to the contributor documentation [on Github](https://github.com/ml5js/ml5-library/blob/development/CONTRIBUTING.md).
+Please refer to the contributor documentation [on Github](https://github.com/ml5js/ml5-library/blob/main/CONTRIBUTING.md).

--- a/docs/reference/bodypix.md
+++ b/docs/reference/bodypix.md
@@ -262,10 +262,10 @@ bodyPix.segmentWithParts(?input, ?options, callback);
 ## Examples
 
 **p5.js**
-* [BodyPix_Image](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/BodyPix/BodyPix_Image)
-* [BodyPix_Webcam](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/BodyPix/BodyPix_Webcam)
-* [BodyPix_Webcam_Parts](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/BodyPix/BodyPix_Webcam_Parts)
-* [BodyPix_p5Instance](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/BodyPix/BodyPix_p5Instance)
+* [BodyPix_Image](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/BodyPix/BodyPix_Image)
+* [BodyPix_Webcam](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/BodyPix/BodyPix_Webcam)
+* [BodyPix_Webcam_Parts](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/BodyPix/BodyPix_Webcam_Parts)
+* [BodyPix_p5Instance](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/BodyPix/BodyPix_p5Instance)
 
 **p5 web editor**
 * [BodyPix_Image](https://editor.p5js.org/ml5/sketches/BodyPix_Image)
@@ -274,9 +274,9 @@ bodyPix.segmentWithParts(?input, ?options, callback);
 * [BodyPix_p5Instance](https://editor.p5js.org/ml5/sketches/BodyPix_p5Instance)
 
 **plain javascript**
-* [BodyPix_Image](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/BodyPix/BodyPix_Image)
-* [BodyPix_Webcam](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/BodyPix/BodyPix_Webcam)
-* [BodyPix_Webcam_Parts](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/BodyPix/BodyPix_Webcam_Parts)
+* [BodyPix_Image](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/BodyPix/BodyPix_Image)
+* [BodyPix_Webcam](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/BodyPix/BodyPix_Webcam)
+* [BodyPix_Webcam_Parts](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/BodyPix/BodyPix_Webcam_Parts)
 
 ## Demo
 
@@ -347,4 +347,4 @@ TBD
 
 ## Source Code
 
-* [/src/BodyPix](https://github.com/ml5js/ml5-library/tree/development/src/BodyPix)
+* [/src/BodyPix](https://github.com/ml5js/ml5-library/tree/main/src/BodyPix)

--- a/docs/reference/charrnn.md
+++ b/docs/reference/charrnn.md
@@ -153,9 +153,9 @@ charrnn.reset();
 ## Examples
 
 **p5.js**
-* [CharRNN_Interactive](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/CharRNN/CharRNN_Interactive)
-* [CharRNN_Text](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/CharRNN/CharRNN_Text)
-* [CharRNN_Text_Stateful](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/CharRNN/CharRNN_Text_Stateful)
+* [CharRNN_Interactive](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/CharRNN/CharRNN_Interactive)
+* [CharRNN_Text](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/CharRNN/CharRNN_Text)
+* [CharRNN_Text_Stateful](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/CharRNN/CharRNN_Text_Stateful)
 
 **p5 web editor**
 
@@ -164,9 +164,9 @@ charrnn.reset();
 * [CharRNN_Text_Stateful](https://editor.p5js.org/ml5/sketches/CharRNN_Text_Stateful)
 
 **plain javascript**
-* [CharRNN_Interactive](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/CharRNN/CharRNN_Interactive)
-* [CharRNN_Text](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/CharRNN/CharRNN_Text)
-* [CharRNN_Text_Stateful](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/CharRNN/CharRNN_Text_Stateful)
+* [CharRNN_Interactive](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/CharRNN/CharRNN_Interactive)
+* [CharRNN_Text](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/CharRNN/CharRNN_Text)
+* [CharRNN_Text_Stateful](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/CharRNN/CharRNN_Text_Stateful)
 
 ## Demo
 

--- a/docs/reference/cvae.md
+++ b/docs/reference/cvae.md
@@ -85,13 +85,13 @@ cvae.generate(label, callback);
 ## Examples
 
 **p5.js**
-* [CVAE_QuickDraw](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/CVAE/CVAE_QuickDraw)
+* [CVAE_QuickDraw](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/CVAE/CVAE_QuickDraw)
 
 **p5 web editor**
 * [CVAE_QuickDraw](https://editor.p5js.org/ml5/sketches/CVAE_QuickDraw)
 
 **plain javascript**
-* [CVAE_QuickDraw](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/CVAE/CVAE_QuickDraw)
+* [CVAE_QuickDraw](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/CVAE/CVAE_QuickDraw)
 
 
 ## Demo
@@ -157,4 +157,4 @@ TBD
 
 ## Source Code
 
-[/src/CVAE/](https://github.com/ml5js/ml5-library/tree/development/src/CVAE)
+[/src/CVAE/](https://github.com/ml5js/ml5-library/tree/main/src/CVAE)

--- a/docs/reference/dcgan.md
+++ b/docs/reference/dcgan.md
@@ -105,10 +105,10 @@ dcgan.generate(callback, ?latentVector);
 ## Examples
 
 **p5.js**
-* [DCGAN_LatentVector](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/DCGAN/DCGAN_LatentVector)
-* [DCGAN_LatentVector_RandomWalk](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/DCGAN/DCGAN_LatentVector_RandomWalk)
-* [DCGAN_LatentVector_Slider](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/DCGAN/DCGAN_LatentVector_Slider)
-* [DCGAN_Random](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/DCGAN/DCGAN_Random)
+* [DCGAN_LatentVector](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/DCGAN/DCGAN_LatentVector)
+* [DCGAN_LatentVector_RandomWalk](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/DCGAN/DCGAN_LatentVector_RandomWalk)
+* [DCGAN_LatentVector_Slider](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/DCGAN/DCGAN_LatentVector_Slider)
+* [DCGAN_Random](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/DCGAN/DCGAN_Random)
 
 **p5 web editor**
 * [DCGAN_LatentVector](https://editor.p5js.org/ml5/sketches/DCGAN_LatentVector)
@@ -118,10 +118,10 @@ dcgan.generate(callback, ?latentVector);
 
 
 **plain javascript**
-* [DCGAN_LatentVector](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/DCGAN/DCGAN_LatentVector)
-* [DCGAN_LatentVector_RandomWalk](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/DCGAN/DCGAN_LatentVector_RandomWalk)
-* [DCGAN_LatentVector_Slider](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/DCGAN/DCGAN_LatentVector_Slider)
-* [DCGAN_Random](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/DCGAN/DCGAN_Random)
+* [DCGAN_LatentVector](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/DCGAN/DCGAN_LatentVector)
+* [DCGAN_LatentVector_RandomWalk](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/DCGAN/DCGAN_LatentVector_RandomWalk)
+* [DCGAN_LatentVector_Slider](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/DCGAN/DCGAN_LatentVector_Slider)
+* [DCGAN_Random](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/DCGAN/DCGAN_Random)
 
 
 

--- a/docs/reference/face-api.md
+++ b/docs/reference/face-api.md
@@ -139,18 +139,18 @@ faceapi.detectSingle(optionsOrCallback, configOrCallback, callback);
 ## Examples
 
 **p5.js**
-* [FaceApi_Image_Landmarks](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/FaceApi/FaceApi_Image_Landmarks)
-* [FaceApi_Video_Landmarks](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/FaceApi/FaceApi_Video_Landmarks)
-* [FaceApi_Video_Landmarks_LocalModels](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/FaceApi/FaceApi_Video_Landmarks_LocalModels)
+* [FaceApi_Image_Landmarks](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/FaceApi/FaceApi_Image_Landmarks)
+* [FaceApi_Video_Landmarks](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/FaceApi/FaceApi_Video_Landmarks)
+* [FaceApi_Video_Landmarks_LocalModels](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/FaceApi/FaceApi_Video_Landmarks_LocalModels)
 
 **p5 web editor**
 * [FaceApi_Image_Landmarks](https://editor.p5js.org/ml5/sketches/FaceApi_Image_Landmarks)
 * [FaceApi_Video_Landmarks](https://editor.p5js.org/ml5/sketches/FaceApi_Video_Landmarks)
 
 **plain javascript**
-* [FaceApi_Image_Landmarks](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/FaceApi/FaceApi_Image_Landmarks/)
-* [FaceApi_Video_Landmarks](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/FaceApi/FaceApi_Video_Landmarks/)
-* [FaceApi_Video_Landmarks_LocalModels](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/FaceApi/FaceApi_Video_Landmarks_LocalModels/)
+* [FaceApi_Image_Landmarks](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/FaceApi/FaceApi_Image_Landmarks/)
+* [FaceApi_Video_Landmarks](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/FaceApi/FaceApi_Video_Landmarks/)
+* [FaceApi_Video_Landmarks_LocalModels](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/FaceApi/FaceApi_Video_Landmarks_LocalModels/)
 
 ## Demo
 
@@ -289,4 +289,4 @@ Each model is a type of convolutional neural network (CNN). A CNN finds patterns
 
 ## Source Code
 
-* [/src/FaceApi](https://github.com/ml5js/ml5-library/tree/development/src/FaceApi)
+* [/src/FaceApi](https://github.com/ml5js/ml5-library/tree/main/src/FaceApi)

--- a/docs/reference/facemesh.md
+++ b/docs/reference/facemesh.md
@@ -161,8 +161,8 @@ const facemesh = ml5.facemesh(?video, ?options, ?callback);
 ## Examples
 
 **p5.js**
-* [Facemesh_Image](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/Facemesh/Facemesh_Image)
-* [Facemesh_Webcam](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/Facemesh/Facemesh_Webcam)
+* [Facemesh_Image](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/Facemesh/Facemesh_Image)
+* [Facemesh_Webcam](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/Facemesh/Facemesh_Webcam)
 
 **p5 web editor**
 * [Facemesh_Image](https://editor.p5js.org/ml5/sketches/Facemesh_Image)
@@ -188,4 +188,4 @@ Coming soon!
 
 ## Source Code
 
-* [/src/Facemesh](https://github.com/ml5js/ml5-library/tree/development/src/Facemesh)
+* [/src/Facemesh](https://github.com/ml5js/ml5-library/tree/main/src/Facemesh)

--- a/docs/reference/feature-extractor.md
+++ b/docs/reference/feature-extractor.md
@@ -256,8 +256,8 @@ featureExtractor.load(filesOrPath = null, callback);
 ## Examples
 
 **p5.js**
-* [FeatureExtractor_Image_Regression](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/FeatureExtractor/FeatureExtractor_Image_Regression)
-* [FeatureExtractor_Image_Classification](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/FeatureExtractor/FeatureExtractor_Image_Classification)
+* [FeatureExtractor_Image_Regression](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/FeatureExtractor/FeatureExtractor_Image_Regression)
+* [FeatureExtractor_Image_Classification](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/FeatureExtractor/FeatureExtractor_Image_Classification)
 
 **p5 web editor**
 * [FeatureExtractor_Image_Regression](https://editor.p5js.org/ml5/sketches/FeatureExtractor_Image_Regression)
@@ -265,8 +265,8 @@ featureExtractor.load(filesOrPath = null, callback);
 
 
 **plain javascript**
-* [FeatureExtractor_Image_Regression](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/FeatureExtractor/FeatureExtractor_Image_Regression)
-* [FeatureExtractor_Image_Classification](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/FeatureExtractor/FeatureExtractor_Image_Classification)
+* [FeatureExtractor_Image_Regression](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/FeatureExtractor/FeatureExtractor_Image_Regression)
+* [FeatureExtractor_Image_Classification](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/FeatureExtractor/FeatureExtractor_Image_Classification)
 
 
 
@@ -295,4 +295,4 @@ No demos yet - contribute one today!
 
 ## Source Code
 
-[src/FeatureExtractor](https://github.com/ml5js/ml5-library/tree/development/src/FeatureExtractor)
+[src/FeatureExtractor](https://github.com/ml5js/ml5-library/tree/main/src/FeatureExtractor)

--- a/docs/reference/handpose.md
+++ b/docs/reference/handpose.md
@@ -156,8 +156,8 @@ const options = {
 ## Examples
 
 **p5.js**
-* [Handpose_Image](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/Handpose/Handpose_Image)
-* [Handpose_Webcam](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/Handpose/Handpose_Webcam)
+* [Handpose_Image](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/Handpose/Handpose_Image)
+* [Handpose_Webcam](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/Handpose/Handpose_Webcam)
 
 **p5 web editor**
 * [Handpose_Image](https://editor.p5js.org/ml5/sketches/Handpose_Image)
@@ -183,4 +183,4 @@ Coming soon!
 
 ## Source Code
 
-* [/src/Handpose](https://github.com/ml5js/ml5-library/tree/development/src/Handpose)
+* [/src/Handpose](https://github.com/ml5js/ml5-library/tree/main/src/Handpose)

--- a/docs/reference/image-classifier.md
+++ b/docs/reference/image-classifier.md
@@ -124,16 +124,16 @@ classifier.classify(?numberOfClasses , ?callback);
 ## Examples
 
 **p5.js**
-* [ImageClassification](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/ImageClassification/ImageClassification)
-* [ImageClassification_DoodleNet_Canvas](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/ImageClassification/ImageClassification_DoodleNet_Canvas)
-* [ImageClassification_DoodleNet_Video](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/ImageClassification/ImageClassification_DoodleNet_Video)
-* [ImageClassification_MultipleImages](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/ImageClassification/ImageClassification_MultipleImages)
-* [ImageClassification_Teachable-Machine](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/ImageClassification/ImageClassification_Teachable-Machine)
-* [ImageClassification_Video](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/ImageClassification/ImageClassification_Video)
-* [ImageClassification_VideoScavengerHunt](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/ImageClassification/ImageClassification_VideoScavengerHunt)
-* [ImageClassification_VideoSound](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/ImageClassification/ImageClassification_VideoSound)
-* [ImageClassification_VideoSoundTranslate](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/ImageClassification/ImageClassification_VideoSoundTranslate)
-* [ImageClassification_Video_Load](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/ImageClassification/ImageClassification_Video_Load)
+* [ImageClassification](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/ImageClassification/ImageClassification)
+* [ImageClassification_DoodleNet_Canvas](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/ImageClassification/ImageClassification_DoodleNet_Canvas)
+* [ImageClassification_DoodleNet_Video](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/ImageClassification/ImageClassification_DoodleNet_Video)
+* [ImageClassification_MultipleImages](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/ImageClassification/ImageClassification_MultipleImages)
+* [ImageClassification_Teachable-Machine](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/ImageClassification/ImageClassification_Teachable-Machine)
+* [ImageClassification_Video](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/ImageClassification/ImageClassification_Video)
+* [ImageClassification_VideoScavengerHunt](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/ImageClassification/ImageClassification_VideoScavengerHunt)
+* [ImageClassification_VideoSound](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/ImageClassification/ImageClassification_VideoSound)
+* [ImageClassification_VideoSoundTranslate](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/ImageClassification/ImageClassification_VideoSoundTranslate)
+* [ImageClassification_Video_Load](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/ImageClassification/ImageClassification_Video_Load)
 
 **p5.js Web Editor**
 
@@ -148,15 +148,15 @@ classifier.classify(?numberOfClasses , ?callback);
 * [ImageClassification_VideoSoundTranslate](https://editor.p5js.org/ml5/sketches/ImageClassification_VideoSoundTranslate)
 
 **plain javascript**
-* [ImageClassification](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/ImageClassification/ImageClassification)
-* [ImageClassification_DoodleNet_Canvas](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/ImageClassification/ImageClassification_DoodleNet_Canvas)
-* [ImageClassification_DoodleNet_Video](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/ImageClassification/ImageClassification_DoodleNet_Video)
-* [ImageClassification_MultipleImages](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/ImageClassification/ImageClassification_MultipleImages)
-* [ImageClassification_Video](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/ImageClassification/ImageClassification_Video)
-* [ImageClassification_VideoScavengerHunt](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/ImageClassification/ImageClassification_VideoScavengerHunt)
-* [ImageClassification_VideoSound](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/ImageClassification/ImageClassification_VideoSound)
-* [ImageClassification_VideoSoundTranslate](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/ImageClassification/ImageClassification_VideoSoundTranslate)
-* [ImageClassification_Video_Load](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/ImageClassification/ImageClassification_Video_Load)
+* [ImageClassification](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/ImageClassification/ImageClassification)
+* [ImageClassification_DoodleNet_Canvas](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/ImageClassification/ImageClassification_DoodleNet_Canvas)
+* [ImageClassification_DoodleNet_Video](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/ImageClassification/ImageClassification_DoodleNet_Video)
+* [ImageClassification_MultipleImages](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/ImageClassification/ImageClassification_MultipleImages)
+* [ImageClassification_Video](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/ImageClassification/ImageClassification_Video)
+* [ImageClassification_VideoScavengerHunt](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/ImageClassification/ImageClassification_VideoScavengerHunt)
+* [ImageClassification_VideoSound](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/ImageClassification/ImageClassification_VideoSound)
+* [ImageClassification_VideoSoundTranslate](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/ImageClassification/ImageClassification_VideoSoundTranslate)
+* [ImageClassification_Video_Load](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/ImageClassification/ImageClassification_Video_Load)
 
 ## Demo
 
@@ -293,4 +293,4 @@ A nice description of the models overview
 
 ## Source Code
 
-* [/src/ImageClassifier](https://github.com/ml5js/ml5-library/tree/development/src/ImageClassifier)
+* [/src/ImageClassifier](https://github.com/ml5js/ml5-library/tree/main/src/ImageClassifier)

--- a/docs/reference/kmeans.md
+++ b/docs/reference/kmeans.md
@@ -90,7 +90,7 @@ const kmeans = ml5.kmeans(data, ?options, ?callback);
 ## Examples
 
 **p5.js**
-* [KMeans_imageSegmentation](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/KMeans/KMeans_imageSegmentation/)
+* [KMeans_imageSegmentation](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/KMeans/KMeans_imageSegmentation/)
 
 **p5 web editor**
 * [KMeans_imageSegmentation](https://editor.p5js.org/ml5/sketches/KMeans_imageSegmentation/)
@@ -99,7 +99,7 @@ const kmeans = ml5.kmeans(data, ?options, ?callback);
 * coming soon
 
 **d3.js**
-* [KMeans_GaussianClusterDemo](https://github.com/ml5js/ml5-library/tree/development/examples/d3/KMeans/KMeans_GaussianClusterDemo)
+* [KMeans_GaussianClusterDemo](https://github.com/ml5js/ml5-library/tree/main/examples/d3/KMeans/KMeans_GaussianClusterDemo)
 
 ## Demo
 
@@ -120,4 +120,4 @@ No tutorials yet - contribute one today!
 
 ## Source Code
 
-* [/src/KMeans](https://github.com/ml5js/ml5-library/tree/development/src/KMeans)
+* [/src/KMeans](https://github.com/ml5js/ml5-library/tree/main/src/KMeans)

--- a/docs/reference/knn-classifier.md
+++ b/docs/reference/knn-classifier.md
@@ -227,10 +227,10 @@ knnClassifier.load(path, ?callback);
 ## Examples
 
 **p5.js**
-* [KNNClassification_PoseNet](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/KNNClassification/KNNClassification_PoseNet)
-* [KNNClassification_Video](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/KNNClassification/KNNClassification_Video)
-* [KNNClassification_VideoSound](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/KNNClassification/KNNClassification_VideoSound)
-* [KNNClassification_VideoSquare](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/KNNClassification/KNNClassification_VideoSquare)
+* [KNNClassification_PoseNet](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/KNNClassification/KNNClassification_PoseNet)
+* [KNNClassification_Video](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/KNNClassification/KNNClassification_Video)
+* [KNNClassification_VideoSound](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/KNNClassification/KNNClassification_VideoSound)
+* [KNNClassification_VideoSquare](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/KNNClassification/KNNClassification_VideoSquare)
 
 **p5 web editor**
 * [KNNClassification_PoseNet](https://editor.p5js.org/ml5/sketches/KNNClassification_PoseNet)
@@ -240,10 +240,10 @@ knnClassifier.load(path, ?callback);
 
 
 **plain javascript**
-* [KNNClassification_PoseNet](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/KNNClassification/KNNClassification_PoseNet)
-* [KNNClassification_Video](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/KNNClassification/KNNClassification_Video)
-* [KNNClassification_VideoSound](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/KNNClassification/KNNClassification_VideoSound)
-* [KNNClassification_VideoSquare](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/KNNClassification/KNNClassification_VideoSquare)
+* [KNNClassification_PoseNet](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/KNNClassification/KNNClassification_PoseNet)
+* [KNNClassification_Video](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/KNNClassification/KNNClassification_Video)
+* [KNNClassification_VideoSound](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/KNNClassification/KNNClassification_VideoSound)
+* [KNNClassification_VideoSquare](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/KNNClassification/KNNClassification_VideoSquare)
 
 
 
@@ -272,4 +272,4 @@ No demos yet - contribute one today!
 
 ## Source Code
 
-[/src/KNNClassifier/](https://github.com/ml5js/ml5-library/tree/development/src/KNNClassifier)
+[/src/KNNClassifier/](https://github.com/ml5js/ml5-library/tree/main/src/KNNClassifier)

--- a/docs/reference/neural-network.md
+++ b/docs/reference/neural-network.md
@@ -773,21 +773,21 @@ neuralNetwork.load(?filesOrPath, ?callback);
 
 
 **p5.js**
-- [NeuralNetwork_Simple_Classification](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/NeuralNetwork/NeuralNetwork_Simple_Classification)
-- [NeuralNetwork_Simple_Regression](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/NeuralNetwork/NeuralNetwork_Simple_Regression)
-- [NeuralNetwork_XOR](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/NeuralNetwork/NeuralNetwork_XOR)
-- [NeuralNetwork_basics](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/NeuralNetwork/NeuralNetwork_basics)
-- [NeuralNetwork_co2net](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/NeuralNetwork/NeuralNetwork_co2net)
-- [NeuralNetwork_color_classifier](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/NeuralNetwork/NeuralNetwork_color_classifier)
-- [NeuralNetwork_load_model](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/NeuralNetwork/NeuralNetwork_load_model)
-- [NeuralNetwork_load_saved_data](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/NeuralNetwork/NeuralNetwork_load_saved_data)
-- [NeuralNetwork_lowres_pixels](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/NeuralNetwork/NeuralNetwork_lowres_pixels)
-- [NeuralNetwork_multiple_layers](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/NeuralNetwork/NeuralNetwork_multiple_layers)
-- [NeuralNetwork_musical_face](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/NeuralNetwork/NeuralNetwork_musical_face)
-- [NeuralNetwork_musical_mouse](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/NeuralNetwork/NeuralNetwork_musical_mouse)
-- [NeuralNetwork_pose_classifier](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/NeuralNetwork/NeuralNetwork_pose_classifier)
-- [NeuralNetwork_titanic](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/NeuralNetwork/NeuralNetwork_titanic)
-- [NeuralNetwork_xy_classifier](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/NeuralNetwork/NeuralNetwork_xy_classifier)
+- [NeuralNetwork_Simple_Classification](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/NeuralNetwork/NeuralNetwork_Simple_Classification)
+- [NeuralNetwork_Simple_Regression](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/NeuralNetwork/NeuralNetwork_Simple_Regression)
+- [NeuralNetwork_XOR](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/NeuralNetwork/NeuralNetwork_XOR)
+- [NeuralNetwork_basics](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/NeuralNetwork/NeuralNetwork_basics)
+- [NeuralNetwork_co2net](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/NeuralNetwork/NeuralNetwork_co2net)
+- [NeuralNetwork_color_classifier](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/NeuralNetwork/NeuralNetwork_color_classifier)
+- [NeuralNetwork_load_model](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/NeuralNetwork/NeuralNetwork_load_model)
+- [NeuralNetwork_load_saved_data](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/NeuralNetwork/NeuralNetwork_load_saved_data)
+- [NeuralNetwork_lowres_pixels](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/NeuralNetwork/NeuralNetwork_lowres_pixels)
+- [NeuralNetwork_multiple_layers](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/NeuralNetwork/NeuralNetwork_multiple_layers)
+- [NeuralNetwork_musical_face](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/NeuralNetwork/NeuralNetwork_musical_face)
+- [NeuralNetwork_musical_mouse](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/NeuralNetwork/NeuralNetwork_musical_mouse)
+- [NeuralNetwork_pose_classifier](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/NeuralNetwork/NeuralNetwork_pose_classifier)
+- [NeuralNetwork_titanic](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/NeuralNetwork/NeuralNetwork_titanic)
+- [NeuralNetwork_xy_classifier](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/NeuralNetwork/NeuralNetwork_xy_classifier)
 
 **p5 web editor**
 - [NeuralNetwork_Simple_Classification](https://editor.p5js.org/ml5/sketches/NeuralNetwork_Simple_Classification)
@@ -842,4 +842,4 @@ No demos yet - contribute one today!
 
 ## Source Code
 
-* [/src/NeuralNetwork](https://github.com/ml5js/ml5-library/tree/development/src/NeuralNetwork)
+* [/src/NeuralNetwork](https://github.com/ml5js/ml5-library/tree/main/src/NeuralNetwork)

--- a/docs/reference/object-detector.md
+++ b/docs/reference/object-detector.md
@@ -72,10 +72,10 @@ objectDetector.detect(input, ?callback);
 
 
 **p5.js**
-* [COCOSSD_Video](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/ObjectDetector/ObjectDetector_COCOSSD_Video)
-* [COCOSSD_single_image](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/ObjectDetector/ObjectDetector_COCOSSD_single_image)
-* [YOLO_single_image](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/ObjectDetector/ObjectDetector_YOLO_single_image)
-* [YOLO_Video](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/ObjectDetector/ObjectDetector_YOLO_single_image)
+* [COCOSSD_Video](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/ObjectDetector/ObjectDetector_COCOSSD_Video)
+* [COCOSSD_single_image](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/ObjectDetector/ObjectDetector_COCOSSD_single_image)
+* [YOLO_single_image](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/ObjectDetector/ObjectDetector_YOLO_single_image)
+* [YOLO_Video](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/ObjectDetector/ObjectDetector_YOLO_single_image)
 
 **p5 web editor**
 
@@ -85,10 +85,10 @@ objectDetector.detect(input, ?callback);
 * [YOLO_webcam](https://editor.p5js.org/ml5/sketches/ObjectDetector_YOLO_webcam)
 
 **plain javascript**
-* [COCOSSD_single_image](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/ObjectDetector/COCOSSD_single_image)
-* [COCOSSD_webcam](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/ObjectDetector/COCOSSD_webcam)
-* [YOLO_single_image](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/ObjectDetector/YOLO_single_image)
-* [YOLO_webcam](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/ObjectDetector/YOLO_webcam)
+* [COCOSSD_single_image](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/ObjectDetector/COCOSSD_single_image)
+* [COCOSSD_webcam](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/ObjectDetector/COCOSSD_webcam)
+* [YOLO_single_image](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/ObjectDetector/YOLO_single_image)
+* [YOLO_webcam](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/ObjectDetector/YOLO_webcam)
 
 ## Demo
 
@@ -197,4 +197,4 @@ Each model is a type of convolutional neural network (CNN). A CNN finds patterns
 
 ## Source Code
 
-* [/src/ObjectDetector](https://github.com/ml5js/ml5-library/tree/development/src/ObjectDetector)
+* [/src/ObjectDetector](https://github.com/ml5js/ml5-library/tree/main/src/ObjectDetector)

--- a/docs/reference/pitch-detection.md
+++ b/docs/reference/pitch-detection.md
@@ -104,9 +104,9 @@ detector.getPitch(?callback);
 ## Examples
 
 **p5.js**
-* [PitchDetection](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/PitchDetection/PitchDetection)
-* [PitchDetection_Game](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/PitchDetection/PitchDetection_Game)
-* [PitchDetection_Piano](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/PitchDetection/PitchDetection_Piano)
+* [PitchDetection](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/PitchDetection/PitchDetection)
+* [PitchDetection_Game](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/PitchDetection/PitchDetection_Game)
+* [PitchDetection_Piano](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/PitchDetection/PitchDetection_Piano)
 
 **p5 web editor**
 * [PitchDetection](https://editor.p5js.org/ml5/sketches/PitchDetection)
@@ -114,9 +114,9 @@ detector.getPitch(?callback);
 * [PitchDetection_Piano](https://editor.p5js.org/ml5/sketches/PitchDetection_Piano)
 
 **plain javascript**
-* [PitchDetection](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/PitchDetection/PitchDetection)
-* [PitchDetection_Game](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/PitchDetection/PitchDetection_Game)
-* [PitchDetection_Piano](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/PitchDetection/PitchDetection_Piano)
+* [PitchDetection](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/PitchDetection/PitchDetection)
+* [PitchDetection_Game](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/PitchDetection/PitchDetection_Game)
+* [PitchDetection_Piano](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/PitchDetection/PitchDetection_Piano)
 
 ## Demo
 
@@ -198,4 +198,4 @@ This model was trained on two datasets of synthesized audio:
 
 ## Source Code
 
-[/src/PitchDetection](https://github.com/ml5js/ml5-library/tree/development/src/PitchDetection)
+[/src/PitchDetection](https://github.com/ml5js/ml5-library/tree/main/src/PitchDetection)

--- a/docs/reference/pix2pix.md
+++ b/docs/reference/pix2pix.md
@@ -83,16 +83,16 @@ styleTransfer.transfer(canvas, ?callback);
 
 
 **p5.js**
-* [Pix2Pix_callback](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/Pix2Pix/Pix2Pix_callback)
-* [Pix2Pix_promise](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/Pix2Pix/Pix2Pix_promise)
+* [Pix2Pix_callback](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/Pix2Pix/Pix2Pix_callback)
+* [Pix2Pix_promise](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/Pix2Pix/Pix2Pix_promise)
 
 **p5 web editor**
 * [Pix2Pix_callback](https://editor.p5js.org/ml5/sketches/Pix2Pix_callback)
 * [Pix2Pix_promise](https://editor.p5js.org/ml5/sketches/Pix2Pix_promise)
 
 **plain javascript**
-* [Pix2Pix_callback](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/Pix2Pix/Pix2Pix_callback)
-* [Pix2Pix_promise](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/Pix2Pix/Pix2Pix_promise)
+* [Pix2Pix_callback](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/Pix2Pix/Pix2Pix_callback)
+* [Pix2Pix_promise](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/Pix2Pix/Pix2Pix_promise)
 
 
 ## Demo
@@ -157,4 +157,4 @@ A nice description of the models overview
 
 ## Source Code
 
-[/src/Pix2pix](https://github.com/ml5js/ml5-library/tree/development/src/Pix2pix)
+[/src/Pix2pix](https://github.com/ml5js/ml5-library/tree/main/src/Pix2pix)

--- a/docs/reference/posenet.md
+++ b/docs/reference/posenet.md
@@ -242,9 +242,9 @@ poseNet.multiPose(?input);
 ## Examples
 
 **p5.js**
-* [PoseNet_image_single](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/PoseNet/PoseNet_image_single)
-* [PoseNet_part_selection](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/PoseNet/PoseNet_part_selection)
-* [PoseNet_webcam](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/PoseNet/PoseNet_webcam)
+* [PoseNet_image_single](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/PoseNet/PoseNet_image_single)
+* [PoseNet_part_selection](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/PoseNet/PoseNet_part_selection)
+* [PoseNet_webcam](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/PoseNet/PoseNet_webcam)
 
 **p5 web editor**
 * [PoseNet_image_single](https://editor.p5js.org/ml5/sketches/PoseNet_image_single)
@@ -252,9 +252,9 @@ poseNet.multiPose(?input);
 * [PoseNet_webcam](https://editor.p5js.org/ml5/sketches/PoseNet_webcam)
 
 **plain javascript**
-* [PoseNet_image_single](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/PoseNet/PoseNet_image_single)
-* [PoseNet_part_selection](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/PoseNet/PoseNet_part_selection)
-* [PoseNet_webcam](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/PoseNet/PoseNet_webcam)
+* [PoseNet_image_single](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/PoseNet/PoseNet_image_single)
+* [PoseNet_part_selection](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/PoseNet/PoseNet_part_selection)
+* [PoseNet_webcam](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/PoseNet/PoseNet_webcam)
 
 ## Demo
 
@@ -354,4 +354,4 @@ Each model is a type of convolutional neural network (CNN). A CNN finds patterns
 
 ## Source Code
 
-* [/src/PoseNet](https://github.com/ml5js/ml5-library/tree/development/src/PoseNet)
+* [/src/PoseNet](https://github.com/ml5js/ml5-library/tree/main/src/PoseNet)

--- a/docs/reference/sentiment.md
+++ b/docs/reference/sentiment.md
@@ -80,13 +80,13 @@ sentiment.predict(text);
 ## Examples
 
 **p5.js**
-* [Sentiment_Interactive](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/Sentiment/Sentiment_Interactive)
+* [Sentiment_Interactive](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/Sentiment/Sentiment_Interactive)
 
 **p5 web editor**
 * [Sentiment_Interactive](https://editor.p5js.org/ml5/sketches/Sentiment_Interactive)
 
 **plain javascript**
-* [Sentiment_Interactive](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/Sentiment/Sentiment_Interactive)
+* [Sentiment_Interactive](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/Sentiment/Sentiment_Interactive)
 
 ## Demo
 
@@ -150,4 +150,4 @@ A nice description of the models overview
 
 ## Source Code
 
-[/src/Sentiment/](https://github.com/ml5js/ml5-library/tree/development/src/Sentiment)
+[/src/Sentiment/](https://github.com/ml5js/ml5-library/tree/main/src/Sentiment)

--- a/docs/reference/sketchrnn.md
+++ b/docs/reference/sketchrnn.md
@@ -107,16 +107,16 @@ sketchrnn.generate(?seed, ?options, ?callback);
 ## Examples
 
 **p5.js**
-* [SketchRNN_basic](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/SketchRNN/SketchRNN_basic)
-* [SketchRNN_interactive](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/SketchRNN/SketchRNN_interactive)
+* [SketchRNN_basic](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/SketchRNN/SketchRNN_basic)
+* [SketchRNN_interactive](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/SketchRNN/SketchRNN_interactive)
 
 **p5 web editor**
 * [SketchRNN_basic](https://editor.p5js.org/ml5/sketches/SketchRNN_basic)
 * [SketchRNN_interactive](https://editor.p5js.org/ml5/sketches/SketchRNN_interactive)
 
 **plain javascript**
-* [SketchRNN_basic](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/SketchRNN/_basic)
-* [SketchRNN_interactive](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/SketchRNN/SketchRNN_interactive)
+* [SketchRNN_basic](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/SketchRNN/_basic)
+* [SketchRNN_interactive](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/SketchRNN/SketchRNN_interactive)
 
 
 ## Demo
@@ -189,4 +189,4 @@ A nice description of the models overview
 
 ## Source Code
 
-* [/src/SketchRNN/](https://github.com/ml5js/ml5-library/tree/development/src/SketchRNN)
+* [/src/SketchRNN/](https://github.com/ml5js/ml5-library/tree/main/src/SketchRNN)

--- a/docs/reference/sound-classifier.md
+++ b/docs/reference/sound-classifier.md
@@ -96,16 +96,16 @@ soundclassifier.classify(callback);
 ## Examples
 
 **p5.js**
-* [SoundClassification_speechcommand](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/SoundClassification/SoundClassification_speechcommand)
-* [SoundClassification_speechcommand_load](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/SoundClassification/SoundClassification_speechcommand_load)
+* [SoundClassification_speechcommand](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/SoundClassification/SoundClassification_speechcommand)
+* [SoundClassification_speechcommand_load](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/SoundClassification/SoundClassification_speechcommand_load)
 
 **p5 web editor**
 * [SoundClassification_speechcommand](https://editor.p5js.org/ml5/sketches/SoundClassification_speechcommand)
 * [SoundClassification_speechcommand_load](https://editor.p5js.org/ml5/sketches/SoundClassification_speechcommand_load)
 
 **plain javascript**
-* [SoundClassification_speechcommand](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/SoundClassification/SoundClassification_speechcommand)
-* [SoundClassification_speechcommand_load](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/SoundClassification/SoundClassification_speechcommand_load)
+* [SoundClassification_speechcommand](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/SoundClassification/SoundClassification_speechcommand)
+* [SoundClassification_speechcommand_load](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/SoundClassification/SoundClassification_speechcommand_load)
 
 
 
@@ -177,4 +177,4 @@ This method allows you to use a provided pre-trained model or import a model tha
 
 ## Source Code
 
-* [/src/SoundClassifier/](https://github.com/ml5js/ml5-library/tree/development/src/SoundClassifier)
+* [/src/SoundClassifier/](https://github.com/ml5js/ml5-library/tree/main/src/SoundClassifier)

--- a/docs/reference/style-transfer.md
+++ b/docs/reference/style-transfer.md
@@ -86,16 +86,16 @@ styletransfer.transfer(input, ?callback);
 
 
 **p5.js**
-* [StyleTransfer_Image](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/StyleTransfer/StyleTransfer_Image)
-* [StyleTransfer_Video](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/StyleTransfer/StyleTransfer_Video)
+* [StyleTransfer_Image](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/StyleTransfer/StyleTransfer_Image)
+* [StyleTransfer_Video](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/StyleTransfer/StyleTransfer_Video)
 
 **p5 web editor**
 * [StyleTransfer_Image](https://editor.p5js.org/ml5/sketches/StyleTransfer_Image)
 * [StyleTransfer_Video](https://editor.p5js.org/ml5/sketches/StyleTransfer_Video)
 
 **plain javascript**
-* [StyleTransfer_Image](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/StyleTransfer/StyleTransfer_Image)
-* [StyleTransfer_Video](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/StyleTransfer/StyleTransfer_Video)
+* [StyleTransfer_Image](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/StyleTransfer/StyleTransfer_Image)
+* [StyleTransfer_Video](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/StyleTransfer/StyleTransfer_Video)
 
 ## Demo
 
@@ -156,4 +156,4 @@ TBD
 
 ## Source Code
 
-* [/src/StyleTransfer/](https://github.com/ml5js/ml5-library/tree/development/src/StyleTransfer)
+* [/src/StyleTransfer/](https://github.com/ml5js/ml5-library/tree/main/src/StyleTransfer)

--- a/docs/reference/unet.md
+++ b/docs/reference/unet.md
@@ -108,13 +108,13 @@ unet.segment(?video, ?callback);
 ## Examples
 
 **p5.js**
-* [UNET_webcam](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/UNET/UNET_webcam)
+* [UNET_webcam](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/UNET/UNET_webcam)
 
 **p5 web editor**
 * [UNET_webcam](https://editor.p5js.org/ml5/sketches/UNET_webcam)
 
 **plain javascript**
-* [UNET_webcam](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/UNET/UNET_webcam)
+* [UNET_webcam](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/UNET/UNET_webcam)
 
 
 ## Demo
@@ -180,4 +180,4 @@ A nice description of the models overview
 
 ## Source Code
 
-* [/src/UNET/](https://github.com/ml5js/ml5-library/tree/development/src/UNET)
+* [/src/UNET/](https://github.com/ml5js/ml5-library/tree/main/src/UNET)

--- a/docs/reference/utils.md
+++ b/docs/reference/utils.md
@@ -66,4 +66,4 @@ const flippedImage = ml5.flipImage(input);
 
 ## Source Code
 
-* [/src/utils/](https://github.com/ml5js/ml5-library/tree/development/src/utils)
+* [/src/utils/](https://github.com/ml5js/ml5-library/tree/main/src/utils)

--- a/docs/reference/word2vec.md
+++ b/docs/reference/word2vec.md
@@ -10,7 +10,7 @@
 
 Word2vec is a group of related models that are used to produce [word embeddings](https://en.wikipedia.org/wiki/Word2vec)</sup>. This method allows you to perform vector operations on a given set of input vectors.
 
-You can use the word models [we provide](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/Word2Vec/Word2Vec_Interactive/data), trained on a corpus of english words (watch out for bias data!), or you can train your own vector models following [this tutorial](https://github.com/ml5js/ml5-data-and-training/tree/master/training). More of this soon!
+You can use the word models [we provide](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/Word2Vec/Word2Vec_Interactive/data), trained on a corpus of english words (watch out for bias data!), or you can train your own vector models following [this tutorial](https://github.com/ml5js/ml5-data-and-training/tree/master/training). More of this soon!
 
 ## Quickstart
 
@@ -186,13 +186,13 @@ word2vec.getRandomWord(?callback);
 ## Examples
 
 **p5.js**
-* [Word2Vec_Interactive](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/Word2Vec/Word2Vec_Interactive)
+* [Word2Vec_Interactive](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/Word2Vec/Word2Vec_Interactive)
 
 **p5 web editor**
 * [Word2Vec_Interactive](https://editor.p5js.org/ml5/sketches/Word2Vec_Interactive)
 
 **plain javascript**
-* [Word2Vec_Interactive](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/Word2Vec/Word2Vec_Interactive)
+* [Word2Vec_Interactive](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/Word2Vec/Word2Vec_Interactive)
 
 ## Demo
 
@@ -258,4 +258,4 @@ A nice description of the models overview
 
 ## Source Code
 
-* [/src/Word2vec/](https://github.com/ml5js/ml5-library/tree/development/src/Word2vec)
+* [/src/Word2vec/](https://github.com/ml5js/ml5-library/tree/main/src/Word2vec)

--- a/docs/reference/yolo.md
+++ b/docs/reference/yolo.md
@@ -102,16 +102,16 @@ yolo.detect(?input, ?callback);
 
 
 **p5.js**
-* [YOLO_single_image](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/YOLO/YOLO_single_image)
-* [YOLO_webcam](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/YOLO/YOLO_webcam)
+* [YOLO_single_image](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/YOLO/YOLO_single_image)
+* [YOLO_webcam](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/YOLO/YOLO_webcam)
 
 **p5 web editor**
 * [YOLO_single_image](https://editor.p5js.org/ml5/sketches/YOLO_single_image)
 * [YOLO_webcam](https://editor.p5js.org/ml5/sketches/YOLO_webcam)
 
 **plain javascript**
-* [YOLO_single_image](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/YOLO/YOLO_single_image)
-* [YOLO_webcam](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/YOLO/YOLO_webcam)
+* [YOLO_single_image](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/YOLO/YOLO_single_image)
+* [YOLO_webcam](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/YOLO/YOLO_webcam)
 
 ## Demo
 
@@ -131,4 +131,4 @@ No tutorials yet - contribute one today!
 
 ## Source Code
 
-* [/src/YOLO](https://github.com/ml5js/ml5-library/tree/development/src/YOLO)
+* [/src/YOLO](https://github.com/ml5js/ml5-library/tree/main/src/YOLO)

--- a/docs/tutorials/hello-ml5.md
+++ b/docs/tutorials/hello-ml5.md
@@ -44,7 +44,7 @@ Your project directory should look something like this:
 
 ## Demo
 
-This example is built with p5.js. You can also find the same example without p5.js [here](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/ImageClassification/ImageClassification).
+This example is built with p5.js. You can also find the same example without p5.js [here](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/ImageClassification/ImageClassification).
 
 <br/>
 
@@ -200,7 +200,7 @@ Some guiding questions you might start to think about are:
 1. When classifying an image with MobileNet, does the computer see people? If not, why do you think that is?
 2. Do you notice that MobileNet is better at classifying some animals over others? Why do you think that is?
 
-## [Source](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/ImageClassification/ImageClassification)
+## [Source](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/ImageClassification/ImageClassification)
 
-- [ml5.js image classification on Github](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/ImageClassification/ImageClassification)
+- [ml5.js image classification on Github](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/ImageClassification/ImageClassification)
 - [ml5.js image classification on p5 web editor](https://editor.p5js.org/ml5/sketches/ImageClassification)

--- a/docs/tutorials/local-web-server.md
+++ b/docs/tutorials/local-web-server.md
@@ -4,12 +4,12 @@ If you've looked at our [quickstart](/getting-started/) and [introduction to ml5
 
 <br/>
 
-A big part of the ml5 project is to create lots of examples as launching points for all your creative project ideas. You can find all of the ml5.js examples at our Github page: [ml5-library](https://github.com/ml5js/ml5-library/tree/development/examples). If you start to explore these examples you can see how the different ml5 functions are used to accomplish different outcomes. We try our best to keep the examples as simple as possible so you can easily start to build your ideas on top of them.
+A big part of the ml5 project is to create lots of examples as launching points for all your creative project ideas. You can find all of the ml5.js examples at our Github page: [ml5-library](https://github.com/ml5js/ml5-library/tree/main/examples). If you start to explore these examples you can see how the different ml5 functions are used to accomplish different outcomes. We try our best to keep the examples as simple as possible so you can easily start to build your ideas on top of them.
 
 You can check out all the examples running:
 > - [on this massive list](https://examples.ml5js.org/)
 > - [on the p5 web editor](https://editor.p5js.org/ml5/sketches)
 
-If you'd like to download the examples and run them locally, download the [ml5-library github repo](https://github.com/ml5js/ml5-library) and follow the instructions [here](https://github.com/ml5js/ml5-library/blob/development/examples/README.md#setup).
+If you'd like to download the examples and run them locally, download the [ml5-library github repo](https://github.com/ml5js/ml5-library) and follow the instructions [here](https://github.com/ml5js/ml5-library/blob/main/examples/README.md#setup).
 
 You may also be interested in watching [CodingTrain - getting set up](https://www.youtube.com/watch?v=UCHzlUiDD10) for a nice intro on getting set up with writing code for the web.

--- a/scripts/batch-update-p5webeditor.js
+++ b/scripts/batch-update-p5webeditor.js
@@ -6,7 +6,7 @@ const Q = require("q");
 const { ok } = require("assert");
 
 // TODO: Change branchName if necessary
-const branchName = "release";
+const branchName = "main";
 const branchRef = `?ref=${branchName}`;
 const baseUrl = "https://api.github.com/repos/ml5js/ml5-examples/contents";
 const clientId = process.env.GITHUB_ID;

--- a/src/FaceApi/index_test.js
+++ b/src/FaceApi/index_test.js
@@ -32,7 +32,7 @@ describe('faceApi', () => {
   async function getImage() {
     const img = new Image();
     img.crossOrigin = true;
-    img.src = 'https://raw.githubusercontent.com/ml5js/ml5-library/development/examples/javascript/FaceApi/FaceApi_Image_Landmarks/assets/frida.jpg';
+    img.src = 'https://raw.githubusercontent.com/ml5js/ml5-library/main/examples/javascript/FaceApi/FaceApi_Image_Landmarks/assets/frida.jpg';
     await new Promise((resolve) => {
       img.onload = resolve;
     });

--- a/src/ImageClassifier/index_test.js
+++ b/src/ImageClassifier/index_test.js
@@ -23,7 +23,7 @@ const DEFAULTS = {
 async function getImage() {
   const img = new Image();
   img.crossOrigin = true;
-  img.src = 'https://cdn.jsdelivr.net/gh/ml5js/ml5-library@development/assets/bird.jpg';
+  img.src = 'https://cdn.jsdelivr.net/gh/ml5js/ml5-library@main/assets/bird.jpg';
   await new Promise((resolve) => {
     img.onload = resolve;
   });
@@ -130,7 +130,7 @@ describe('videoClassifier', () => {
   async function getVideo() {
     const video = document.createElement('video');
     video.crossOrigin = true;
-    video.src = 'https://cdn.jsdelivr.net/gh/ml5js/ml5-library@development/assets/pelican.mp4' /* TODO add univeral url */;
+    video.src = 'https://cdn.jsdelivr.net/gh/ml5js/ml5-library@main/assets/pelican.mp4' /* TODO add univeral url */;
     video.width = 200;
     video.height = 200;
     return video;

--- a/src/KMeans/index_test.js
+++ b/src/KMeans/index_test.js
@@ -14,7 +14,7 @@ const KMEANS_DEFAULTS = {
 describe("kMeans", () => {
   let kmeansModel;
   const dataurl =
-    "https://raw.githubusercontent.com/ml5js/ml5-library/development/examples/d3/KMeans/KMeans_GaussianClusterDemo/data/gaussian2d_2clusters.csv";
+    "https://raw.githubusercontent.com/ml5js/ml5-library/main/examples/d3/KMeans/KMeans_GaussianClusterDemo/data/gaussian2d_2clusters.csv";
 
   beforeAll(async () => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;

--- a/src/utils/testingUtils/index.js
+++ b/src/utils/testingUtils/index.js
@@ -2,7 +2,7 @@
 export const getRobin = async () => {
   const img = new Image();
   img.crossOrigin = "";
-  img.src = "https://cdn.jsdelivr.net/gh/ml5js/ml5-library@development/assets/bird.jpg";
+  img.src = "https://cdn.jsdelivr.net/gh/ml5js/ml5-library@main/assets/bird.jpg";
   await new Promise(resolve => {
     img.onload = resolve;
   });


### PR DESCRIPTION
As part of the changes we're discussing in https://github.com/ml5js/ml5-library/issues/917, we're preparing a new `main` branch that will be our new default branch moving forward.

This PR includes changes to switch references to the `development` and `release` branches to `main. Many of these changes are just find and replace changes for the code reference links in the docs. I've also made some placeholder changes to the CONTRIBUTING documentation, which I believe will need a more complex update in a future PR.