### PR TITLE
Converted debug to a boolean while initializing the neural network

### DIFF
--- a/src/NeuralNetwork/index.js
+++ b/src/NeuralNetwork/index.js
@@ -29,8 +29,8 @@ class DiyNeuralNetwork {
       DEFAULTS.learningRate = 0.02;
     }
     
-    if (typeof options.debug === 'string' {
-      if (options.debug === "true") {
+    if (typeof options.debug === 'string') {
+      if (options.debug === 'true') {
         options.debug = true;
       } else {
         options.debug = false; 

--- a/src/NeuralNetwork/index.js
+++ b/src/NeuralNetwork/index.js
@@ -28,20 +28,20 @@ class DiyNeuralNetwork {
     if (options.task === 'imageClassification') {
       DEFAULTS.learningRate = 0.02;
     }
-    
-    if (typeof options.debug === 'string') {
-      if (options.debug === 'true') {
-        options.debug = true;
-      } else {
-        options.debug = false; 
-      }
-    }
 
     this.options =
       {
         ...DEFAULTS,
         ...options,
       } || DEFAULTS;
+
+    if (typeof this.options.debug === 'string') {
+      if (this.options.debug === 'true') {
+        this.options.debug = true;
+      } else {
+        this.options.debug = false; 
+      }
+    }
 
     this.neuralNetwork = new NeuralNetwork();
     this.neuralNetworkData = new NeuralNetworkData();

--- a/src/NeuralNetwork/index.js
+++ b/src/NeuralNetwork/index.js
@@ -28,6 +28,14 @@ class DiyNeuralNetwork {
     if (options.task === 'imageClassification') {
       DEFAULTS.learningRate = 0.02;
     }
+    
+    if (typeof options.debug === 'string' {
+      if (options.debug === "true") {
+        options.debug = true;
+      } else {
+        options.debug = false; 
+      }
+    }
 
     this.options =
       {


### PR DESCRIPTION
<!--------------------------------------------
🌈DEAR BELOVED ML5 COMMUNITY MEMBER. WELCOME. 🌈
---------------------------------------------->

Dear ml5 community, 

I'm making a Pull Request(PR). Please see the details below.

The PR adds a check in the Neural Network constructor to convert the `debug` value to a boolean in case the user passes in a string by mistake. 
This is a common scenario where the user could initialize the library with 
```js
    let shapeClassifier = ml5.neuralNetwork({
         ...options.
         debug: "true"
    })
```

This PR comes as a response to the video https://www.youtube.com/watch?v=3MqJzMvHE3E where Dan encountered this exact scenario.


