### PR TITLE
Copy over ml5.js license from Code-of-Conduct repo

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,49 @@
-MIT License
+# ml5.js LICENSE
 
-Copyright (c) 2018 ML5.js
+_Version 1.0 of the ml5.js license was adopted and last updated on May 10, 2021. It applies to all contributions to the ml5.js library as of May 20,2021. Contributions prior to that date are licensed under the MIT license. You can read the blog post announcing and explaining the development of the license [here](https://ml5js.medium.com/6b0e4c109b76)._
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+## Purpose
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+This license gives everyone as much permission to work with this software as possible as long as they comply with the ml5.js [Code of Conduct](README.md), while protecting contributors from liability.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+## Acceptance
+
+In order to receive this license, you must agree to its rules. The rules of this license are both obligations under that agreement and conditions to your license. You must not do anything with this software that triggers a rule that you cannot or will not follow.
+
+## Copyright
+
+Each contributor licenses you to do everything with this software that would otherwise infringe that contributor’s copyright in it.
+
+## License Reversion
+
+Each contribution to this software is licensed under this license for three years from the date it is contributed to the software. After that three year period the contribution is licensed under the [Blue Oak Model License v 1.0.0](https://blueoakcouncil.org/license/1.0.0).
+
+## Code of Conduct
+
+You must use this software in compliance with the ml5.js [Code of Conduct](README.md) as it exists at the time of your use. This includes cooperating with any investigations of your compliance with the ml5.js Code of Conduct.
+
+## Notices
+
+You must ensure that everyone who gets a copy of any part of this software from you, with or without changes, also gets the text of this license or a link to https://ml5js.org/license.
+
+## Excuse
+
+If anyone notifies you in writing that you have not complied with [Notices](https://github.com/ml5js/Code-of-Conduct/blob/main/LICENSE.md#notices), you can keep your license by taking all practical steps to comply within 30 days after the notice. If you do not do so, your license ends immediately.
+
+If anyone notifies you in writing that you have not complied with the Code of Conduct, you can keep your license by taking all practical steps to comply within 30 days after the notice. If you do not do so, and the ml5.js Code of Conduct Committee (or its equivalent or successor) agrees that you are in violation of the Code of Conduct, your license ends immediately.
+
+## Patent
+
+Each contributor licenses you to do everything with this software that would otherwise infringe any patent claims they can license or become able to license.
+
+## Reliability
+
+No contributor can revoke this license.
+
+## No Liability
+
+**_As far as the law allows, this software comes as is, without any warranty or condition, and no contributor will be liable to anyone for any damages related to this software or this license, under any kind of legal claim._**
+
+## Permission
+
+Each contributor licenses you to do everything with this license that would otherwise infringe that contributor’s copyright in it.


### PR DESCRIPTION
Fixes #1203 following @mwweinberg's suggestion to copy over the license into this repo.