### PR TITLE
perf(ImageClassifier): use urls directly from teachablemachine

### DIFF
--- a/src/ImageClassifier/index.js
+++ b/src/ImageClassifier/index.js
@@ -65,7 +65,10 @@ class ImageClassifier {
             this.modelToUse = null;
         }
       } else {
+        // its a url, we expect to find model.json
         this.modelUrl = modelNameOrUrl;
+        // The teachablemachine urls end with a slash, so add model.json to complete the full path
+        if (this.modelUrl.endsWith('/')) this.modelUrl += "model.json";
       }
     }
     // Load the model


### PR DESCRIPTION
When using a model exported from teachablemachine, with ImageClassifier, 'model.json' has to be added manually at the end of the url
I am using ml5 in my class in along with teachablemachine, and students always find this confusing.
With this simple addition, it will automatically add the 'model.json' to the end of the URL, if it ends with a slash



