### PR TITLE
Use the 'hand' event for Handpose event emitter

### DIFF
--- a/docs/reference/handpose.md
+++ b/docs/reference/handpose.md
@@ -26,8 +26,8 @@ function modelLoaded() {
   console.log('Model Loaded!');
 }
 
-// Listen to new 'predict' events
-handpose.on('predict', results => {
+// Listen to new 'hand' events
+handpose.on('hand', results => {
   predictions = results;
 });
 ```
@@ -130,11 +130,11 @@ const options = {
 
 ***
 
-#### .on('predict', ...)
+#### .on('hand', ...)
 > An event listener that returns the results when a new hand detection prediction occurs.
 
   ```js
-  handpose.on('predict', callback);
+  handpose.on('hand', callback);
   ```
 
 📥 **Inputs**
@@ -142,7 +142,7 @@ const options = {
 * **callback**: REQUIRED.  A callback function to handle new hand detection predictions. For example:
 
   ```js
-  handpose.on('predict', results => {
+  handpose.on('hand', results => {
     // do something with the results
     console.log(results);
   });

--- a/examples/p5js/Handpose/Handpose_Image/sketch.js
+++ b/examples/p5js/Handpose/Handpose_Image/sketch.js
@@ -24,7 +24,7 @@ function modelReady() {
   // handpose what to do with the results.
   // in this case we assign the results to our global
   // predictions variable
-  handpose.on("predict", results => {
+  handpose.on("hand", results => {
     predictions = results;
   });
 

--- a/examples/p5js/Handpose/Handpose_Webcam/sketch.js
+++ b/examples/p5js/Handpose/Handpose_Webcam/sketch.js
@@ -11,7 +11,7 @@ function setup() {
 
   // This sets up an event that fills the global variable "predictions"
   // with an array every time new hand poses are detected
-  handpose.on("predict", results => {
+  handpose.on("hand", results => {
     predictions = results;
   });
 

--- a/src/Handpose/index.js
+++ b/src/Handpose/index.js
@@ -67,7 +67,10 @@ class Handpose extends EventEmitter {
     const { flipHorizontal } = this.config;
     const predictions = await this.model.estimateHands(input, flipHorizontal);
     const result = predictions;
+    // Soon, we will remove the 'predict' event and prefer the 'hand' event. During
+    // the interim period, we will both events.
     this.emit("predict", result);
+    this.emit("hand", result);
 
     if (this.video) {
       return tf.nextFrame().then(() => this.predict());


### PR DESCRIPTION
Fixes #1156.

This adds the 'hand' event name to be emitted by the Handpose model when new predictions are made. Since people are likely using the original 'predict' event, I decided to leave that in as well for now so that both approaches continue to work. I would feel comfortable fully removing it in our next minor version update.

Tested by running the Handpose examples from my local server started with `npm run develop`.