### PR TITLE
chore: bumps package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ml5",
-  "version": "0.8.14",
+  "version": "0.8.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ml5",
-      "version": "0.8.14",
+      "version": "0.8.16",
       "license": "MIT",
       "dependencies": {
         "@magenta/sketch": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ml5",
-  "version": "0.8.14",
+  "version": "0.8.16",
   "description": "A friendly machine learning library for the web.",
   "main": "dist/ml5.min.js",
   "directories": {


### PR DESCRIPTION
Update package number to 0.8.16, as I had accidentally merged a prior PR without updating the version to 0.8.15 a few minutes ago. The 0.8.16 release may include just this PR.