### PR TITLE
Fix memory leak in pix2pix promise example & cleanup

### DIFF
--- a/examples/javascript/Pix2Pix/Pix2Pix_callback/index.html
+++ b/examples/javascript/Pix2Pix/Pix2Pix_callback/index.html
@@ -16,8 +16,8 @@
   <p>4. You could click the "Clear" button to clear the canvas and draw again.</p>
   <p id="status">Loading Model... Please wait...</p>
 
-  <img id="inputImage" width="256px" src="images/input.png" alt="input image"         />
-  <img id="outputImage" width="256px" src="" alt="output image"         />
+  <img id="inputImage" width="256" src="images/input.png" alt="input image"         />
+  <img id="outputImage" width="256" src="" alt="output image"         />
 
   <div class="flex">
     <div>

--- a/examples/javascript/Pix2Pix/Pix2Pix_promise/index.html
+++ b/examples/javascript/Pix2Pix/Pix2Pix_promise/index.html
@@ -16,8 +16,8 @@
   <p>4. You could click the "Clear" button to clear the canvas and draw again.</p>
   <p id="status">Loading Model... Please wait...</p>
 
-  <img id="inputImage" width="256px" src="images/input.png" alt="input image"         />
-  <img id="outputImage" width="256px" src="" alt="output image"         />
+  <img id="inputImage" width="256" src="images/input.png" alt="input image"         />
+  <img id="outputImage" width="256" src="" alt="output image"         />
 
   <div class="flex">
     <div>


### PR DESCRIPTION
Promise example:
 * Fix MAJOR memory leak where model was re-created on every animation frame.

Both examples:
* Move contents of `setup()` function to the top-level so that variables can be declared and assigned in one operation, which gets rid of a lot of `let` variables.
* Transfer image immediately when mouse is released from canvas.
* Initiate drawing through event handlers on the canvas element instead of calling `draw()` on every animation frame.  Now the drawing code it is only executed when the user is interacting with the canvas.