### PR TITLE
Code clean-up: class-methods-use-this

### DIFF
--- a/src/CartoonGAN/index.js
+++ b/src/CartoonGAN/index.js
@@ -12,11 +12,7 @@
 import * as tf from '@tensorflow/tfjs';
 import callCallback from '../utils/callcallback';
 import p5Utils from '../utils/p5Utils';
-import {
-  isInstanceOfSupportedElement,
-  // eslint-disable-next-line no-unused-vars
-  imgToTensor
-} from '../utils/imageUtilities';
+import { isInstanceOfSupportedElement } from '../utils/imageUtilities';
 
 const IMAGE_SIZE = 256;
 
@@ -102,7 +98,6 @@ class Cartoon {
     return result;
   }
 
-  /* eslint class-methods-use-this: "off" */
   async resultFinalize(res){
     const tensor = res;
     const raw = await res.data();

--- a/src/DCGAN/index.js
+++ b/src/DCGAN/index.js
@@ -11,6 +11,7 @@ This version is based on alantian's TensorFlow.js implementation: https://github
 import * as tf from '@tensorflow/tfjs';
 import axios from 'axios';
 import callCallback from '../utils/callcallback';
+import modelLoader from "../utils/modelLoader";
 import  p5Utils from '../utils/p5Utils';
 
 // Default pre-trained face model
@@ -32,6 +33,7 @@ class DCGANBase {
     this.model = {};
     this.modelPath = modelPath;
     this.modelInfo = {};
+    // TODO: this variable is never set anywhere.
     this.modelPathPrefix = '';
     this.modelReady = false;
     this.config = {
@@ -51,7 +53,7 @@ class DCGANBase {
     this.modelInfo = modelInfoJson
         
     const [modelUrl] = this.modelPath.split('manifest.json')
-    const modelJsonPath = this.isAbsoluteURL(modelUrl) ? this.modelInfo.model : this.modelPathPrefix + this.modelInfo.model
+    const modelJsonPath = modelLoader.isAbsoluteURL(modelUrl) ? this.modelInfo.model : this.modelPathPrefix + this.modelInfo.model
 
     this.model = await tf.loadLayersModel(modelJsonPath);
     this.modelReady = true;
@@ -139,13 +141,6 @@ class DCGANBase {
 
     return result;
 
-  }
-
-    
-  /* eslint class-methods-use-this: "off" */
-  isAbsoluteURL(str) {
-    const pattern = new RegExp('^(?:[a-z]+:)?//', 'i');
-    return !!pattern.test(str);
   }
 
 }

--- a/src/FaceApi/index.js
+++ b/src/FaceApi/index.js
@@ -203,7 +203,7 @@ class FaceApiBase {
     // sets the return options if any are passed in during .detect() or .detectSingle()
     this.config = this.setReturnOptions(faceApiOptions);
 
-    const {withLandmarks, withDescriptors} = this.config;
+    const { withLandmarks, withDescriptors } = this.config;
 
     let result;
 
@@ -309,7 +309,7 @@ class FaceApiBase {
     // sets the return options if any are passed in during .detect() or .detectSingle()
     this.config = this.setReturnOptions(faceApiOptions);
 
-    const {withLandmarks, withDescriptors} = this.config;
+    const { withLandmarks, withDescriptors } = this.config;
 
     let result;
     if (withLandmarks) {
@@ -387,7 +387,7 @@ class FaceApiBase {
         // if landmarks exist return parts
         const newItem = Object.assign({}, item);
         if (newItem.landmarks) {
-          const {landmarks} = newItem;
+          const { landmarks } = newItem;
           newItem.parts = {
             mouth: landmarks.getMouth(),
             nose: landmarks.getNose(),
@@ -414,7 +414,7 @@ class FaceApiBase {
     } else {
       output = Object.assign({}, result);
       if (output.landmarks) {
-        const {landmarks} = result;
+        const { landmarks } = result;
         output.parts = {
           mouth: landmarks.getMouth(),
           nose: landmarks.getNose(),

--- a/src/FaceApi/index.js
+++ b/src/FaceApi/index.js
@@ -14,6 +14,7 @@
 import * as tf from "@tensorflow/tfjs";
 import * as faceapi from "face-api.js";
 import callCallback from "../utils/callcallback";
+import modelLoader from "../utils/modelLoader";
 
 const DEFAULTS = {
   withLandmarks: true,
@@ -47,31 +48,26 @@ class FaceApiBase {
     this.modelReady = false;
     this.detectorOptions = null;
     this.config = {
-      minConfidence: this.checkUndefined(options.minConfidence, DEFAULTS.minConfidence),
-      withLandmarks: this.checkUndefined(options.withLandmarks, DEFAULTS.withLandmarks),
-      withDescriptors: this.checkUndefined(options.withDescriptors, DEFAULTS.withDescriptors),
-      withTinyNet: this.checkUndefined(options.withTinyNet, DEFAULTS.withTinyNet),
+      minConfidence: options.minConfidence || DEFAULTS.minConfidence,
+      withLandmarks: options.withLandmarks || DEFAULTS.withLandmarks,
+      withDescriptors: options.withDescriptors || DEFAULTS.withDescriptors,
+      withTinyNet: options.withTinyNet || DEFAULTS.withTinyNet,
       MODEL_URLS: {
-        Mobilenetv1Model: this.checkUndefined(
-          options.Mobilenetv1Model,
+        Mobilenetv1Model:
+          options.Mobilenetv1Model ||
           DEFAULTS.MODEL_URLS.Mobilenetv1Model,
-        ),
-        TinyFaceDetectorModel: this.checkUndefined(
-          options.TinyFaceDetectorModel,
+        TinyFaceDetectorModel:
+          options.TinyFaceDetectorModel ||
           DEFAULTS.MODEL_URLS.TinyFaceDetectorModel,
-        ),
-        FaceLandmarkModel: this.checkUndefined(
-          options.FaceLandmarkModel,
+        FaceLandmarkModel:
+          options.FaceLandmarkModel ||
           DEFAULTS.MODEL_URLS.FaceLandmarkModel,
-        ),
-        FaceLandmark68TinyNet: this.checkUndefined(
-          options.FaceLandmark68TinyNet,
+        FaceLandmark68TinyNet:
+          options.FaceLandmark68TinyNet ||
           DEFAULTS.MODEL_URLS.FaceLandmark68TinyNet,
-        ),
-        FaceRecognitionModel: this.checkUndefined(
-          options.FaceRecognitionModel,
+        FaceRecognitionModel:
+          options.FaceRecognitionModel ||
           DEFAULTS.MODEL_URLS.FaceRecognitionModel,
-        ),
       },
     };
 
@@ -93,7 +89,7 @@ class FaceApiBase {
 
     Object.keys(this.config.MODEL_URLS).forEach(item => {
       if (modelOptions.includes(item)) {
-        this.config.MODEL_URLS[item] = this.getModelPath(this.config.MODEL_URLS[item]);
+        this.config.MODEL_URLS[item] = modelLoader.getModelPath(this.config.MODEL_URLS[item]);
       }
     });
 
@@ -207,7 +203,7 @@ class FaceApiBase {
     // sets the return options if any are passed in during .detect() or .detectSingle()
     this.config = this.setReturnOptions(faceApiOptions);
 
-    const { withLandmarks, withDescriptors } = this.config;
+    const {withLandmarks, withDescriptors} = this.config;
 
     let result;
 
@@ -313,7 +309,7 @@ class FaceApiBase {
     // sets the return options if any are passed in during .detect() or .detectSingle()
     this.config = this.setReturnOptions(faceApiOptions);
 
-    const { withLandmarks, withDescriptors } = this.config;
+    const {withLandmarks, withDescriptors} = this.config;
 
     let result;
     if (withLandmarks) {
@@ -343,27 +339,6 @@ class FaceApiBase {
     result = this.landmarkParts(result);
 
     return result;
-  }
-
-  /**
-   * Check if the given _param is undefined, otherwise return the _default
-   * @param {*} _param
-   * @param {*} _default
-   */
-  checkUndefined(_param, _default) {
-    return _param !== undefined ? _param : _default;
-  }
-
-  /**
-   * Checks if the given string is an absolute or relative path and returns
-   *      the path to the modelJson
-   * @param {String} absoluteOrRelativeUrl
-   */
-  getModelPath(absoluteOrRelativeUrl) {
-    const modelJsonPath = this.isAbsoluteURL(absoluteOrRelativeUrl)
-      ? absoluteOrRelativeUrl
-      : window.location.pathname + absoluteOrRelativeUrl;
-    return modelJsonPath;
   }
 
   /**
@@ -399,16 +374,11 @@ class FaceApiBase {
     });
   }
 
-  /* eslint class-methods-use-this: "off" */
-  isAbsoluteURL(str) {
-    const pattern = new RegExp("^(?:[a-z]+:)?//", "i");
-    return !!pattern.test(str);
-  }
-
   /**
    * get parts from landmarks
    * @param {*} result
    */
+  // eslint-disable-next-line class-methods-use-this
   landmarkParts(result) {
     let output;
     // multiple detections is an array
@@ -417,7 +387,7 @@ class FaceApiBase {
         // if landmarks exist return parts
         const newItem = Object.assign({}, item);
         if (newItem.landmarks) {
-          const { landmarks } = newItem;
+          const {landmarks} = newItem;
           newItem.parts = {
             mouth: landmarks.getMouth(),
             nose: landmarks.getNose(),
@@ -444,7 +414,7 @@ class FaceApiBase {
     } else {
       output = Object.assign({}, result);
       if (output.landmarks) {
-        const { landmarks } = result;
+        const {landmarks} = result;
         output.parts = {
           mouth: landmarks.getMouth(),
           nose: landmarks.getNose(),

--- a/src/utils/modelLoader.js
+++ b/src/utils/modelLoader.js
@@ -1,11 +1,24 @@
+/**
+ * Check if the provided URL string starts with http://, https://, etc.
+ * @param {string} str
+ * @returns {boolean}
+ */
 function isAbsoluteURL(str) {
   const pattern = new RegExp('^(?:[a-z]+:)?//', 'i');
-  return !!pattern.test(str);
+  return pattern.test(str);
 }
 
+/**
+ * Accepts a URL that may be a complete URL, or a relative location.
+ * Returns an absolute URL based on the current window location.
+ * @param {string} absoluteOrRelativeUrl
+ * @returns {string}
+ */
 function getModelPath(absoluteOrRelativeUrl) {
-  const modelJsonPath = isAbsoluteURL(absoluteOrRelativeUrl) ? absoluteOrRelativeUrl : window.location.pathname + absoluteOrRelativeUrl
-  return modelJsonPath;
+  if (!isAbsoluteURL(absoluteOrRelativeUrl) && typeof window !== 'undefined') {
+    return window.location.pathname + absoluteOrRelativeUrl;
+  }
+  return absoluteOrRelativeUrl;
 }
 
 export default {


### PR DESCRIPTION
Fixes some violations of eslint rule `class-methods-use-this` which were suppressed.

* Use the `isAbsoluteUrl` and `getModelPath` utilities from `modelLoader` instead of duplicating them in multiple classes.
* Removed one `eslint-disable` which was not actually needed.
* Use boolean `||` instead of class method `checkUndefined` to set defaults in `FaceApi`.  I wanted to use the [nullish coalescing `??`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator) but the eslint version is too outdated to support it!
___

The FaceApi code could be cleaned up further with object spreading, but the behavior would differ slightly if the user explicitly provides a falsey value.  It could be reduced to:
```
this.config = {
  ...DEFAULTS,
  ...options,
  MODEL_URLS: {
    ...DEFAULTS.MODEL_URLS,
    ...options.MODEL_URLS
  }
}
```

