### PR TITLE
Cleanup of CharRNN

### DIFF
--- a/examples/javascript/CharRNN/CharRNN_Text/sketch.js
+++ b/examples/javascript/CharRNN/CharRNN_Text/sketch.js
@@ -72,27 +72,27 @@ function generate() {
     // Make it to lower case
     const txt = original.toLowerCase();
 
-    // Check if there's something to send
-    if (txt.length > 0) {
-      // This is what the LSTM generator needs
-      // Seed text, temperature, length to outputs
-      // TODO: What are the defaults?
-      const data = {
-        seed: txt,
-        temperature: tempSlider.value,
-        length: lengthSlider.value
-      };
+    // This is what the LSTM generator needs
+    // Seed text, temperature, length to outputs
+    const data = {
+      seed: txt,
+      temperature: tempSlider.value,
+      length: lengthSlider.value
+    };
 
-      // Generate text with the charRNN
-      charRNN.generate(data, gotData);
+    // Generate text with the charRNN
+    charRNN.generate(data, gotData);
 
-      // When it's done
-      function gotData(err, result) {
-        // Update the status log
-        status.innerHTML = 'Ready!';
-        resultText.innerHTML = txt + result.sample;
-        runningInference = false;
+    // When it's done
+    function gotData(err, result) {
+      // Update the status log
+      if (err) {
+        status.innerHTML = `Error: ${err.message}`;
+        return;
       }
+      status.innerHTML = 'Ready!';
+      resultText.innerHTML = txt + result.sample;
+      runningInference = false;
     }
   }
 }

--- a/src/CharRNN/index.js
+++ b/src/CharRNN/index.js
@@ -281,16 +281,11 @@ class CharRNN {
   async feed(inputSeed, callback) {
     await this.ready;
     const seed = Array.from(inputSeed);
-    const encodedInput = [];
+    const encodedInput = seed.map(char => this.vocab[char]);
 
-    seed.forEach(char => {
-      encodedInput.push(this.vocab[char]);
-    });
-
-    let input = encodedInput[0];
     for (let i = 0; i < seed.length; i += 1) {
       const onehotBuffer = await tf.buffer([1, this.vocabSize]);
-      onehotBuffer.set(1.0, 0, input);
+      onehotBuffer.set(1.0, 0, encodedInput[i]);
       const onehot = onehotBuffer.toTensor();
       let output;
       if (this.model.embedding) {
@@ -301,7 +296,6 @@ class CharRNN {
       }
       this.state.c = output[0];
       this.state.h = output[1];
-      input = encodedInput[i];
     }
     if (callback) {
       callback();

--- a/src/CharRNN/index.js
+++ b/src/CharRNN/index.js
@@ -3,7 +3,6 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-/* eslint prefer-destructuring: ["error", {AssignmentExpression: {array: false}}] */
 /* eslint no-await-in-loop: "off" */
 /*
 A LSTM Generator: Run inference mode for a pre-trained LSTM.
@@ -22,60 +21,113 @@ const regexFullyConnected = /softmax/gi;
 class CharRNN {
   /**
    * Create a CharRNN.
-   * @param {String} modelPath - The path to the trained charRNN model.
-   * @param {function} callback  - Optional. A callback to be called once
+   * @param {string} modelPath - The path to the trained charRNN model.
+   * @param {function} [callback] - Optional. A callback to be called once
    *    the model has loaded. If no callback is provided, it will return a
    *    promise that will be resolved once the model has loaded.
    */
   constructor(modelPath, callback) {
     /**
-     * Boolean value that specifies if the model has loaded.
-     * @type {boolean}
-     * @public
-     */
-    this.ready = false;
-
-    /**
      * The pre-trained charRNN model.
-     * @type {model}
+     * @type {Record<string, tf.Tensor>}
      * @public
      */
     this.model = {};
+    /**
+     * The count of kernels in the model.
+     * @type {number}
+     */
     this.cellsAmount = 0;
+    /**
+     * Array of functions which create LSTM cells.
+     * @type {Array<tf.LSTMCellFunc>}
+     */
     this.cells = [];
+    /**
+     * @typedef {Object} CharRNNState
+     * @property {Array<tf.Tensor2D>} c
+     * @property {Array<tf.Tensor2D>} h
+     */
+    /**
+     * @type {CharRNNState}
+     */
     this.zeroState = { c: [], h: [] };
     /**
      * The vocabulary size (or total number of possible characters).
-     * @type {c: Array, h: Array}
+     * @type {CharRNNState}
      * @public
      */
     this.state = { c: [], h: [] };
+    /**
+     * Mapping of characters to their id numbers.
+     * @type {Record<string, number>}
+     */
     this.vocab = {};
+    /**
+     * Count of total unique characters.
+     * @type {number}
+     */
     this.vocabSize = 0;
+    /**
+     * TODO: consider removing as an instance property.
+     * @type {Float32Array | Array<number>}
+     */
     this.probabilities = [];
+    /**
+     * TODO: this should not be an instance property.
+     * @type {CharRNNOptions}
+     */
     this.defaults = {
       seed: "a", // TODO: use no seed by default
       length: 20,
       temperature: 0.5,
       stateful: false,
     };
-
+    /**
+     * Promise which resolves when the model has loaded.
+     * @type {Promise<CharRNN>}
+     * @public
+     */
     this.ready = callCallback(this.loadCheckpoints(modelPath), callback);
     // this.then = this.ready.then.bind(this.ready);
   }
 
+  /**
+   * @deprecated
+   *
+   * TODO: remove
+   */
   resetState() {
-    this.state = this.zeroState;
+    this.reset();
   }
 
+  /**
+   * @private
+   * @param {CharRNNState} state
+   * @void
+   */
   setState(state) {
+    // dispose of previous state, if it is not the same tensors as zeroState.
+    if (this.state !== this.zeroState) {
+      this.state.c.forEach(tensor => tensor.dispose());
+      this.state.h.forEach(tensor => tensor.dispose());
+    }
     this.state = state;
   }
 
+  /**
+   * @return {CharRNNState}
+   */
   getState() {
     return this.state;
   }
 
+  /**
+   * @private
+   *
+   * @param {string} path
+   * @return {Promise<CharRNN>}
+   */
   async loadCheckpoints(path) {
     const reader = new CheckpointLoader(path);
     const vars = await reader.getAllVariables();
@@ -102,6 +154,12 @@ class CharRNN {
     return this;
   }
 
+  /**
+   * @private
+   *
+   * @param {string} path
+   * @return {Promise<Record<string, number>>}
+   */
   async loadVocab(path) {
     try {
       const { data } = await axios.get(`${path}/vocab.json`);
@@ -109,19 +167,30 @@ class CharRNN {
       this.vocabSize = Object.keys(data).length;
       return this.vocab;
     } catch (err) {
-      return err;
+      throw new Error(`Unable to load vocab from URL ${path}/vocab.json. Failed with error: ${err.toString()}`);
     }
   }
 
+  /**
+   * @private
+   *
+   * @return {Promise<void>}
+   */
   async initCells() {
     this.cells = [];
     this.zeroState = { c: [], h: [] };
-    const forgetBias = tf.tensor(1.0);
 
+    /**
+     * @param {number} i
+     * @return {tf.LSTMCellFunc}
+     */
     const lstm = i => {
+      /**
+       * @type {tf.LSTMCellFunc}
+       */
       const cell = (DATA, C, H) =>
         tf.basicLSTMCell(
-          forgetBias,
+          1.0,
           this.model[`Kernel_${i}`],
           this.model[`Bias_${i}`],
           DATA,
@@ -137,67 +206,105 @@ class CharRNN {
       this.cells.push(lstm(i));
     }
 
-    this.state = this.zeroState;
+    // copy new zeroState to state.
+    this.reset();
   }
 
-  async generateInternal(options) {
-    await this.ready;
-    const seed = options.seed || this.defaults.seed;
-    const length = +options.length || this.defaults.length;
-    const temperature = +options.temperature || this.defaults.temperature;
-    const stateful = options.stateful || this.defaults.stateful;
-    if (!stateful) {
-      this.state = this.zeroState;
-    }
-
-    const results = [];
-    const userInput = Array.from(seed);
-    const encodedInput = [];
-
-    userInput.forEach(char => {
-      encodedInput.push(this.vocab[char]);
-    });
-
-    let input = encodedInput[0];
-    let probabilitiesNormalized = []; // will contain final probabilities (normalized)
-
-    for (let i = 0; i < userInput.length + length + -1; i += 1) {
-      const onehotBuffer = await tf.buffer([1, this.vocabSize]);
+  /**
+   * @private
+   * Common logic from feed() and generateInternal().
+   * Updates this.state based on the current character.
+   *
+   * @param {number} input - character id
+   * @return {Promise<void>}
+   */
+  async nextState(input) {
+    const onehotBuffer = await tf.buffer([1, this.vocabSize]);
+    const [c, h] = tf.tidy(() => {
       onehotBuffer.set(1.0, 0, input);
       const onehot = onehotBuffer.toTensor();
-      let output;
-      if (this.model.embedding) {
-        const embedded = tf.matMul(onehot, this.model.embedding);
-        output = tf.multiRNNCell(this.cells, embedded, this.state.c, this.state.h);
-      } else {
-        output = tf.multiRNNCell(this.cells, onehot, this.state.c, this.state.h);
-      }
+      const data = this.model.embedding ? tf.matMul(onehot, this.model.embedding) : onehot;
+      return tf.multiRNNCell(this.cells, data, this.state.c, this.state.h);
+    });
+    this.setState({ c, h });
+  }
 
-      this.state.c = output[0];
-      this.state.h = output[1];
-
+  /**
+   * @private
+   * Common logic from feed() and generateInternal().
+   * Get an array with the probabilities of each character appearing next.
+   *
+   * @param {number} temperature
+   * @return {Promise<Float32Array>}
+   */
+  async nextChar(temperature) {
+    const normalized = tf.tidy(() => {
       const outputH = this.state.h[1];
       const weightedResult = tf.matMul(outputH, this.model.fullyConnectedWeights);
       const logits = tf.add(weightedResult, this.model.fullyConnectedBiases);
       const divided = tf.div(logits, tf.tensor(temperature));
       const probabilities = tf.exp(divided);
-      probabilitiesNormalized = await tf.div(probabilities, tf.sum(probabilities)).data();
+      return tf.div(probabilities, tf.sum(probabilities));
+    });
+    const probabilitiesNormalized = await normalized.data();
+    normalized.dispose();
+    return probabilitiesNormalized;
+  }
+
+
+  /**
+   * @private
+   * Convert a numeric id to its text character.
+   *
+   * @param {number} index
+   * @return {string}
+   */
+  findChar(index) {
+    const result = Object.keys(this.vocab).find(key => this.vocab[key] === index);
+    if (!result) {
+      throw new Error(`No character in the model's vocab corresponds to predicted index ${index}.`);
+    }
+    return result;
+  }
+
+  /**
+   * @private
+   *
+   * @param {CharRNNOptions} options
+   * @return {Promise<{state: CharRNNState, sample: string}>}
+   */
+  async generateInternal(options) {
+    await this.ready;
+    // TODO: implement documented behavior "default seed is a random character from the model"
+    const seed = options.seed || this.defaults.seed;
+    const length = +options.length || this.defaults.length;
+    const temperature = +options.temperature || this.defaults.temperature;
+    const stateful = options.stateful || this.defaults.stateful;
+    if (!stateful) {
+      this.reset();
+    }
+
+    const results = [];
+    const userInput = Array.from(seed);
+    const encodedInput = userInput.map(char => this.vocab[char]);
+
+    let input = encodedInput[0];
+    let probabilitiesNormalized = []; // will contain final probabilities (normalized)
+
+    for (let i = 0; i < userInput.length + length + -1; i += 1) {
+
+      await this.nextState(input);
 
       if (i < userInput.length - 1) {
         input = encodedInput[i + 1];
       } else {
+        probabilitiesNormalized = await this.nextChar(temperature);
         input = sampleFromDistribution(probabilitiesNormalized);
         results.push(input);
       }
     }
 
-    let generated = "";
-    results.forEach(char => {
-      const mapped = Object.keys(this.vocab).find(key => this.vocab[key] === char);
-      if (mapped) {
-        generated += mapped;
-      }
-    });
+    const generated = results.map(id => this.findChar(id)).join('');
     this.probabilities = probabilitiesNormalized;
     return {
       sample: generated,
@@ -206,33 +313,38 @@ class CharRNN {
   }
 
   /**
+   * @public
+   * @void
+   *
    * Reset the model state.
    */
   reset() {
-    this.state = this.zeroState;
+    this.setState(this.zeroState);
   }
 
   /**
-   * @typedef {Object} options
+   * @typedef {Object} CharRNNOptions
    * @property {String} seed
    * @property {number} length
    * @property {number} temperature
+   * @property {boolean} stateful
    */
 
   // stateless
   /**
    * Generates content in a stateless manner, based on some initial text
    *    (known as a "seed"). Returns a string.
-   * @param {options} options - An object specifying the input parameters of
+   * @param {Partial<CharRNNOptions>} options - An object specifying the input parameters of
    *    seed, length and temperature. Default length is 20, temperature is 0.5
    *    and seed is a random character from the model. The object should look like
    *    this:
-   * @param {function} callback - Optional. A function to be called when the model
+   * @param {function} [callback] - Optional. A function to be called when the model
    *    has generated content. If no callback is provided, it will return a promise
    *    that will be resolved once the model has generated new content.
+   *
+   * @return {Promise<{state: CharRNNState, sample: string}>}
    */
   async generate(options, callback) {
-    this.reset();
     return callCallback(this.generateInternal(options), callback);
   }
 
@@ -240,27 +352,25 @@ class CharRNN {
   /**
    * Predict the next character based on the model's current state.
    * @param {number} temp
-   * @param {function} callback - Optional. A function to be called when the
+   * @param {function} [callback] - Optional. A function to be called when the
    *    model finished adding the seed. If no callback is provided, it will
    *    return a promise that will be resolved once the prediction has been generated.
+   * @return {Promise<{sample: string, probabilities: Array<{probability: number, char: string}>}>}
    */
   async predict(temp, callback) {
-    let probabilitiesNormalized = [];
     const temperature = temp > 0 ? temp : 0.1;
-    const outputH = this.state.h[1];
-    const weightedResult = tf.matMul(outputH, this.model.fullyConnectedWeights);
-    const logits = tf.add(weightedResult, this.model.fullyConnectedBiases);
-    const divided = tf.div(logits, tf.tensor(temperature));
-    const probabilities = tf.exp(divided);
-    probabilitiesNormalized = await tf.div(probabilities, tf.sum(probabilities)).data();
+    const probabilitiesNormalized = await this.nextChar(temperature);
 
+    // The index of the predicted char.
     const sample = sampleFromDistribution(probabilitiesNormalized);
-    const result = Object.keys(this.vocab).find(key => this.vocab[key] === sample);
+    // The character itself.
+    const result = this.findChar(sample);
     this.probabilities = probabilitiesNormalized;
     if (callback) {
+      // TODO: why call callback here and not at the end of the function?
+      // why call with result first and not error first?
       callback(result);
     }
-    /* eslint max-len: ["error", { "code": 180 }] */
     const pm = Object.keys(this.vocab).map(c => ({
       char: c,
       probability: this.probabilities[this.vocab[c]],
@@ -273,33 +383,36 @@ class CharRNN {
 
   /**
    * Feed a string of characters to the model state.
-   * @param {String} inputSeed - A string to feed the charRNN model state.
-   * @param {function} callback  - Optional. A function to be called when
+   * @param {string} inputSeed - A string to feed the charRNN model state.
+   * @param {function} [callback] - Optional. A function to be called when
    *    the model finished adding the seed. If no callback is provided, it
    *    will return a promise that will be resolved once seed has been fed.
+   * @return {Promise<void>}
    */
   async feed(inputSeed, callback) {
-    await this.ready;
-    const seed = Array.from(inputSeed);
-    const encodedInput = seed.map(char => this.vocab[char]);
+    return callCallback((async () => {
+      await this.ready;
+      Array.from(inputSeed).forEach(char => {
+        const encoded = this.vocab[char];
+        this.nextState(encoded);
+      });
+    })(), callback);
+  }
 
-    for (let i = 0; i < seed.length; i += 1) {
-      const onehotBuffer = await tf.buffer([1, this.vocabSize]);
-      onehotBuffer.set(1.0, 0, encodedInput[i]);
-      const onehot = onehotBuffer.toTensor();
-      let output;
-      if (this.model.embedding) {
-        const embedded = tf.matMul(onehot, this.model.embedding);
-        output = tf.multiRNNCell(this.cells, embedded, this.state.c, this.state.h);
-      } else {
-        output = tf.multiRNNCell(this.cells, onehot, this.state.c, this.state.h);
-      }
-      this.state.c = output[0];
-      this.state.h = output[1];
-    }
-    if (callback) {
-      callback();
-    }
+  /**
+   * @public
+   * @void
+   *
+   * Cleans up memory by disposing of tensors used in instance properties.
+   */
+  dispose() {
+    [
+      Object.values(this.model),
+      this.zeroState.c,
+      this.zeroState.h,
+      this.state.c,
+      this.state.h
+    ].forEach(array => array.forEach(tensor => tensor.dispose()));
   }
 }
 


### PR DESCRIPTION
Extends PR #1356.

Implements all of the potentially breaking changes discussed in #1356 plus:

- Restructure `this.model` so that bias and weight tensors are stored in arrays (`this.model.weights[i]`) rather than named properties (`this.model['Kernel_${i}']`).
- Remove instance property `this.cellsAmount`.
- Consistent handling of callbacks.
- Changed "empty" seed text from character `"a"` to a space `" "` so that the generated text starts with a word instead of mid-word.