### PR TITLE
Fix typo in sentiment documentaion

### DIFF
--- a/docs/reference/sentiment.md
+++ b/docs/reference/sentiment.md
@@ -33,7 +33,7 @@ console.log(prediction);
 ### Initialize
 
 ```js
-const magic = ml5.Sentiment(model, ?callback);
+const sentiment = ml5.sentiment(model, ?callback);
 ```
 
 #### Parameters


### PR DESCRIPTION
Fixes #1143. 

We have a small casing issue in the Sentiment documents and we also received a suggestion for how to make the documentation clearer by removing the word "magic".