### PR TITLE
Remove unnecessary sketch file import from KMeans Mouse Clustering example

### DIFF
--- a/examples/p5js/KMeans/KMeans_mouseClustering/index.html
+++ b/examples/p5js/KMeans/KMeans_mouseClustering/index.html
@@ -4,7 +4,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.1.9/p5.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.1.9/addons/p5.sound.min.js"></script>
     <script src="http://localhost:8080/ml5.js"></script>
-    <script src="sketch.js"></script>
 
     <title>Kmeans Mouse Clustering</title>
   </head>


### PR DESCRIPTION
Noticed that the sketch.js is imported twice unnecessarily. Removing the one in the head tag and important at the end of the HTML document!