### PR TITLE
Refactor: breakup ImageClassifier

### DIFF
--- a/src/ImageClassifier/custom.js
+++ b/src/ImageClassifier/custom.js
@@ -1,0 +1,129 @@
+import * as tf from '@tensorflow/tfjs';
+import axios from 'axios';
+
+/**
+ * Wrapper around a tf.LayersModel used for image classification.
+ */
+
+class CustomImageClassifier {
+
+  /**
+   * @param {string} url
+   */
+  constructor(url) {
+    // its a url, we expect to find model.json
+    // The teachablemachine urls end with a slash, so add model.json to complete the full path
+    /**
+     * @type {string}
+     */
+    this.url = url.endsWith('/') ? `${url}model.json` : url;
+    /**
+     * @type {string[]}
+     */
+    this.labels = [];
+    /**
+     * @type {tf.LayersModel | null}
+     */
+    this.model = null;
+  }
+
+  /**
+   * @private
+   * Attempt to load labels from a property `ml5Specs` in the `model.json`
+   * or from a `metadata.json` file in the same directory.
+   * If no labels can be found, the model will treat the indices as labels.
+   * @return {Promise<void>}
+   */
+  async loadLabels() {
+    // first try from the model.json
+    try {
+      const result = await axios.get(this.url);
+      // eslint-disable-next-line prefer-destructuring
+      const data = result.data;
+
+      if (data.ml5Specs) {
+        this.labels = data.ml5Specs.mapStringToIndex;
+        return;
+      }
+    } catch (error) {
+      console.warn("Error loading model json file.", error);
+    }
+    // then try from the metadata.json
+    try {
+      const prefix = this.url.slice(0, this.url.lastIndexOf("/"));
+      const metadataUrl = `${prefix}/metadata.json`;
+
+      const result = await axios.get(metadataUrl);
+      // eslint-disable-next-line prefer-destructuring
+      const data = result.data;
+      if (!data.labels) {
+        console.warn(`metadata.json file does not contain property 'labels'.`);
+      }
+      this.labels = data.labels;
+    } catch (error) {
+      console.warn("Tried to fetch metadata.json, but it seems to be missing.", error);
+    }
+  }
+
+  /**
+   * @private
+   * Load the TensorFlow model from the URL.
+   * @return {Promise<void>}
+   */
+  async loadModel() {
+    try {
+      this.model = await tf.loadLayersModel(this.url);
+    } catch (error) {
+      throw new Error(`Error loading model: ${error}`);
+    }
+  }
+
+  /**
+   * @public
+   * Load the model and the labels in parallel.
+   * @return {Promise<void>}
+   */
+  async load() {
+    await Promise.all([
+      this.loadLabels(),
+      this.loadModel()
+    ])
+  }
+
+  /**
+   * @param {tf.Tensor3D} img
+   * @param {number} topk
+   * @return {Promise<{probability: number, className: number|string}[]>}
+   */
+  async classify(img, topk) {
+    const predictedClasses = tf.tidy(() => {
+      return this.model.predict(img).as1D();
+    });
+    // TODO: combine with getTopKClassesFromTensor in other models.
+    const data = await predictedClasses.data();
+    return Array.from(data)
+      .map((probability, index) => {
+        const className =
+          this.labels.length > 0 && this.labels[index]
+            ? this.labels[index]
+            : index;
+        return {
+          className,
+          probability,
+        };
+      })
+      .sort((a, b) => b.probability - a.probability)
+      .slice(0, topk);
+  }
+}
+
+/**
+ * @param {string} url
+ * @return {Promise<CustomImageClassifier>}
+ */
+// eslint-disable-next-line import/prefer-default-export
+export async function load(url) {
+  const model = new CustomImageClassifier(url);
+  await model.load();
+  return model;
+}

--- a/src/ImageClassifier/index.js
+++ b/src/ImageClassifier/index.js
@@ -8,23 +8,32 @@ Image Classifier using pre-trained networks
 */
 
 import * as tf from "@tensorflow/tfjs";
-// eslint-disable-next-line no-unused-vars
-import axios from "axios";
 import * as mobilenet from "@tensorflow-models/mobilenet";
 import * as darknet from "./darknet";
 import * as doodlenet from "./doodlenet";
+import * as modelFromUrl from "./custom";
 import callCallback from "../utils/callcallback";
 import { imgToTensor } from "../utils/imageUtilities";
 
 const DEFAULTS = {
   mobilenet: {
     version: 2,
-    alpha: 1.0,
-    topk: 3,
+    alpha: 1.0
   },
+  topk: 3
 };
 const IMAGE_SIZE = 224;
-const MODEL_OPTIONS = ["mobilenet", "darknet", "darknet-tiny", "doodlenet"];
+
+/**
+ * @typedef Classify
+ * @param {tf.Tensor3D} img
+ * @param {number} classes
+ * @return {Promise<Array<{ className: string, probability: number }>>}
+ */
+/**
+ * @typedef {Object} ClassifierModel
+ * @property {Classify} classify
+ */
 
 class ImageClassifier {
   /**
@@ -37,89 +46,43 @@ class ImageClassifier {
    */
   constructor(modelNameOrUrl, video, options, callback) {
     this.video = video;
+    /**
+     * @type {null|ClassifierModel}
+     */
     this.model = null;
-    this.mapStringToIndex = [];
-    if (typeof modelNameOrUrl === "string") {
-      if (MODEL_OPTIONS.includes(modelNameOrUrl)) {
-        this.modelName = modelNameOrUrl;
-        this.modelUrl = null;
-        switch (this.modelName) {
-          case "mobilenet":
-            this.modelToUse = mobilenet;
-            this.version = options.version || DEFAULTS.mobilenet.version;
-            this.alpha = options.alpha || DEFAULTS.mobilenet.alpha;
-            this.topk = options.topk || DEFAULTS.mobilenet.topk;
-            break;
-          case "darknet":
-            this.version = "reference"; // this a 28mb model
-            this.modelToUse = darknet;
-            break;
-          case "darknet-tiny":
-            this.version = "tiny"; // this a 4mb model
-            this.modelToUse = darknet;
-            break;
-          case "doodlenet":
-            this.modelToUse = doodlenet;
-            break;
-          default:
-            this.modelToUse = null;
-        }
-      } else {
-        // its a url, we expect to find model.json
-        this.modelUrl = modelNameOrUrl;
-        // The teachablemachine urls end with a slash, so add model.json to complete the full path
-        if (this.modelUrl.endsWith('/')) this.modelUrl += "model.json";
-      }
-    }
+    const { topk, ...rest } = options;
+    /**
+     * @type number
+     */
+    this.topk = topk;
     // Load the model
-    this.ready = callCallback(this.loadModel(this.modelUrl), callback);
+    this.ready = callCallback(this.loadModel(modelNameOrUrl, rest), callback);
   }
 
   /**
    * Load the model and set it to this.model
+   * @param {string} modelNameOrUrl
+   * @param {object} [options]
    * @return {this} The ImageClassifier.
    */
-  async loadModel(modelUrl) {
-    if (modelUrl) this.model = await this.loadModelFrom(modelUrl);
-    else this.model = await this.modelToUse.load({ version: this.version, alpha: this.alpha });
-
-    return this;
-  }
-
-  async loadModelFrom(path = null) {
-    try {
-      let data;
-      if (path !== null) {
-        const result = await axios.get(path);
-        // eslint-disable-next-line prefer-destructuring
-        data = result.data;
-      }
-
-      if (data.ml5Specs) {
-        this.mapStringToIndex = data.ml5Specs.mapStringToIndex;
-      }
-      if (this.mapStringToIndex.length === 0) {
-        const split = path.split("/");
-        const prefix = split.slice(0, split.length - 1).join("/");
-        const metadataUrl = `${prefix}/metadata.json`;
-
-        const metadataResponse = await axios.get(metadataUrl).catch((metadataError) => {
-          console.log("Tried to fetch metadata.json, but it seems to be missing.", metadataError);
-        });
-        if (metadataResponse) {
-          const metadata = metadataResponse.data;
-          
-          if (metadata.labels) {
-            this.mapStringToIndex = metadata.labels;
-          }
-        }
-      }
-      this.model = await tf.loadLayersModel(path);
-      return this.model;
-    } catch (err) {
-      console.error(err);
-      return err;
+  async loadModel(modelNameOrUrl, options= {}) {
+    switch (modelNameOrUrl.toLowerCase()) {
+      case "mobilenet":
+        this.model = await mobilenet.load({ ...DEFAULTS.mobilenet, ...options });
+        break;
+      case "darknet":
+        this.model = await darknet.load({ version: "reference" }); // this a 28mb model
+        break;
+      case "darknet-tiny":
+        this.model = await darknet.load({ version: "reference" }); // this a 4mb model
+        break;
+      case "doodlenet":
+        this.model = await doodlenet.load();
+        break;
+      default:
+        this.model = await modelFromUrl.load(modelNameOrUrl);
     }
+    return this;
   }
 
   /**
@@ -128,7 +91,7 @@ class ImageClassifier {
    *    takes an image to run the classification on.
    * @param {number} numberOfClasses - a number of labels to return for the image
    *    classification.
-   * @return {object} an object with {label, confidence}.
+   * @return {Promise<{confidence: number, label: string}[]>} an object with {label, confidence}.
    */
   async classifyInternal(imgToPredict, numberOfClasses) {
     // Wait for the model to be ready
@@ -151,30 +114,6 @@ class ImageClassifier {
 
     // Process the images
     const imageResize = [IMAGE_SIZE, IMAGE_SIZE];
-
-    if (this.modelUrl) {
-      await tf.nextFrame();
-      const predictedClasses = tf.tidy(() => {
-        const processedImg = imgToTensor(imgToPredict, imageResize);
-        const predictions = this.model.predict(processedImg);
-        return Array.from(predictions.as1D().dataSync());
-      });
-
-      const results = await predictedClasses
-        .map((confidence, index) => {
-          const label =
-            this.mapStringToIndex.length > 0 && this.mapStringToIndex[index]
-              ? this.mapStringToIndex[index]
-              : index;
-          return {
-            label,
-            confidence,
-          };
-        })
-        .sort((a, b) => b.confidence - a.confidence);
-      return results;
-    }
-
     const processedImg = imgToTensor(imgToPredict, imageResize);
     const results = this.model
       .classify(processedImg, numberOfClasses)
@@ -263,11 +202,9 @@ const imageClassifier = (modelName, videoOrOptionsOrCallback, optionsOrCallback,
   let options = {};
   let callback = cb;
 
-  let model = modelName;
+  const model = modelName;
   if (typeof model !== "string") {
     throw new Error('Please specify a model to use. E.g: "MobileNet"');
-  } else if (model.indexOf("http") === -1) {
-    model = modelName.toLowerCase();
   }
 
   if (videoOrOptionsOrCallback instanceof HTMLVideoElement) {


### PR DESCRIPTION
Take the code in ImageClassifier which deals with loading a model from a URL and move that into its own CustomImageClassifier class.

All 4 model types -- darknet, mobilenet, doodlenet, and custom -- can be used interchangeably.