### PR TITLE
Fix eslint variable issues in p5js examples.

### DIFF
--- a/examples/p5js/CartoonGAN/CartoonGan_Basic/sketch.js
+++ b/examples/p5js/CartoonGAN/CartoonGan_Basic/sketch.js
@@ -1,27 +1,26 @@
 let cartoonGan;
 let img;
-let newImage;
-function preload(){
+
+function preload() {
   img = loadImage('MrBubz.jpg');
 }
 
-function setup(){
+function setup() {
   createCanvas(160, 160);
 
-  cartoonGan = ml5.cartoon(modelLoaded)
-  image(img, 0,0, width, height)
+  cartoonGan = ml5.cartoon(modelLoaded);
+  image(img, 0, 0, width, height);
 }
 
-function modelLoaded(){
-  cartoonGan.generate(img, gotResults)
+function modelLoaded() {
+  cartoonGan.generate(img, gotResults);
 }
 
-function gotResults(err, result){
-  if(err){
+function gotResults(err, result) {
+  if (err) {
     return;
   }
-  console.log(result)
-  image(result.image, 0,0, 160, 160);
-    
+  console.log(result);
+  image(result.image, 0, 0, width, height);
 }
 

--- a/examples/p5js/CartoonGAN/CartoonGan_LoadModel/sketch.js
+++ b/examples/p5js/CartoonGAN/CartoonGan_LoadModel/sketch.js
@@ -1,27 +1,26 @@
 let cartoonGan;
 let img;
-let newImage;
-function preload(){
+
+function preload() {
   img = loadImage('MrBubz.jpg');
 }
 
-function setup(){
+function setup() {
   createCanvas(160, 160);
 
-  cartoonGan = ml5.cartoon("./model/model.json",modelLoaded)
-  image(img, 0,0, width, height)
+  cartoonGan = ml5.cartoon("./model/model.json", modelLoaded);
+  image(img, 0, 0, width, height);
 }
 
-function modelLoaded(){
-  cartoonGan.generate(img, gotResults)
+function modelLoaded() {
+  cartoonGan.generate(img, gotResults);
 }
 
-function gotResults(err, result){
-  if(err){
+function gotResults(err, result) {
+  if (err) {
     return;
   }
-  console.log(result)
-  image(result.image, 0,0, 160, 160);
-    
+  console.log(result);
+  image(result.image, 0, 0, width, height);
 }
 

--- a/examples/p5js/CharRNN/CharRNN_Text_Stateful/sketch.js
+++ b/examples/p5js/CharRNN/CharRNN_Text_Stateful/sketch.js
@@ -11,11 +11,7 @@ For more models see: https://github.com/ml5js/ml5-data-and-training/tree/master/
 === */
 
 let charRNN;
-let textInput;
 let tempSlider;
-let startBtn;
-let resetBtn;
-let singleBtn;
 let generating = false;
 
 const canvasHeight = 100;
@@ -25,16 +21,12 @@ function setup() {
   // Create the LSTM Generator passing it the model directory
   charRNN = ml5.charRNN('https://raw.githubusercontent.com/ml5js/ml5-data-and-models/main/models/charRNN/woolf/', modelReady);
   // Grab the DOM elements
-  textInput = select('#textInput');
   tempSlider = select('#tempSlider');
-  startBtn = select('#start');
-  resetBtn = select('#reset');
-  singleBtn = select('#single');
 
   // DOM element events
-  startBtn.mousePressed(generate);
-  resetBtn.mousePressed(resetModel);
-  singleBtn.mousePressed(predict);
+  select('#start').mousePressed(generate);
+  select('#reset').mousePressed(resetModel);
+  select('#single').mousePressed(predict);
   tempSlider.input(updateSliders);
 }
 
@@ -62,10 +54,10 @@ function resetModel() {
 function generate() {
   if (generating) {
     generating = false;
-    startBtn.html('Start');
+    select('#start').html('Start');
   } else {
     generating = true;
-    startBtn.html('Pause');
+    select('#start').html('Pause');
     loopRNN();
   }
 }

--- a/examples/p5js/FaceApi/FaceApi_Image_Landmarks/sketch.js
+++ b/examples/p5js/FaceApi/FaceApi_Image_Landmarks/sketch.js
@@ -39,12 +39,12 @@ function gotResults(err, result) {
   image(img, 0, 0, width, height);
   if (detections) {
     // console.log(detections)
-    drawBox(detections);
-    drawLandmarks(detections);
+    drawBox();
+    drawLandmarks();
   }
 }
 
-function drawBox(detections) {
+function drawBox() {
   const alignedRect = detections.alignedRect;
   const { _x, _y, _width, _height } = alignedRect._box;
   noFill();
@@ -53,7 +53,7 @@ function drawBox(detections) {
   rect(_x, _y, _width, _height);
 }
 
-function drawLandmarks(detections) {
+function drawLandmarks() {
   noFill();
   stroke(161, 95, 251);
   strokeWeight(2);

--- a/examples/p5js/FaceApi/FaceApi_Video_Landmarks/sketch.js
+++ b/examples/p5js/FaceApi/FaceApi_Video_Landmarks/sketch.js
@@ -39,14 +39,14 @@ function gotResults(err, result) {
   if (detections) {
     if (detections.length > 0) {
       // console.log(detections)
-      drawBox(detections);
-      drawLandmarks(detections);
+      drawBox();
+      drawLandmarks();
     }
   }
   faceapi.detect(gotResults);
 }
 
-function drawBox(detections) {
+function drawBox() {
   for (let i = 0; i < detections.length; i += 1) {
     const alignedRect = detections[i].alignedRect;
     const x = alignedRect._box._x;
@@ -61,7 +61,7 @@ function drawBox(detections) {
   }
 }
 
-function drawLandmarks(detections) {
+function drawLandmarks() {
   noFill();
   stroke(161, 95, 251);
   strokeWeight(2);

--- a/examples/p5js/FaceApi/FaceApi_Video_Landmarks_LocalModels/sketch.js
+++ b/examples/p5js/FaceApi/FaceApi_Video_Landmarks_LocalModels/sketch.js
@@ -43,14 +43,14 @@ function gotResults(err, result) {
   if (detections) {
     if (detections.length > 0) {
       // console.log(detections)
-      drawBox(detections);
-      drawLandmarks(detections);
+      drawBox();
+      drawLandmarks();
     }
   }
   faceapi.detect(gotResults);
 }
 
-function drawBox(detections) {
+function drawBox() {
   for (let i = 0; i < detections.length; i += 1) {
     const alignedRect = detections[i].alignedRect;
     const x = alignedRect._box._x;
@@ -65,7 +65,7 @@ function drawBox(detections) {
   }
 }
 
-function drawLandmarks(detections) {
+function drawLandmarks() {
   noFill();
   stroke(161, 95, 251);
   strokeWeight(2);

--- a/examples/p5js/FeatureExtractor/FeatureExtractor_Image_Classification/sketch.js
+++ b/examples/p5js/FeatureExtractor/FeatureExtractor_Image_Classification/sketch.js
@@ -52,7 +52,7 @@ function classify() {
 function setupButtons() {
   // When the Cat button is pressed, add the current frame
   // from the video with a label of "cat" to the classifier
-  buttonA = select("#catButton");
+  const buttonA = select("#catButton");
   buttonA.mousePressed(function() {
     classifier.addImage("cat");
     select("#amountOfCatImages").html((catImages += 1));
@@ -60,7 +60,7 @@ function setupButtons() {
 
   // When the Dog button is pressed, add the current frame
   // from the video with a label of "dog" to the classifier
-  buttonB = select("#dogButton");
+  const buttonB = select("#dogButton");
   buttonB.mousePressed(function() {
     classifier.addImage("dog");
     select("#amountOfDogImages").html((dogImages += 1));
@@ -68,14 +68,14 @@ function setupButtons() {
 
   // When the Dog button is pressed, add the current frame
   // from the video with a label of "dog" to the classifier
-  buttonC = select("#badgerButton");
+  const buttonC = select("#badgerButton");
   buttonC.mousePressed(function() {
     classifier.addImage("badger");
     select("#amountOfBadgerImages").html((badgerImages += 1));
   });
 
   // Train Button
-  train = select("#train");
+  const train = select("#train");
   train.mousePressed(function() {
     classifier.train(function(lossValue) {
       if (lossValue) {
@@ -88,17 +88,17 @@ function setupButtons() {
   });
 
   // Predict Button
-  buttonPredict = select("#buttonPredict");
+  const buttonPredict = select("#buttonPredict");
   buttonPredict.mousePressed(classify);
 
   // Save model
-  saveBtn = select("#save");
+  const saveBtn = select("#save");
   saveBtn.mousePressed(function() {
     classifier.save();
   });
 
   // Load model
-  loadBtn = select("#load");
+  const loadBtn = select("#load");
   loadBtn.changed(function() {
     classifier.load(loadBtn.elt.files, function() {
       select("#modelStatus").html("Custom Model Loaded!");

--- a/examples/p5js/ImageClassification/ImageClassification_MultipleImages/sketch.js
+++ b/examples/p5js/ImageClassification/ImageClassification_MultipleImages/sketch.js
@@ -11,7 +11,7 @@ Multiple Image classification using MobileNet and p5.js
 // Initialize the Image Classifier method using MobileNet
 let classifier;
 
-let img;
+let data;
 let currentIndex = 0;
 const allImages = [];
 const predictions = [];
@@ -29,8 +29,8 @@ function setup() {
 }
 
 function appendImages() {
-  for (i = 0; i < data.images.length; i += 1) {
-    imgPath = data.images[i];
+  for (let i = 0; i < data.images.length; i++) {
+    const imgPath = data.images[i];
     allImages.push(`images/dataset/${imgPath}`);
   }
 }
@@ -43,7 +43,7 @@ function imageReady(img) {
 }
 
 function savePredictions() {
-  predictionsJSON = {
+  const predictionsJSON = {
     predictions,
   };
   saveJSON(predictionsJSON, "predictions.json");
@@ -56,7 +56,7 @@ function gotResult(err, results) {
     console.error(err);
   }
 
-  information = {
+  const information = {
     name: allImages[currentIndex],
     result: results,
   };

--- a/examples/p5js/KMeans/KMeans_imageSegmentation/sketch.js
+++ b/examples/p5js/KMeans/KMeans_imageSegmentation/sketch.js
@@ -1,5 +1,6 @@
 let kmeans;
 let baseImage;
+let img;
 const data = [];
 
 const imgSize = 30;
@@ -38,7 +39,7 @@ function setup() {
       const g = img.pixels[off + 1];
       const b = img.pixels[off + 2];
       const a = img.pixels[off + 3];
-      // push this to the globa data[] array
+      // push this to the global data[] array
       data.push({
         r,
         g,
@@ -49,7 +50,7 @@ function setup() {
 
   // display the resized image on another canvas
   baseImage = select("#baseImage");
-  baseImageCtx = baseImage.elt.getContext("2d");
+  const baseImageCtx = baseImage.elt.getContext("2d");
   baseImageCtx.drawImage(img.canvas, 0, 0, width, height);
 
   // call kmeans on the data

--- a/examples/p5js/KMeans/KMeans_mouseClustering/sketch.js
+++ b/examples/p5js/KMeans/KMeans_mouseClustering/sketch.js
@@ -9,9 +9,10 @@ Created by Tom-Lucas Säger 2021
 let data = [];
 let calculated = false;
 let kmeans; 
-let slider, sliderLabel;
+let slider
+let sliderLabel;
 
-//We set up our canvas and change the colorMode to HSB which will come in handy later. 
+// We set up our canvas and change the colorMode to HSB which will come in handy later.
 function setup() {
   createCanvas(600, 400);
   background(200);
@@ -19,10 +20,10 @@ function setup() {
   // User instructions are added 
   let instructions = "Click on the canvas to add data points.\nClick the button Cluster, to cluster them. \nAdjust the number of clusters with the slider."
   text(instructions, 10, height/2);
-  //A button is added to start clustering the data
+  // A button is added to start clustering the data
   let calculateButton = createButton('Cluster');
   calculateButton.mouseClicked(cluster)
-  //A slider with a label is added to let the user adjust the number of clusters 
+  // A slider with a label is added to let the user adjust the number of clusters
   slider = createSlider(1,10,2,1);
   slider.input(sliderAdjusted);
   sliderLabel = createP('Number of Clusters: ' + slider.value());
@@ -30,12 +31,12 @@ function setup() {
   noStroke();
   ellipseMode(CENTER);
 }
-//Once the slider is updated we adjust the label.
+// Once the slider is updated we adjust the label.
 function sliderAdjusted(){
   sliderLabel.html('Number of Cluster: ' + slider.value())
 }
-//If the mouse is clicked and it is not in bottom of our canvas, 
-//the mouse coordinates get added to our data array and drawn to the canvas. 
+// If the mouse is clicked and it is not in bottom of our canvas,
+// the mouse coordinates get added to our data array and drawn to the canvas.
 function mousePressed(){
   if(mouseY < height-5){
   data.push({x: mouseX, y: mouseY});
@@ -43,7 +44,7 @@ function mousePressed(){
   ellipse(mouseX, mouseY, 20,20)
   }
 }
-//On click of the cluster button we create our kmeans object with to data we collected,
+// On click of the cluster button we create our kmeans object with to data we collected,
 // the number of clusters from our slider and two other options.
 function cluster(){
   const options = {
@@ -57,17 +58,17 @@ function cluster(){
 function clustersCalculated() {
   calculated = true;
 }
-//Once the results are in we recolor the data-points based on their centroid 
+// Once the results are in we recolor the data-points based on their centroid
 function draw() {
   if (calculated) {
-    for (i = 0; i < kmeans.dataset.length; i++) {
+    for (let i = 0; i < kmeans.dataset.length; i++) {
       let centroid = kmeans.dataset[i].centroid;
       let datapointx = kmeans.dataset[i][0];
       let datapointy = kmeans.dataset[i][1];
-      //We are using the HSB colorMode here
+      // We are using the HSB colorMode here
       fill(centroid * 36, 100,100);
       ellipse(datapointx, datapointy, 20, 20);
-      //We also add a label to the output, so it could be interpreted without the color
+      // We also add a label to the output, so it could be interpreted without the color
       fill(0);
       textAlign(CENTER, CENTER);
       text(centroid + 1, datapointx, datapointy);

--- a/examples/p5js/KNNClassification/KNNClassification_Video/sketch.js
+++ b/examples/p5js/KNNClassification/KNNClassification_Video/sketch.js
@@ -69,55 +69,55 @@ function classify() {
 function createButtons() {
   // When the A button is pressed, add the current frame
   // from the video with a label of "rock" to the classifier
-  buttonA = select('#addClassRock');
+  const buttonA = select('#addClassRock');
   buttonA.mousePressed(function() {
     addExample('Rock');
   });
 
   // When the B button is pressed, add the current frame
   // from the video with a label of "paper" to the classifier
-  buttonB = select('#addClassPaper');
+  const buttonB = select('#addClassPaper');
   buttonB.mousePressed(function() {
     addExample('Paper');
   });
 
   // When the C button is pressed, add the current frame
   // from the video with a label of "scissor" to the classifier
-  buttonC = select('#addClassScissor');
+  const buttonC = select('#addClassScissor');
   buttonC.mousePressed(function() {
     addExample('Scissor');
   });
 
   // Reset buttons
-  resetBtnA = select('#resetRock');
+  const resetBtnA = select('#resetRock');
   resetBtnA.mousePressed(function() {
     clearLabel('Rock');
   });
-	
-  resetBtnB = select('#resetPaper');
+
+  const resetBtnB = select('#resetPaper');
   resetBtnB.mousePressed(function() {
     clearLabel('Paper');
   });
-	
-  resetBtnC = select('#resetScissor');
+
+  const resetBtnC = select('#resetScissor');
   resetBtnC.mousePressed(function() {
     clearLabel('Scissor');
   });
 
   // Predict button
-  buttonPredict = select('#buttonPredict');
+  const buttonPredict = select('#buttonPredict');
   buttonPredict.mousePressed(classify);
 
   // Clear all classes button
-  buttonClearAll = select('#clearAll');
+  const buttonClearAll = select('#clearAll');
   buttonClearAll.mousePressed(clearAllLabels);
 
   // Load saved classifier dataset
-  buttonSetData = select('#load');
+  const buttonSetData = select('#load');
   buttonSetData.mousePressed(loadMyKNN);
 
   // Get classifier dataset
-  buttonGetData = select('#save');
+  const buttonGetData = select('#save');
   buttonGetData.mousePressed(saveMyKNN);
 }
 

--- a/examples/p5js/KNNClassification/KNNClassification_VideoSound/sketch.js
+++ b/examples/p5js/KNNClassification/KNNClassification_VideoSound/sketch.js
@@ -64,23 +64,23 @@ function classify() {
 // A util function to create UI buttons
 function createButtons() {
   // When the A button is pressed, add the current frame to class "Hello"
-  buttonA = select('#addClass1');
+  const buttonA = select('#addClass1');
   buttonA.mousePressed(function() {
     addExample('Hello');
   });
 
   // When the B button is pressed, add the current frame to class "goodbye"
-  buttonB = select('#addClass2');
+  const buttonB = select('#addClass2');
   buttonB.mousePressed(function() {
     addExample('Goodbye');
   });
 
   // Predict button
-  buttonPredict = select('#buttonPredict');
+  const buttonPredict = select('#buttonPredict');
   buttonPredict.mousePressed(classify);
 
   // Clear all classes button
-  buttonClearAll = select('#clearAll');
+  const buttonClearAll = select('#clearAll');
   buttonClearAll.mousePressed(clearAllLabels);
 }
 

--- a/examples/p5js/KNNClassification/KNNClassification_VideoSquare/sketch.js
+++ b/examples/p5js/KNNClassification/KNNClassification_VideoSquare/sketch.js
@@ -77,35 +77,35 @@ function classify() {
 // A util function to create UI buttons
 function createButtons() {
   // When the addClass1 button is pressed, add the current frame to class "Up"
-  buttonA = select("#addClass1");
+  const buttonA = select("#addClass1");
   buttonA.mousePressed(function() {
     addExample("Up");
   });
 
   // When the addClass2 button is pressed, add the current frame to class "Right"
-  buttonB = select("#addClass2");
+  const buttonB = select("#addClass2");
   buttonB.mousePressed(function() {
     addExample("Right");
   });
 
   // When the addClass3 button is pressed, add the current frame to class "Down"
-  buttonC = select("#addClass3");
+  const buttonC = select("#addClass3");
   buttonC.mousePressed(function() {
     addExample("Down");
   });
 
   // When the addClass4 button is pressed, add the current frame to class "Left"
-  buttonC = select("#addClass4");
-  buttonC.mousePressed(function() {
+  const buttonD = select("#addClass4");
+  buttonD.mousePressed(function() {
     addExample("Left");
   });
 
   // Predict button
-  buttonPredict = select("#buttonPredict");
+  const buttonPredict = select("#buttonPredict");
   buttonPredict.mousePressed(classify);
 
   // Clear all classes button
-  buttonClearAll = select("#clearAll");
+  const buttonClearAll = select("#clearAll");
   buttonClearAll.mousePressed(clearAllLabels);
 }
 

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_Interactive_Regression/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_Interactive_Regression/sketch.js
@@ -71,8 +71,8 @@ function startTraining() {
 
 function doneTraining() {
   // build x-bases to calculate corresponding y-values. We take every x-value possible of the canvas to make it look like a line
-  xMany = [];
-  for (x = 0; x <= canvasSize; x += 1) {
+  const xMany = [];
+  for (let x = 0; x <= canvasSize; x++) {
     xMany.push([x]);
   }
 
@@ -83,8 +83,8 @@ function doneTraining() {
     } else {
       console.log(results);
       for (let i = 0; i < results.length; i += 1) {
-        x = xMany[i][0];
-        y = results[i][0].value;
+        const x = xMany[i][0];
+        const y = results[i][0].value;
         circle(x, y, 1);
       }
     }

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_XOR/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_XOR/sketch.js
@@ -68,7 +68,7 @@ function finishedTraining() {
 function gotResults(error, results) {
   background(0);
   if (error) {
-    console.log(err);
+    console.log(error);
     return;
   }
   // console.log(results);

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_basics/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_basics/sketch.js
@@ -64,7 +64,9 @@ function trainModel() {
   // Add training data
   // const trainingInput = [-0.6, 1, 0.25];
   // const trainingTarget = [0.3, 0.9];
-  let a, b, c;
+  let a;
+  let b;
+  let c;
   let trainingTarget;
   for (let i = 0; i < 500; i += 1) {
     if (i % 2) {

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_co2net/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_co2net/sketch.js
@@ -11,7 +11,6 @@ This example uses a callback pattern to create the classifier
 // y: scope1_ghg_emissions_tons_co2e
 === */
 let nn;
-let data;
 
 let counter = 0;
 const testInputs = [100, 50000, 100000, 500000, 2500000, 5000000, 10000000, 15000000];

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_color_classifier/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_color_classifier/sketch.js
@@ -1,7 +1,8 @@
 let neuralNetwork;
-let submitButton;
 
-let rSlider, gSlider, bSlider;
+let rSlider;
+let gSlider;
+let bSlider;
 let labelP;
 let lossP;
 
@@ -43,7 +44,7 @@ function whileTraining(epoch, logs) {
   lossP.html(`Epoch: ${epoch} - loss: ${logs.loss.toFixed(2)}`);
 }
 
-function finishedTraining(anything) {
+function finishedTraining() {
   console.log('done!');
 }
 

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_load_model/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_load_model/sketch.js
@@ -1,7 +1,8 @@
 let neuralNetwork;
-let submitButton;
 
-let rSlider, gSlider, bSlider;
+let rSlider;
+let gSlider;
+let bSlider;
 let labelP;
 let lossP;
 
@@ -38,7 +39,7 @@ function setup() {
 function modelReady() {
   console.log('model loaded!')
   classify();
-};
+}
 
 
 function classify() {

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_lowres_pixels/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_lowres_pixels/sketch.js
@@ -7,7 +7,6 @@ let ready = false;
 const videoSize = 10;
 
 // For sound synthesis
-const playing = false;
 let frequency;
 let osc;
 

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_multiple_layers/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_multiple_layers/sketch.js
@@ -48,7 +48,8 @@ function setup() {
 
 function addData() {
   for (let i = 0; i < 500; i += 1) {
-    let xVal, labelVal;
+    let xVal;
+    let labelVal;
     if (i < 250) {
       xVal = i;
       labelVal = "a";

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_musical_face/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_musical_face/sketch.js
@@ -11,10 +11,8 @@ let faceBrain;
 
 //  Sound
 let osc;
-const freqMax = 800;
 
 // Keeping track of state
-const trained = false;
 let collecting = false;
 
 function setup() {
@@ -143,7 +141,7 @@ function gotFrequency(error, outputs) {
     console.error(error);
     return;
   }
-  frequency = outputs[0].value;
+  const frequency = outputs[0].value;
   osc.freq(frequency);
   select('#prediction').html(frequency.toFixed(2));
   predict();

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_musical_mouse/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_musical_mouse/sketch.js
@@ -2,7 +2,6 @@
 let brain;
 
 // Variables to track p5 oscillator
-const playing = false;
 let frequency;
 let osc;
 

--- a/examples/p5js/PitchDetection/PitchDetection_Game/sketch.js
+++ b/examples/p5js/PitchDetection/PitchDetection_Game/sketch.js
@@ -9,10 +9,9 @@ A game using pitch Detection with CREPE
 === */
 
 // Pitch variables
-let crepe;
-const voiceLow = 100;
-const voiceHigh = 500;
-let audioStream;
+let audioContext;
+let mic;
+let pitch;
 
 // Circle variables
 const circleSize = 42;
@@ -21,12 +20,9 @@ const scale = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
 // Text variables
 let goalNote = 0;
 let currentNote = '';
-const currentText = '';
-let textCoordinates;
 
 function setup() {
   createCanvas(410, 320);
-  textCoordinates = [width / 2, 30];
   gameReset();
   audioContext = getAudioContext();
   mic = new p5.AudioIn();
@@ -58,13 +54,13 @@ function draw() {
   // Goal Circle is Blue
   noStroke();
   fill(0, 0, 255);
-  goalHeight = map(goalNote, 0, scale.length - 1, 0, height);
+  const goalHeight = map(goalNote, 0, scale.length - 1, 0, height);
   ellipse(width / 2, goalHeight, circleSize, circleSize);
   fill(255);
   text(scale[goalNote], (width / 2) - 5, goalHeight + (circleSize / 6));
   // Current Pitch Circle is Pink
   if (currentNote) {
-    currentHeight = map(scale.indexOf(currentNote), 0, scale.length - 1, 0, height);
+    const currentHeight = map(scale.indexOf(currentNote), 0, scale.length - 1, 0, height);
     fill(255, 0, 255);
     ellipse(width / 2, currentHeight, circleSize, circleSize);
     fill(255);

--- a/examples/p5js/PitchDetection/PitchDetection_Piano/sketch.js
+++ b/examples/p5js/PitchDetection/PitchDetection_Piano/sketch.js
@@ -11,7 +11,7 @@ A piano using pitch Detection with CREPE
 // Pitch variables
 let pitch;
 let audioContext;
-let audioStream;
+let mic;
 
 // Keyboard variables
 const cornerCoords = [10, 40];

--- a/examples/p5js/Pix2Pix/Pix2Pix_callback/sketch.js
+++ b/examples/p5js/Pix2Pix/Pix2Pix_callback/sketch.js
@@ -13,7 +13,15 @@ For more models see: https://github.com/ml5js/ml5-data-and-training/tree/master/
 // The pre-trained Edges2Pikachu model is trained on 256x256 images
 // So the input images can only be 256x256 or 512x512, or multiple of 256
 const SIZE = 256;
-let inputImg, inputCanvas, outputContainer, statusMsg, pix2pix, clearBtn, transferBtn, modelReady = false, isTransfering = false;
+let inputImg;
+let inputCanvas;
+let outputContainer;
+let statusMsg;
+let pix2pix;
+let clearBtn;
+let transferBtn;
+let modelReady = false;
+let isTransfering = false;
 
 function setup() {
   // Create a canvas

--- a/examples/p5js/Pix2Pix/Pix2Pix_promise/sketch.js
+++ b/examples/p5js/Pix2Pix/Pix2Pix_promise/sketch.js
@@ -13,7 +13,12 @@ For more models see: https://github.com/ml5js/ml5-data-and-training/tree/master/
 // The pre-trained Edges2Pikachu model is trained on 256x256 images
 // So the input images can only be 256x256 or 512x512, or multiple of 256
 const SIZE = 256;
-let inputImg, inputCanvas, outputContainer, statusMsg, transferBtn, clearBtn;
+let inputImg;
+let inputCanvas;
+let outputContainer;
+let statusMsg;
+let transferBtn;
+let clearBtn;
 
 function setup() {
   // Create a canvas

--- a/examples/p5js/SketchRNN/SketchRNN_basic/sketch.js
+++ b/examples/p5js/SketchRNN/SketchRNN_basic/sketch.js
@@ -13,7 +13,8 @@ let model;
 // Start by drawing
 let previousPen = "down";
 // Current location of drawing
-let x, y;
+let x
+let y;
 // The current "stroke" of the drawing
 let strokePath;
 

--- a/examples/p5js/SketchRNN/SketchRNN_interactive/sketch.js
+++ b/examples/p5js/SketchRNN/SketchRNN_interactive/sketch.js
@@ -13,7 +13,8 @@ let model;
 // Start by drawing
 let previousPen = "down";
 // Current location of drawing
-let x, y;
+let x
+let y;
 // The current "stroke" of the drawing
 let strokePath;
 let seedStrokes = [];


### PR DESCRIPTION
Fixed a whole bunch of extremely easy issues for the following eslint rules:

- `no-undef`: added some missing `const` and `let` declarations.
- `no-unused-vars`: deleted some variables which were not actually used anywhere.
- `no-shadow-vars`: in the FaceApi examples, the functions do not need to get `detections` as an argument because they can already access the global variable.
- `one-var`: split a bunch of `let x, y;` into separate declarations.

I did not fix every single error for these rules.  Just the easy ones.  For example I do not know how to properly address the multi-file NeuralNetwork examples which declare a class or variable in one file (causing `no-unused-vars`) and use it in a different file (causing `no-undef`).

Also:
 - Cleaned up the formatting on CartoonGAN examples.
 - CharRNN_Text_Stateful used a mix of declared button variables `let startBtn;` and inline selections `select('#start').html('Start');`.  I cleaned this up a bit, preferring the inline syntax.