### PR TITLE
issue(384): export retrained model

### DIFF
--- a/src/NeuralNetwork/NeuralNetwork.js
+++ b/src/NeuralNetwork/NeuralNetwork.js
@@ -180,7 +180,7 @@ class NeuralNetwork {
    * @param {*} nameOrCb
    * @param {*} cb
    */
-  async save(nameOrCb, cb) {
+  async save({nameOrCb, cb, downloadOnSave = true}) {
     let modelName;
     let callback;
 
@@ -209,10 +209,15 @@ class NeuralNetwork {
           ],
         };
 
-        await saveBlob(data.weightData, `${modelName}.weights.bin`, 'application/octet-stream');
-        await saveBlob(JSON.stringify(this.weightsManifest), `${modelName}.json`, 'text/plain');
+        if (downloadOnSave) {
+          await saveBlob(data.weightData, `${modelName}.weights.bin`, 'application/octet-stream');
+          await saveBlob(JSON.stringify(this.weightsManifest), `${modelName}.json`, 'text/plain');
+        }
         if (callback) {
-          callback();
+          callback({
+            weightData: data.weightData,
+            manifest: this.weightsManifest
+          });
         }
       }),
     );

--- a/src/NeuralNetwork/NeuralNetworkData.js
+++ b/src/NeuralNetwork/NeuralNetworkData.js
@@ -753,7 +753,7 @@ class NeuralNetworkData {
    * @param {*} nameOrCb
    * @param {*} cb
    */
-  async saveMeta(nameOrCb, cb) {
+  async saveMeta({nameOrCb, cb, downloadOnSave = true}) {
     let modelName;
     let callback;
 
@@ -770,9 +770,13 @@ class NeuralNetworkData {
       modelName = 'model';
     }
 
-    await saveBlob(JSON.stringify(this.meta), `${modelName}_meta.json`, 'text/plain');
+    if (downloadOnSave) {
+      await saveBlob(JSON.stringify(this.meta), `${modelName}_meta.json`, 'text/plain');
+    }
     if (callback) {
-      callback();
+      callback({
+        meta: this.meta
+      });
     }
   }
 

--- a/src/NeuralNetwork/index.js
+++ b/src/NeuralNetwork/index.js
@@ -18,6 +18,7 @@ const DEFAULTS = {
   learningRate: 0.2,
   hiddenUnits: 16,
   noTraining: false,
+  downloadModelsOnSave: true
 };
 class DiyNeuralNetwork {
   constructor(options, cb) {
@@ -1152,9 +1153,32 @@ class DiyNeuralNetwork {
       modelName = 'model';
     }
 
+    const downloadOnSave = this.options.downloadModelsOnSave;
+
     // save the model
-    this.neuralNetwork.save(modelName, () => {
-      this.neuralNetworkData.saveMeta(modelName, callback);
+    this.neuralNetwork.save({
+      modelName,
+      cb: ({
+        weightData,
+        manifest
+      }) => {
+        this.neuralNetworkData.saveMeta({
+          modelName,
+          cb: ({ meta }) => {
+            if (downloadOnSave === false) {
+              callback({
+                meta,
+                weightData,
+                manifest
+              })
+            } else {
+              callback()
+            }
+          },
+          downloadOnSave
+        });
+      },
+      downloadOnSave
     });
   }
 


### PR DESCRIPTION
export retrained model without downloading it

<!--------------------------------------------
🌈DEAR BELOVED ML5 COMMUNITY MEMBER. WELCOME. 🌈
---------------------------------------------->

Dear ml5 community, 

I'm making a Pull Request(PR). Please see the details below.


**A good PR 🌟**

### → Step 1: Describe your Pull Request 📝
Implements the requested feature in issue #384. I.e extracting the retrained model without having to download it. This PR allows to pass a new option to the neural network, named `downloadModelsOnSave`. When passed, the NeuralNetwork class doesn't use the `saveToBlob` helper function to download the files. It rather just passes back the entire trained data to the callback provided.

<!-- 

BEFORE SUBMITTING YOUR PULL REQUEST PLEASE MAKE
SURE TO SUBMIT THE RELEVANT INFORMATION
TO THE SECTIONS LISTED BELOW. 
HELP US HELP YOU BY PROVIDING ALL THE HELPFUL
INFORMATION THAT WILL ALLOW THE ML5 COMMUNITY
TO UNDERSTAND WHAT YOUR PR IS ABOUT.
WE WILL PRIORITIZE WELL A DOCUMENTED PR.

THANK YOU! MERCI! ABRIGADO! GRACIAS! DANKE!
-->




