### PR TITLE
Fix CVAE example issues on main

### DIFF
--- a/src/CVAE/index.js
+++ b/src/CVAE/index.js
@@ -11,7 +11,7 @@
 
 import * as tf from '@tensorflow/tfjs';
 import callCallback from '../utils/callcallback';
-import { checkP5 } from '../utils/p5Utils';
+import p5Utils from '../utils/p5Utils';
 
 class Cvae {
   /**
@@ -110,7 +110,7 @@ class Cvae {
     const src = URL.createObjectURL(await this.getBlob(canvas));
     let image;
     /* global loadImage */
-    if (checkP5()) image = await this.loadAsync(src); 
+    if (p5Utils.checkP5()) image = await this.loadAsync(src); 
     return { src, raws, image };
   }
 

--- a/src/utils/p5Utils.js
+++ b/src/utils/p5Utils.js
@@ -4,41 +4,41 @@
 // https://opensource.org/licenses/MIT
 
 class P5Util {
-    constructor() {
-        this.m_p5Instance = window;
-    }
+  constructor() {
+      this.m_p5Instance = window;
+  }
 
   /**
-     * Set p5 instance globally.
-     * @param {Object} p5Instance 
-     */
-    setP5Instance(p5Instance) {
-        this.m_p5Instance = p5Instance;
-    }
-
-    /**
-     * This getter will return p5, checking first if it is in
-     * the window and next if it is in the p5 property of this.m_p5Instance
-     * @returns {boolean} if it is in p5 
-     */
-    get p5Instance() {
-        if (typeof this.m_p5Instance !== "undefined" &&
-            typeof this.m_p5Instance.loadImage === "function") return this.m_p5Instance;
-
-        if (typeof this.m_p5Instance.p5 !== 'undefined' &&
-            typeof this.m_p5Instance.p5.Image !== 'undefined' &&
-            typeof this.m_p5Instance.p5.Image === 'function') return this.m_p5Instance.p5;
-        return undefined;
-    }
+   * Set p5 instance globally.
+   * @param {Object} p5Instance 
+   */
+  setP5Instance(p5Instance) {
+      this.m_p5Instance = p5Instance;
+  }
 
   /**
-     * This function will check if the p5 is in the environment
-     * Either it is in the p5Instance mode OR it is in the window 
-     * @returns {boolean} if it is in p5 
-     */
-    checkP5() {
-        return !!this.p5Instance;
-    }
+   * This getter will return p5, checking first if it is in
+   * the window and next if it is in the p5 property of this.m_p5Instance
+   * @returns {boolean} if it is in p5 
+   */
+  get p5Instance() {
+    if (typeof this.m_p5Instance !== "undefined" &&
+      typeof this.m_p5Instance.loadImage === "function") return this.m_p5Instance;
+
+    if (typeof this.m_p5Instance.p5 !== 'undefined' &&
+      typeof this.m_p5Instance.p5.Image !== 'undefined' &&
+      typeof this.m_p5Instance.p5.Image === 'function') return this.m_p5Instance.p5;
+    return undefined;
+  }
+
+  /**
+   * This function will check if the p5 is in the environment
+   * Either it is in the p5Instance mode OR it is in the window 
+   * @returns {boolean} if it is in p5 
+   */
+  checkP5() {
+    return !!this.p5Instance;
+  }
 
   /**
      * Convert a canvas to Blob


### PR DESCRIPTION
Fixes some issues happening in the CVAE model due to an imported function from p5Utils. This PR simply corrects the import issue.  Also fixed some tabbing issues while here.

Rather than importing a single class method ([which is possible](https://stackoverflow.com/questions/38308307/export-import-single-class-method-using-es6-modules)), I'm just importing the full class and calling the method. I think this is fine and a bit clearer than exporting a single function from the class.

<img width="515" alt="Screen Shot 2020-10-22 at 12 45 01 PM" src="https://user-images.githubusercontent.com/6589909/96903925-6fce2c80-1464-11eb-87b1-998084f3a991.png">
