### PR TITLE
Preserve case in user-provided model URLs.

### DIFF
--- a/src/ImageClassifier/index.js
+++ b/src/ImageClassifier/index.js
@@ -263,11 +263,9 @@ const imageClassifier = (modelName, videoOrOptionsOrCallback, optionsOrCallback,
   let options = {};
   let callback = cb;
 
-  let model = modelName;
+  const model = modelName;
   if (typeof model !== "string") {
     throw new Error('Please specify a model to use. E.g: "MobileNet"');
-  } else if (model.indexOf("http") === -1) {
-    model = modelName.toLowerCase();
   }
 
   if (videoOrOptionsOrCallback instanceof HTMLVideoElement) {

--- a/src/ObjectDetector/index.js
+++ b/src/ObjectDetector/index.js
@@ -57,11 +57,9 @@ const objectDetector = (modelName, videoOrOptionsOrCallback, optionsOrCallback, 
   let options = {};
   let callback = cb;
 
-  let model = modelName;
+  const model = modelName;
   if (typeof model !== "string") {
     throw new Error('Please specify a model to use. E.g: "YOLO"');
-  } else if (model.indexOf("http") === -1) {
-    model = modelName.toLowerCase();
   }
 
   if (videoOrOptionsOrCallback instanceof HTMLVideoElement) {

--- a/src/SoundClassifier/index.js
+++ b/src/SoundClassifier/index.js
@@ -85,11 +85,9 @@ const soundClassifier = (modelName, optionsOrCallback, cb) => {
   let options = {};
   let callback = cb;
 
-  let model = modelName;
+  const model = modelName;
   if (typeof model !== 'string') {
     throw new Error('Please specify a model to use. E.g: "SpeechCommands18w"');
-  } else if (model.indexOf('http') === -1) {
-    model = modelName.toLowerCase();
   }
 
   if (typeof optionsOrCallback === 'object') {


### PR DESCRIPTION
We currently convert all user-provided model URLs to lowercase in `ImageClassifier`, `ObjectDetector`, and `SoundClassifier`.  This will create errors if the user's URL requires uppercase characters.

I can't see any reason why `modelName.toLowerCase()` is good or desirable.  In PR #1322 I added a note `// TODO: I think we should delete this`, but I didn't want to implement any potentially breaking changes.  Now I see that this was discussed way back in PR #650, so I really think we should fix this!