### PR TITLE
Fix issues #1224 & #1213: Don't call `this.predict()` unless there is a video.

### DIFF
--- a/src/Facemesh/index.js
+++ b/src/Facemesh/index.js
@@ -3,9 +3,6 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-/* eslint prefer-destructuring: ["error", {AssignmentExpression: {array: false}}] */
-/* eslint no-await-in-loop: "off" */
-
 /*
  * Facemesh: Facial landmark detection in the browser
  * Ported and integrated from all the hard work by: https://github.com/tensorflow/tfjs-models/tree/master/facemesh
@@ -19,14 +16,17 @@ import callCallback from "../utils/callcallback";
 class Facemesh extends EventEmitter {
   /**
    * Create Facemesh.
-   * @param {HTMLVideoElement} video - An HTMLVideoElement.
-   * @param {object} options - An object with options.
-   * @param {function} callback - A callback to be called when the model is ready.
+   * @param {HTMLVideoElement} [video] - An HTMLVideoElement.
+   * @param {object} [options] - An object with options.
+   * @param {function} [callback] - A callback to be called when the model is ready.
    */
   constructor(video, options, callback) {
     super();
 
     this.video = video;
+    /**
+     * @type {null | facemeshCore.FaceMesh}
+     */
     this.model = null;
     this.modelReady = false;
     this.config = options;
@@ -49,18 +49,21 @@ class Facemesh extends EventEmitter {
         };
       });
     }
-
-    this.predict();
+    if (this.video) {
+      this.predict();
+    }
 
     return this;
   }
 
   /**
-   * Load the model and set it to this.model
-   * @return {this} the Facemesh model.
+   * @return {Promise<facemeshCore.AnnotatedPrediction[]>} an array of predictions.
    */
   async predict(inputOr, callback) {
     const input = this.getInput(inputOr);
+    if (!input) {
+      throw new Error("No input image found.");
+    }
     const { flipHorizontal } = this.config;
     const predictions = await this.model.estimateFaces(input, flipHorizontal);
     const result = predictions;

--- a/src/Handpose/index.js
+++ b/src/Handpose/index.js
@@ -3,9 +3,6 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-/* eslint prefer-destructuring: ["error", {AssignmentExpression: {array: false}}] */
-/* eslint no-await-in-loop: "off" */
-
 /*
  * Handpose: Palm detector and hand-skeleton finger tracking in the browser
  * Ported and integrated from all the hard work by: https://github.com/tensorflow/tfjs-models/tree/master/handpose
@@ -19,14 +16,17 @@ import callCallback from "../utils/callcallback";
 class Handpose extends EventEmitter {
   /**
    * Create Handpose.
-   * @param {HTMLVideoElement} video - An HTMLVideoElement.
-   * @param {object} options - An object with options.
-   * @param {function} callback - A callback to be called when the model is ready.
+   * @param {HTMLVideoElement} [video] - An HTMLVideoElement.
+   * @param {object} [options] - An object with options.
+   * @param {function} [callback] - A callback to be called when the model is ready.
    */
   constructor(video, options, callback) {
     super();
 
     this.video = video;
+    /**
+     * @type {null|handposeCore.HandPose}
+     */
     this.model = null;
     this.modelReady = false;
     this.config = options;
@@ -50,19 +50,20 @@ class Handpose extends EventEmitter {
       });
     }
 
-    this.predict();
+    if (this.video) {
+      this.predict();
+    }
 
     return this;
   }
 
   /**
-   * Load the model and set it to this.model
-   * @return {this} the Handpose model.
+   * @return {Promise<handposeCore.AnnotatedPrediction[]>} an array of predictions.
    */
   async predict(inputOr, callback) {
     const input = this.getInput(inputOr);
     if (!input) {
-      return [];
+      throw new Error("No input image found.");
     }
     const { flipHorizontal } = this.config;
     const predictions = await this.model.estimateHands(input, flipHorizontal);


### PR DESCRIPTION
### Issue
Reported in #1224 and #1213.

The Facemesh and Handpose models are designed such that they user can instantiated it a with a video and use a `facemesh.on("face")` callback to process the result of every frame.  This chain of continuous prediction begins with a call to `this.predict()` inside `this.loadModel()`.

This creates an error when no video is provided, as `this.predict()` is called without any input image.  In Facemesh, this logs an error `Uncaught (in promise) TypeError: Cannot read property 'height' of undefined`.  In Handpose the error is avoided by returning `[]` from `this.predict()`.

### Changes

- Added a conditional statement such that `this.predict()` is only called when there is a video.
- Throw an error in both classes if `predict()` is called with no image or video.
- JSDoc
    - Fix the incorrect return types on `predict()`.
    - Make all three constructor arguments optional.
    - Add a type for `this.model`.
- Removed eslint disabling for rules which aren't actually broken.