### PR TITLE
Separate eslint rules for p5 examples

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,7 +30,7 @@ module.exports = {
           },
         ],
         "new-cap": 0,
-        "no-underscore-dangle": 0,
+        "no-underscore-dangle": 0
       },
     },
     {
@@ -44,7 +44,9 @@ module.exports = {
       rules: {
         "no-plusplus": "off",
         "no-unused-vars": ["error", { varsIgnorePattern: "^(setup|draw|preload|mouse[A-Z].*|windowResized)$" }],
-        "prefer-template": "off"
+        "prefer-template": "off",
+        "no-restricted-syntax": "off",
+        "prefer-destructuring": "off"
       }
     },
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,10 +18,7 @@ module.exports = {
     {
       files: ["examples/**"],
       globals: {
-        ml5: false,
-        p5: false,
-        ...p5Globals,
-        ...p5SoundGlobals,
+        ml5: false
       },
       rules: {
         "no-use-before-define": [
@@ -32,10 +29,23 @@ module.exports = {
             variables: true,
           },
         ],
-        "no-unused-vars": ["error", { varsIgnorePattern: "^setup$|^draw$|^preload$" }],
         "new-cap": 0,
         "no-underscore-dangle": 0,
       },
+    },
+    {
+      files: ["examples/p5js/**"],
+      globals: {
+        ml5: false,
+        p5: false,
+        ...p5Globals,
+        ...p5SoundGlobals,
+      },
+      rules: {
+        "no-plusplus": "off",
+        "no-unused-vars": ["error", { varsIgnorePattern: "^(setup|draw|preload|mouse[A-Z].*|windowResized)$" }],
+        "prefer-template": "off"
+      }
     },
     {
       files: ["**/**_test.js"],


### PR DESCRIPTION
Related to #1190 and the discussion in #1368 

This is not a "final" ruleset, but what this PR does is apply additional overrides to the `examples/p5js` directory without applying those settings to non-p5 examples.  This way we can use prefer to use certain features like object destructuring in our plain JS examples without requiring them in p5.js examples.

I moved the following **existing** settings from all examples to only p5 examples:
- Declaring available `globals`: `p5: false,  ...p5Globals, ...p5SoundGlobals`
- Exempting `setup()`, `draw()`, and `preload()` from `no-unused-vars`

I added these **new** settings for p5 examples only:
- Allow `i++` with `"no-plusplus": "off"`.
- Allow `for (const label of labels)` syntax with `"no-restricted-syntax": "off"`.
- Allow strings to be concatenated using `+` with `"prefer-template": "off"`.
- Allow `const foo = object.foo;` with `"prefer-destructuring": "off"`.
- Added additional exceptions to `no-unused-vars` for `windowResized`, `mousePressed`, etc.