### PR TITLE
small fix: additional h1 title mismatches

### DIFF
--- a/examples/javascript/BodyPix/BodyPix_Image/index.html
+++ b/examples/javascript/BodyPix/BodyPix_Image/index.html
@@ -2,7 +2,7 @@
 
 <head>
   <meta charset="UTF-8">
-  <title>BodyPix with Webcam</title>
+  <title>BodyPix with Image</title>
   <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
 
   <style></style>

--- a/examples/javascript/ImageClassification/ImageClassification_VideoScavengerHunt/index.html
+++ b/examples/javascript/ImageClassification/ImageClassification_VideoScavengerHunt/index.html
@@ -2,7 +2,7 @@
 
 <head>
   <meta charset="UTF-8">
-  <title>Webcam Image Classification with Speech Output using MobileNet</title>
+  <title>Webcam Scavenger Hunt Game using MobileNet</title>
   <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
   
 </head>

--- a/examples/javascript/KNNClassification/KNNClassification_Video/index.html
+++ b/examples/javascript/KNNClassification/KNNClassification_Video/index.html
@@ -9,7 +9,7 @@
 </head>
 
 <body>
-  <h2>KNN Classification on Webcam Images with mobileNet. Built with p5.js</h2>
+  <h2>KNN Classification on Webcam Images with mobileNet.</h2>
   <div id="videoContainer">
     <video id="video" width="640" height="480" autoplay></video>
   </div>

--- a/examples/javascript/PitchDetection/PitchDetection_Game/index.html
+++ b/examples/javascript/PitchDetection/PitchDetection_Game/index.html
@@ -2,7 +2,7 @@
 
 <head>
   <meta charset="UTF-8">
-  <title>Pitch Tone Game</title>
+  <title>Pitch Detect Game</title>
   <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
   
 </head>

--- a/examples/p5js/BodyPix/BodyPix_Image/index.html
+++ b/examples/p5js/BodyPix/BodyPix_Image/index.html
@@ -2,7 +2,7 @@
 
 <head>
   <meta charset="UTF-8">
-  <title>BodyPix with Webcam</title>
+  <title>BodyPix with Image</title>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
   <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>

--- a/examples/p5js/Handpose/Handpose_Image/index.html
+++ b/examples/p5js/Handpose/Handpose_Image/index.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <title>Handpose with Webcam</title>
+    <title>Handpose with single image</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
     <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>

--- a/examples/p5js/ImageClassification/ImageClassification_VideoScavengerHunt/index.html
+++ b/examples/p5js/ImageClassification/ImageClassification_VideoScavengerHunt/index.html
@@ -2,7 +2,7 @@
 
 <head>
   <meta charset="UTF-8">
-  <title>Webcam Image Classification with Speech Output using MobileNet, p5.js, p5.speech</title>
+  <title>Webcam Scavenger Hunt Game using MobileNet, p5.js, p5.speech</title>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>

--- a/examples/p5js/PitchDetection/PitchDetection_Game/index.html
+++ b/examples/p5js/PitchDetection/PitchDetection_Game/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
 
-  <title>Pitch Tone Game</title>
+  <title>Pitch Detect Game</title>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.sound.min.js"></script>

--- a/examples/p5js/UniversalSentenceEncoder/UniversalSentenceEncoder_Basic/index.html
+++ b/examples/p5js/UniversalSentenceEncoder/UniversalSentenceEncoder_Basic/index.html
@@ -1,13 +1,13 @@
 <html>
   <head>
     <meta charset="UTF-8" >
-    <title>Universal Sentence Encoder with Tokenizer</title>
+    <title>Universal Sentence Encoder</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.0.0/p5.min.js"></script>
     <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
   </head>
 
   <body>
-    <h1>Universal Sentence Encoder with Tokenizer</h1>
+    <h1>Universal Sentence Encoder</h1>
     <script src="sketch.js"></script>
   </body>
 </html>

--- a/examples/p5js/UniversalSentenceEncoder/UniversalSentenceEncoder_WithTokenizer/index.html
+++ b/examples/p5js/UniversalSentenceEncoder/UniversalSentenceEncoder_WithTokenizer/index.html
@@ -1,13 +1,13 @@
 <html>
   <head>
     <meta charset="UTF-8" >
-    <title>Universal Sentence Encoder</title>
+    <title>Universal Sentence Encoder with Tokenizer</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.0.0/p5.min.js"></script>
     <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
   </head>
 
   <body>
-    <h1>Universal Sentence Encoder</h1>
+    <h1>Universal Sentence Encoder with Tokenizer</h1>
     <script src="sketch.js"></script>
   </body>
 </html>


### PR DESCRIPTION


<!--------------------------------------------
🌈DEAR BELOVED ML5 COMMUNITY MEMBER. WELCOME. 🌈
---------------------------------------------->

Dear ml5 community, 

I'm making a Pull Request(PR). Please see the details below.

As in my PR yesterday (#1114)  I found a few new mismatches between h1 and the title in the examples library. 
Also one that is mentioning p5.js in a vanilla JS example and one where to projects seem to be switched. 

I also noticed, that the structure of naming the project in regard to the file name is not always coherent. If you like to I could propose an easy structure to apply to all example projects and update accordingly?!
