### PR TITLE
small fix: fixed <title> text

### DIFF
--- a/examples/p5js/Handpose/Handpose_Image/index.html
+++ b/examples/p5js/Handpose/Handpose_Image/index.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <title>Handpose with Webcam</title>
+    <title>Handpose with single image</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
     <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>


### PR DESCRIPTION
The "<title>" of the single image example of Handpose_Image was also called Webcam
I changed it to be "<title>Handpose with single image</title>" instead of "<title>Handpose with Webcam</title>"
so it matches the <\h1>" and the example.

<!--------------------------------------------
🌈DEAR BELOVED ML5 COMMUNITY MEMBER. WELCOME. 🌈
---------------------------------------------->

Dear ml5 community, 

I'm making a Pull Request(PR). Please see the details below.


**A good PR 🌟**

### → Step 1: Describe your Pull Request 📝
> Fixing a Bug? Adding an Update? Submitting a New Feature? Does it introduce a breaking change?





**A great PR 🌟🌟**

### → Step 2: Share a Relevant Example 🦄
> Here's some example code or a demonstration of my feature as a part of this pull request, a separate pull request, in the https://editor.p5js.org, or codepen/jsfiddle/etc...




**The best PR 🌟🌟🌟**

### → Step 3: Screenshots or Relevant Documentation 🖼
> Here's some helpful screenshots and/or documentation of the new feature 




<!-- 

BEFORE SUBMITTING YOUR PULL REQUEST PLEASE MAKE
SURE TO SUBMIT THE RELEVANT INFORMATION
TO THE SECTIONS LISTED BELOW. 
HELP US HELP YOU BY PROVIDING ALL THE HELPFUL
INFORMATION THAT WILL ALLOW THE ML5 COMMUNITY
TO UNDERSTAND WHAT YOUR PR IS ABOUT.
WE WILL PRIORITIZE WELL A DOCUMENTED PR.

THANK YOU! MERCI! ABRIGADO! GRACIAS! DANKE!
-->




