### PR TITLE
Documentation: fix broken link in FAQ page

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,6 +1,6 @@
 # Frequently Asked Questions (FAQ)
 
-### Can I use ml5.js in the [p5 web editor](editor.p5js.org)?
+### Can I use ml5.js in the [p5 web editor](https://editor.p5js.org)?
 
 Mostly.
 


### PR DESCRIPTION
In markdown, you need to add the `https://` when linking to external URLs.

This PR fixes the broken link in the [FAQ page](https://learn.ml5js.org/#/faq).