### PR TITLE
Fix memory leaks in StyleTransfer

### DIFF
--- a/examples/javascript/StyleTransfer/StyleTransfer_Image/sketch.js
+++ b/examples/javascript/StyleTransfer/StyleTransfer_Image/sketch.js
@@ -11,8 +11,8 @@ This uses a pre-trained model of The Great Wave off Kanagawa and Udnie (Young Am
 
 const inputImg = document.getElementById('inputImg'); // The image we want to transfer
 const statusMsg = document.getElementById('statusMsg'); // The status message
-const styleA = document.getElementById('styleA'); // The div contrianer that holds new style image A
-const styleB = document.getElementById('styleB'); // The div contrianer that holds new style image B
+const styleA = document.getElementById('styleA'); // The div container that holds new style image A
+const styleB = document.getElementById('styleB'); // The div container that holds new style image B
 
 ml5.styleTransfer('models/wave')
   .then(style1 => style1.transfer(inputImg))

--- a/src/StyleTransfer/index.js
+++ b/src/StyleTransfer/index.js
@@ -30,9 +30,9 @@ const convertCanvasToImage = canvas => {
 class StyleTransfer extends Video {
   /**
    * Create a new Style Transfer Instance。
-   * @param {model} model - The path to Style Transfer model.
+   * @param {string} model - The path to Style Transfer model.
    * @param {HTMLVideoElement || p5.Video} video  - Optional. A HTML video element or a p5 video element.
-   * @param {funciton} callback - Optional. A function to be called once the model is loaded. If no callback is provided, it will return a promise that will be resolved once the model has loaded.
+   * @param {function} callback - Optional. A function to be called once the model is loaded. If no callback is provided, it will return a promise that will be resolved once the model has loaded.
    */
   constructor(model, video, callback) {
     super(video, IMAGE_SIZE);
@@ -42,7 +42,11 @@ class StyleTransfer extends Video {
      * @public
      */
     this.ready = false;
-    this.variableDictionary = {};
+    /**
+     * @private
+     * @type {Record<string, tf.Tensor>}
+     */
+    this.variables = {};
     this.timesScalar = tf.scalar(150);
     this.plusScalar = tf.scalar(255.0 / 2);
     this.epsilonScalar = tf.scalar(1e-3);
@@ -51,6 +55,11 @@ class StyleTransfer extends Video {
     // this.then = this.ready.then;
   }
 
+  /**
+   * @private
+   * @param {string} model
+   * @return {Promise<StyleTransfer>}
+   */
   async load(model) {
     if (this.videoElt) {
       await this.loadVideo();
@@ -59,11 +68,22 @@ class StyleTransfer extends Video {
     return this;
   }
 
+  /**
+   * @private
+   * @param {string} path
+   * @return {Promise<void>}
+   */
   async loadCheckpoints(path) {
     const checkpointLoader = new CheckpointLoader(path);
     this.variables = await checkpointLoader.getAllVariables();
   }
 
+  /**
+   * @private
+   * @param {tf.Tensor} input
+   * @param {number} id
+   * @return {tf.Tensor3D}
+   */
   instanceNorm(input, id) {
     return tf.tidy( () => {
       const [height, width, inDepth] = input.shape;
@@ -79,36 +99,60 @@ class StyleTransfer extends Video {
     });
   }
 
+  /**
+   * @private
+   * @param {tf.Tensor3D} input
+   * @param {number} strides
+   * @param {boolean} relu
+   * @param {number} id
+   * @return {tf.Tensor3D}
+   */
   convLayer(input, strides, relu, id) {
-    const y = tf.conv2d(input, this.variables[StyleTransfer.getVariableName(id)], [strides, strides], 'same');
-    const y2 = this.instanceNorm(y, id + 1);
-    if (relu) {
-      return tf.relu(y2);
-    }
-    return y2;
-  }
-
-  residualBlock(input, id) {
-    const conv1 = this.convLayer(input, 1, true, id);
-    const conv2 = this.convLayer(conv1, 1, false, id + 3);
-    return tf.add(conv2, input);
-  }
-
-  convTransposeLayer(input, numFilters, strides, id) {
-    const [height, width] = input.shape;
-    const newRows = height * strides;
-    const newCols = width * strides;
-    const newShape = [newRows, newCols, numFilters];
-    const y = tf.conv2dTranspose(input, this.variables[StyleTransfer.getVariableName(id)], newShape, [strides, strides], 'same');
-    const y2 = this.instanceNorm(y, id + 1);
-    const y3 = tf.relu(y2);
-    return y3;
+    return tf.tidy(() => {
+      const y = tf.conv2d(input, this.variables[StyleTransfer.getVariableName(id)], [strides, strides], 'same');
+      const y2 = this.instanceNorm(y, id + 1);
+      return relu ? tf.relu(y2) : y2;
+    });
   }
 
   /**
-   * 
-   * @param {Image || p5.Image || HTMLVideoElement || p5.Video} input  - A HTML video or image element or a p5 image or video element. If no input is provided, the default is to use the video element given in the constructor.
-   * @param {funciton} callback - Optional. A function to run once the model has made the transfer. If no callback is provided, it will return a promise that will be resolved once the model has made the transfer.
+   * @private
+   * @param {tf.Tensor3D} input
+   * @param {number} id
+   * @return {tf.Tensor3D}
+   */
+  residualBlock(input, id) {
+    return tf.tidy(() => {
+      const conv1 = this.convLayer(input, 1, true, id);
+      const conv2 = this.convLayer(conv1, 1, false, id + 3);
+      return tf.add(conv2, input);
+    })
+  }
+
+  /**
+   * @param {tf.Tensor3D} input
+   * @param {number} numFilters
+   * @param {number} strides
+   * @param {number} id
+   * @return {tf.Tensor3D}
+   */
+  convTransposeLayer(input, numFilters, strides, id) {
+    return tf.tidy(() => {
+      const [height, width] = input.shape;
+      const newRows = height * strides;
+      const newCols = width * strides;
+      const newShape = [newRows, newCols, numFilters];
+      const y = tf.conv2dTranspose(input, this.variables[StyleTransfer.getVariableName(id)], newShape, [strides, strides], 'same');
+      const y2 = this.instanceNorm(y, id + 1);
+      const y3 = tf.relu(y2);
+      return y3;
+    })
+  }
+
+  /**
+   * @public
+   * @param {Image || p5.Image || HTMLVideoElement || p5.Video || function} inputOrCallback  - A HTML video or image element or a p5 image or video element. If no input is provided, the default is to use the video element given in the constructor.
+   * @param {function} [cb] - Optional. A function to run once the model has made the transfer. If no callback is provided, it will return a promise that will be resolved once the model has made the transfer.
    */
   async transfer(inputOrCallback, cb) {
     let input;
@@ -134,6 +178,11 @@ class StyleTransfer extends Video {
     return callCallback(this.transferInternal(input), callback);
   }
 
+  /**
+   * @private
+   * @param {ImageData | HTMLImageElement | HTMLCanvasElement | HTMLVideoElement} input
+   * @return {Promise<HTMLImageElement>}
+   */
   async transferInternal(input) {
     const image = tf.browser.fromPixels(input);
     const result = array3DToImage(tf.tidy(() => {
@@ -158,6 +207,18 @@ class StyleTransfer extends Video {
     image.dispose();
     await tf.nextFrame();
     return result;
+  }
+
+  /**
+   * Dispose of all Tensors in instance properties.
+   * @public
+   * @return {void}
+   */
+  dispose() {
+    Object.values(this.variables).forEach(variable => variable.dispose());
+    this.timesScalar.dispose();
+    this.plusScalar.dispose();
+    this.epsilonScalar.dispose();
   }
 
   // Static Methods


### PR DESCRIPTION
### Problem

The StyleTransfer example logs this warning about potential memory leaks.
![image](https://user-images.githubusercontent.com/28965286/163691658-bb09d15b-0a16-482d-be55-ceb1f7942733.png)


### Solution

I added `tf.tidy()` calls around all methods in the `StyleTransfer` class to dispose of all "intermediary" tensors.  This is enough to make the console warning go away!

There are some tensors which are stored as instance properties on the `StyleTransfer` class instance.  These cannot be automatically disposed of because we don't know if the user intends to call `transfer()` again with another image.

I created a public method `dispose()` to handle these.   I haven't added this to the documentation or examples.  I guess it's more of a "nice to have" or an advanced feature.  There are probably a bunch of other model classes which should do something similar if we want to dispose of *all* tensors.

I also added a bunch of JSDoc.

### Technical

You can check on the number of active/undisposed tensors by pasting this in the console:
```
console.log("active tensors", ml5.tf.memory().numTensors);
```
**Without** adding in any calls to `.dispose()`, the total number of active tensors before and after this change is the same (`102`).  That is because the `tf.tidy()` call in `transferInternal()` will dispose of all the tensors created by private methods `this.convLayer()`, etc.

What this PR *does* improve is the total number of tensors active at one time.  You can see this by adding a `console.log` right before the end of the `tf.tidy()` block in `transferInternal()`:
```
const normalized = tf.div(clamped, tf.scalar(255.0));
console.log("active tensors", tf.memory().numTensors);
return normalized;
```

Before:
![image](https://user-images.githubusercontent.com/28965286/163692608-14841138-baf1-474e-9659-44ae904cda05.png)

After:
![image](https://user-images.githubusercontent.com/28965286/163692651-75e5a30b-68f5-46b0-89da-7ac1f02195cf.png)

We go from `257`/`300` down to `74`/`120`.  This shows that calling `tf.tidy()` more frequently has a positive impact on performance.

**With** calling dispose(), the number goes down to 0!
![image](https://user-images.githubusercontent.com/28965286/163692840-8dbe9209-1777-4e68-bb91-e1c0f3f8130c.png)

So I might update those examples after all...