### PR TITLE
Update Docsify edit links to point to main branch

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -106,8 +106,8 @@
     <script>
       const config = {
         editOnGithub: {
-          docBase: 'https://github.com/ml5js/ml5-library/tree/gh-pages/docs/',
-          docEditBase: 'https://ml5js.github.io/ml5-library',
+          docBase: 'https://github.com/ml5js/ml5-library/tree/main/docs/',
+          docEditBase: 'https://learn.ml5js.org/',
           title: 'Edit document',
         },
       };


### PR DESCRIPTION
Fixes https://github.com/ml5js/ml5-library/issues/1013.

Switches our Docsify setup to point the "Edit Document" links towards the `main` branch instead of `gh-pages`. 