### PR TITLE
Fix typos in docs/reference/neural-network.md

### DIFF
--- a/docs/reference/neural-network.md
+++ b/docs/reference/neural-network.md
@@ -703,7 +703,7 @@ neuralNetwork.saveData(?outputName, ?callback);
 > loads the data to `neuralNetwork.data.data.raw`
 
 ```js
-neuralnetwork.loadData(?filesOrPath, ?callback);
+neuralnetwork.loadData(filesOrPath, ?callback);
 ```
 
 📥 **Inputs**
@@ -740,7 +740,7 @@ neuralNetwork.save(?outputName, ?callback);
 > Loads a pre-trained model
 
 ```js
-neuralNetwork.load(?filesOrPath, ?callback);
+neuralNetwork.load(filesOrPath, ?callback);
 ```
 
 📥 **Inputs**


### PR DESCRIPTION
Just a tiny typo correction.