### PR TITLE
Make use of the built-in tensorflow `topk` function.

### DIFF
--- a/src/ImageClassifier/darknet.js
+++ b/src/ImageClassifier/darknet.js
@@ -4,7 +4,7 @@
 // https://opensource.org/licenses/MIT
 
 import * as tf from "@tensorflow/tfjs";
-import { getTopKClassesFromTensor } from "../utils/gettopkclasses";
+import getTopKClasses from "../utils/gettopkclasses";
 import IMAGENET_CLASSES_DARKNET from "../utils/IMAGENET_CLASSES_DARKNET";
 
 const DEFAULTS = {
@@ -87,9 +87,7 @@ export class Darknet {
       const predictions = this.model.predict(imgData);
       return tf.softmax(predictions);
     });
-    const classes = await getTopKClassesFromTensor(logits, topk, IMAGENET_CLASSES_DARKNET);
-    logits.dispose();
-    return classes;
+    return getTopKClasses(logits, topk, IMAGENET_CLASSES_DARKNET);
   }
 }
 

--- a/src/ImageClassifier/doodlenet.js
+++ b/src/ImageClassifier/doodlenet.js
@@ -4,7 +4,7 @@
 // https://opensource.org/licenses/MIT
 
 import * as tf from '@tensorflow/tfjs';
-import { getTopKClassesFromTensor } from '../utils/gettopkclasses';
+import getTopKClasses from '../utils/gettopkclasses';
 import DOODLENET_CLASSES from '../utils/DOODLENET_CLASSES';
 
 const DEFAULTS = {
@@ -61,9 +61,7 @@ export class Doodlenet {
       const predictions = this.model.predict(imgData);
       return predictions;
     });
-    const classes = await getTopKClassesFromTensor(logits, topk, DOODLENET_CLASSES);
-    logits.dispose();
-    return classes;
+    return getTopKClasses(logits, topk, DOODLENET_CLASSES);
   }
 }
 

--- a/src/ImageClassifier/index.js
+++ b/src/ImageClassifier/index.js
@@ -176,11 +176,18 @@ class ImageClassifier {
     }
 
     const processedImg = imgToTensor(imgToPredict, imageResize);
-    const results = this.model
-      .classify(processedImg, numberOfClasses)
-      .then(classes => classes.map(c => ({ label: c.className, confidence: c.probability })));
+    const results = await this.model.classify(processedImg, numberOfClasses);
 
     processedImg.dispose();
+
+    // TODO: handle this better
+    // MobileNet uses className/probability instead of label/confidence.
+    if (this.modelName === "mobilenet") {
+      return results.map(result => ({
+        label: result.className,
+        confidence: result.probability
+      }));
+    }
 
     return results;
   }

--- a/src/SoundClassifier/speechcommands.js
+++ b/src/SoundClassifier/speechcommands.js
@@ -4,7 +4,7 @@
 // https://opensource.org/licenses/MIT
 
 import * as tfjsSpeechCommands from '@tensorflow-models/speech-commands';
-import { getTopKClassesFromArray } from '../utils/gettopkclasses';
+import getTopKClasses  from '../utils/gettopkclasses';
 
 export class SpeechCommands {
   constructor(options) {
@@ -23,10 +23,9 @@ export class SpeechCommands {
   }
 
   classify(topk = this.allLabels.length, cb) {
-    return this.model.listen(result => {
+    return this.model.listen(async (result) => {
       if (result.scores) {
-        const classes = getTopKClassesFromArray(result.scores, topk, this.allLabels)
-          .map(c => ({ label: c.className, confidence: c.probability }));
+        const classes = await getTopKClasses(result.scores, topk, this.allLabels);
         return cb(null, classes);
       }
       return cb(`ERROR: Cannot find scores in result: ${result}`);

--- a/src/utils/gettopkclasses.js
+++ b/src/utils/gettopkclasses.js
@@ -2,37 +2,28 @@
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
+import * as tf from "@tensorflow/tfjs-core";
 
-export function getTopKClassesFromArray(values, topK, CLASSES) {
-  const valuesAndIndices = [];
-  for (let i = 0; i < values.length; i += 1) {
-    valuesAndIndices.push({
-      value: values[i],
-      index: i,
-    });
+/**
+ * @param {tf.Tensor | tf.TensorLike} logits - Tensor or array with the predicted probabilities for each class.
+ * @param {number} topK - Number of results to return.
+ * @param {string[]} [classes] - Array which maps indices to class names. If no classes are provided, the index
+ * will be used as the label. It will be cast to a string for consistency.
+ * @param {boolean} [keepTensor] - The logits will be automatically disposed unless this is `true`.
+ * @return {Promise<Array<{ label: string, confidence: number}>>} - An array of objects with properties `label` and `confidence`.
+ */
+export default async function getTopKClasses(logits, topK, classes, keepTensor= false ) {
+  const top = tf.topk(logits, topK, true);
+  const values = await top.values.data();
+  const indices = await top.indices.data();
+  const result = Array.from(indices).map((index, i) => ({
+    confidence: values[i],
+    label: classes ? classes[index] : index.toString(10)
+  }))
+  top.values.dispose();
+  top.indices.dispose();
+  if (!keepTensor && logits instanceof tf.Tensor) {
+    logits.dispose();
   }
-  valuesAndIndices.sort((a, b) => b.value - a.value);
-
-  const topkValues = new Float32Array(topK);
-  const topkIndices = new Int32Array(topK);
-  for (let i = 0; i < topK; i += 1) {
-    topkValues[i] = valuesAndIndices[i].value;
-    topkIndices[i] = valuesAndIndices[i].index;
-  }
-
-  const topClassesAndProbs = [];
-  for (let i = 0; i < topkIndices.length; i += 1) {
-    topClassesAndProbs.push({
-      className: CLASSES[topkIndices[i]],
-      probability: topkValues[i],
-    });
-  }
-  return topClassesAndProbs;
+  return result;
 }
-
-export async function getTopKClassesFromTensor(logits, topK, CLASSES) {
-  const values = await logits.data();
-  return getTopKClassesFromArray(values, topK, CLASSES);
-}
-
-export default { getTopKClassesFromArray, getTopKClassesFromTensor }


### PR DESCRIPTION
Kills the `getTopKClassesFromArray` and `getTopKClassesFromTensor` functions and uses the built-in [tfjs `topK` function](https://github.com/tensorflow/tfjs/blob/9769ea46f912a767bd78cce0512782bba718b425/tfjs-core/src/ops/topk.ts) instead.  I haven't looked deep into what the `ENGINE.runKernel` is doing under the hood but I would assume it's more performant than our version, which sorts the entire array even though only k results are needed.

The new `getTopKClasses` function is a wrapper around `tf.topk` which:
* Accepts both tensors and arrays.
* Handles the case where no classes are provided by returning the index as the label, eg. `"3"`.
* Automatically disposes of the input tensor. (This can be disabled via a fourth argument)

It is used in `darknet`, `doodlenet`, and `speechcommands`.

This PR might raise some conflicts with #1362 which also touches the `ImageClassifier`.  I can address once one is merged.