### PR TITLE
Use the 'face' event for Facemesh event emitter

### DIFF
--- a/docs/reference/facemesh.md
+++ b/docs/reference/facemesh.md
@@ -26,8 +26,8 @@ function modelLoaded() {
   console.log('Model Loaded!');
 }
 
-// Listen to new 'predict' events
-facemesh.on('predict', results => {
+// Listen to new 'face' events
+facemesh.on('face', results => {
   predictions = results;
 });
 ```
@@ -135,11 +135,11 @@ const facemesh = ml5.facemesh(?video, ?options, ?callback);
 
 ***
 
-#### .on('predict', ...)
+#### .on('face', ...)
 > An event listener that returns the results when a new face detection prediction occurs.
 
   ```js
-  facemesh.on('predict', callback);
+  facemesh.on('face', callback);
   ```
 
 📥 **Inputs**
@@ -147,7 +147,7 @@ const facemesh = ml5.facemesh(?video, ?options, ?callback);
 * **callback**: REQUIRED.  A callback function to handle new face detection predictions. For example:
 
   ```js
-  facemesh.on('predict', results => {
+  facemesh.on('face', results => {
     // do something with the results
     console.log(results);
   });

--- a/examples/p5js/Facemesh/Facemesh_Image/sketch.js
+++ b/examples/p5js/Facemesh/Facemesh_Image/sketch.js
@@ -19,7 +19,7 @@ function setup() {
 function imageReady() {
   facemesh = ml5.facemesh(modelReady);
 
-  facemesh.on("predict", results => {
+  facemesh.on("face", results => {
     predictions = results;
   });
 }

--- a/examples/p5js/Facemesh/Facemesh_Webcam/sketch.js
+++ b/examples/p5js/Facemesh/Facemesh_Webcam/sketch.js
@@ -11,7 +11,7 @@ function setup() {
 
   // This sets up an event that fills the global variable "predictions"
   // with an array every time new predictions are made
-  facemesh.on("predict", results => {
+  facemesh.on("face", results => {
     predictions = results;
   });
 

--- a/src/Facemesh/index.js
+++ b/src/Facemesh/index.js
@@ -64,7 +64,10 @@ class Facemesh extends EventEmitter {
     const { flipHorizontal } = this.config;
     const predictions = await this.model.estimateFaces(input, flipHorizontal);
     const result = predictions;
+    // Soon, we will remove the 'predict' event and prefer the 'face' event. During
+    // the interim period, we will both events.
     this.emit("predict", result);
+    this.emit("face", result);
 
     if (this.video) {
       return tf.nextFrame().then(() => this.predict());


### PR DESCRIPTION
Similar to #1184.

This adds the 'face' event name to be emitted by the Facemesh model when new predictions are made. Since people are likely using the original 'predict' event, I decided to leave that in as well for now so that both approaches continue to work. I would feel comfortable fully removing it in our next minor version update.

Tested by running the Handpose examples from my local server started with `npm run develop`.