### PR TITLE
charRNN documentation update

### DIFF
--- a/docs/reference/charrnn.md
+++ b/docs/reference/charrnn.md
@@ -10,7 +10,7 @@
 
 RNN and LSTMs (Long Short Term Memory networks) are a type of Neural Network architecture useful for working with sequential data (like characters in text or the musical notes of a song) where the order of the that sequence matters. This class allows you run a model pre-trained on a body of text to generate new text.
 
-You can train your own models using this tutorial or use this set of pre trained models.
+You can train your own models [following the instructions in the training-charRNN repo](https://github.com/ml5js/training-charRNN). There is also a selection of [pre-trained model examples available](https://github.com/ml5js/ml5-data-and-models/tree/main/models/charRNN).
 
 ## Quickstart
 


### PR DESCRIPTION
This is a very small fix to add links to the training repo and example trained models.

> You can train your own models [following the instructions in the training-charRNN repo](https://github.com/ml5js/training-charRNN). There is also a selection of [pre-trained model examples available](https://github.com/ml5js/ml5-data-and-models/tree/main/models/charRNN).