### PR TITLE
Better handling of model URL formation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ml5",
-  "version": "0.12.0",
+  "version": "0.12.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ml5",
-      "version": "0.12.0",
+      "version": "0.12.2",
       "license": "MIT",
       "dependencies": {
         "@magenta/sketch": "0.2.0",

--- a/src/CVAE/index.js
+++ b/src/CVAE/index.js
@@ -10,8 +10,8 @@
 */
 
 import * as tf from '@tensorflow/tfjs';
-import axios from "axios";
 import callCallback from '../utils/callcallback';
+import modelLoader from '../utils/modelLoader';
 import p5Utils from '../utils/p5Utils';
 
 class Cvae {
@@ -29,19 +29,17 @@ class Cvae {
     this.ready = false;
     this.model = {};
     this.latentDim = tf.randomUniform([1, 16]);
-
-    const [modelPathPrefix] = modelPath.split('manifest.json');
-    axios.get(modelPath).then(({ data }) => {
-      this.ready = callCallback(this.loadCVAEModel(modelPathPrefix + data.model), callback);
-      this.labels = data.labels;
-      // get an array full of zero with the length of labels [0, 0, 0 ...]
-      this.labelVector = Array(this.labels.length+1).fill(0);
-    });
+    this.ready = callCallback(this.loadCVAEModel(modelPath), callback);
   }
   
   // load tfjs model that is converted by tensorflowjs with graph and weights
   async loadCVAEModel(modelPath) {
-    this.model = await tf.loadLayersModel(modelPath);
+    const loader = modelLoader(modelPath, 'manifest');
+    const manifest = await loader.loadManifestJson();
+    this.labels = manifest.labels;
+    // get an array full of zero with the length of labels [0, 0, 0 ...]
+    this.labelVector = Array(this.labels.length + 1).fill(0);
+    this.model = await loader.loadLayersModel(manifest.model);
     return this;
   }
 

--- a/src/DCGAN/index.js
+++ b/src/DCGAN/index.js
@@ -9,8 +9,8 @@ This version is based on alantian's TensorFlow.js implementation: https://github
 */
 
 import * as tf from '@tensorflow/tfjs';
-import axios from 'axios';
 import callCallback from '../utils/callcallback';
+import modelLoader from '../utils/modelLoader';
 import  p5Utils from '../utils/p5Utils';
 
 // Default pre-trained face model
@@ -32,7 +32,6 @@ class DCGANBase {
     this.model = {};
     this.modelPath = modelPath;
     this.modelInfo = {};
-    this.modelPathPrefix = '';
     this.modelReady = false;
     this.config = {
       returnTensors: options.returnTensors || false,
@@ -45,15 +44,9 @@ class DCGANBase {
      * @return {this} the dcgan.
      */
   async loadModel() {
-    const modelInfo = await axios.get(this.modelPath);
-    const modelInfoJson = modelInfo.data;
-
-    this.modelInfo = modelInfoJson
-        
-    const [modelUrl] = this.modelPath.split('manifest.json')
-    const modelJsonPath = this.isAbsoluteURL(modelUrl) ? this.modelInfo.model : this.modelPathPrefix + this.modelInfo.model
-
-    this.model = await tf.loadLayersModel(modelJsonPath);
+    const loader = modelLoader(this.modelPath, 'manifest');
+    this.modelInfo = await loader.loadManifestJson();
+    this.model = await loader.loadLayersModel(this.modelInfo.model);
     this.modelReady = true;
     return this;
   }
@@ -139,13 +132,6 @@ class DCGANBase {
 
     return result;
 
-  }
-
-    
-  /* eslint class-methods-use-this: "off" */
-  isAbsoluteURL(str) {
-    const pattern = new RegExp('^(?:[a-z]+:)?//', 'i');
-    return !!pattern.test(str);
   }
 
 }

--- a/src/FaceApi/index.js
+++ b/src/FaceApi/index.js
@@ -15,7 +15,7 @@
 import * as tf from "@tensorflow/tfjs";
 import * as faceapi from "face-api.js";
 import callCallback from "../utils/callcallback";
-import modelLoader from "../utils/modelLoader";
+import { getModelPath } from "../utils/modelLoader";
 
 const DEFAULTS = {
   withLandmarks: true,
@@ -95,7 +95,7 @@ class FaceApiBase {
 
     Object.keys(this.config.MODEL_URLS).forEach(item => {
       if (modelOptions.includes(item)) {
-        this.config.MODEL_URLS[item] = modelLoader.getModelPath(this.config.MODEL_URLS[item]);
+        this.config.MODEL_URLS[item] = getModelPath(this.config.MODEL_URLS[item]);
       }
     });
 

--- a/src/ObjectDetector/YOLO/index.js
+++ b/src/ObjectDetector/YOLO/index.js
@@ -74,13 +74,8 @@ export class YOLOBase extends Video {
       this.video = await this.loadVideo();
     }
 
-    if (modelLoader.isAbsoluteURL(this.modelUrl) === true) {
-      this.model = await tf.loadLayersModel(this.modelUrl);
-    } else {
-      const modelPath = modelLoader.getModelPath(this.modelUrl);
-      this.modelUrl = `${modelPath}/model.json`;
-      this.model = await tf.loadLayersModel(this.modelUrl);
-    }
+    const loader = modelLoader(this.modelUrl, 'model');
+    this.model = await loader.loadLayersModel();
 
     this.modelReady = true;
     return this;

--- a/src/PitchDetection/index.js
+++ b/src/PitchDetection/index.js
@@ -11,6 +11,7 @@
 
 import * as tf from '@tensorflow/tfjs';
 import callCallback from '../utils/callcallback';
+import modelLoader from '../utils/modelLoader';
 
 class PitchDetection {
   /**
@@ -44,7 +45,8 @@ class PitchDetection {
   }
 
   async loadModel(model) {
-    this.model = await tf.loadLayersModel(`${model}/model.json`);
+    const loader = modelLoader(model, 'model');
+    this.model = await loader.loadLayersModel();
     if (this.audioContext) {
       await this.processStream();
     } else {

--- a/src/SketchRNN/index.js
+++ b/src/SketchRNN/index.js
@@ -11,8 +11,8 @@ SketchRNN
 
 import * as ms from '@magenta/sketch';
 import callCallback from '../utils/callcallback';
+import { getModelPath, isAbsoluteURL } from '../utils/modelLoader';
 import modelPaths from './models';
-import modelLoader from '../utils/modelLoader';
 
 // const PATH_START_LARGE = 'https://storage.googleapis.com/quickdraw-models/sketchRNN/large_models/';
 // const PATH_START_SMALL = 'https://storage.googleapis.com/quickdraw-models/sketchRNN/models/';
@@ -30,10 +30,10 @@ const DEFAULTS = {
 
 class SketchRNN {
   /**
-   * Create SketchRNN. 
+   * Create SketchRNN.
    * @param {String} model - The name of the sketch model to be loaded.
    *    The names can be found in the models.js file
-   * @param {function} callback - Optional. A callback function that is called once the model has loaded. If no callback is provided, it will return a promise 
+   * @param {function} callback - Optional. A callback function that is called once the model has loaded. If no callback is provided, it will return a promise
    *    that will be resolved once the model has loaded.
    */
   constructor(model, callback, large = true) {
@@ -47,13 +47,11 @@ class SketchRNN {
       modelPath_large: DEFAULTS.modelPath_large,
       PATH_END: DEFAULTS.PATH_END,
     };
-    
-    
-    if(modelLoader.isAbsoluteURL(checkpointUrl) === true){
-      const modelPath = modelLoader.getModelPath(checkpointUrl);
-      this.config.modelPath = modelPath;
 
-    } else if(modelPaths.has(checkpointUrl)) {
+    // TODO: support relative URL
+    if (isAbsoluteURL(checkpointUrl) === true) {
+      this.config.modelPath = getModelPath(checkpointUrl);
+    } else if (modelPaths.has(checkpointUrl)) {
       checkpointUrl = (large ? this.config.modelPath : this.config.modelPath_small) + checkpointUrl + this.config.PATH_END;
       this.config.modelPath = checkpointUrl;
     } else {

--- a/src/SoundClassifier/speechcommands.js
+++ b/src/SoundClassifier/speechcommands.js
@@ -15,7 +15,7 @@ export class SpeechCommands {
   async load(url) {
     if (url) {
       const loader = modelLoader(url);
-      this.model = tfjsSpeechCommands.create('BROWSER_FFT', undefined, url, loader.metadataUrl);
+      this.model = tfjsSpeechCommands.create('BROWSER_FFT', undefined, loader.modelUrl, loader.metadataUrl);
     } else this.model = tfjsSpeechCommands.create('BROWSER_FFT');
     await this.model.ensureModelLoaded();
     this.allLabels = this.model.wordLabels();

--- a/src/SoundClassifier/speechcommands.js
+++ b/src/SoundClassifier/speechcommands.js
@@ -5,6 +5,7 @@
 
 import * as tfjsSpeechCommands from '@tensorflow-models/speech-commands';
 import { getTopKClassesFromArray } from '../utils/gettopkclasses';
+import modelLoader from '../utils/modelLoader';
 
 export class SpeechCommands {
   constructor(options) {
@@ -13,10 +14,8 @@ export class SpeechCommands {
 
   async load(url) {
     if (url) {
-      const split = url.split("/");
-      const prefix = split.slice(0, split.length - 1).join("/");
-      const metadataJson = `${prefix}/metadata.json`;
-      this.model = tfjsSpeechCommands.create('BROWSER_FFT', undefined, url, metadataJson);
+      const loader = modelLoader(url);
+      this.model = tfjsSpeechCommands.create('BROWSER_FFT', undefined, url, loader.metadataUrl);
     } else this.model = tfjsSpeechCommands.create('BROWSER_FFT');
     await this.model.ensureModelLoaded();
     this.allLabels = this.model.wordLabels();

--- a/src/utils/modelLoader.js
+++ b/src/utils/modelLoader.js
@@ -1,10 +1,13 @@
+import * as tf from '@tensorflow/tfjs';
+import axios from 'axios';
+
 /**
  * Check if the provided URL string starts with a hostname,
  * such as http://, https://, etc.
  * @param {string} str
  * @returns {boolean}
  */
-function isAbsoluteURL(str) {
+export function isAbsoluteURL(str) {
   const pattern = new RegExp('^(?:[a-z]+:)?//', 'i');
   return pattern.test(str);
 }
@@ -15,14 +18,112 @@ function isAbsoluteURL(str) {
  * @param {string} absoluteOrRelativeUrl
  * @returns {string}
  */
-function getModelPath(absoluteOrRelativeUrl) {
+export function getModelPath(absoluteOrRelativeUrl) {
   if (!isAbsoluteURL(absoluteOrRelativeUrl) && typeof window !== 'undefined') {
     return window.location.pathname + absoluteOrRelativeUrl;
   }
   return absoluteOrRelativeUrl;
 }
 
-export default {
-  isAbsoluteURL,
-  getModelPath
+function isKnownName(name) {
+  return ['model', 'manifest', 'metadata'].includes(name);
+}
+
+/**
+ * @property {string} directory
+ * @property {string} modelUrl
+ * @property {string} manifestUrl
+ * @property {string} metadataUrl
+ */
+class ModelLoader {
+  /**
+   * Can provide the url to a model.json/metadata.json/manifest.json file,
+   * or to a folder containing the files.
+   *
+   * @param {string} path
+   * @param {'model'|'manifest'|'metadata'} expected
+   * @param {boolean} prepend
+   */
+  constructor(path, expected = 'model', prepend = true) {
+    const url = prepend ? getModelPath(path) : path;
+    const known = {};
+    // If a specific URL is provided, make sure that we don't overwrite it with generic '/model.json'
+    // But warn the user and try to correct if it seems like they passed the wrong file type.
+    if (url.endsWith('.json')) {
+      const pos = url.lastIndexOf('/') + 1;
+      this.directory = url.slice(0, pos);
+      const fileName = url.slice(pos, -5);
+      if (fileName !== expected && isKnownName(fileName)) {
+        console.warn(`Expected a ${expected}.json file URL, but received a ${fileName}.json file instead.`);
+      } else {
+        known[expected] = url;
+      }
+    } else {
+      this.directory = url.endsWith('/') ? url : `${url}/`;
+    }
+    this.modelUrl = known.model || this.getPath('model.json');
+    this.metadataUrl = known.metadata || this.getPath('metadata.json');
+    this.manifestUrl = known.manifest || this.getPath('manifest.json');
+  }
+
+  /**
+   * Appends the filename to the base directory.
+   * @param {string} filename
+   * @return {string}
+   */
+  getPath(filename) {
+    return isAbsoluteURL(filename) ? filename : this.directory + filename;
+  }
+
+  /**
+   * Fetch the JSON data from the manifest file, and throw an error if not found.
+   * @return {Promise<any>}
+   */
+  async loadManifestJson() {
+    try {
+      const res = await axios.get(this.manifestUrl);
+      return res.data;
+    } catch (error) {
+      throw new Error(`Error loading manifest.json file from URL ${this.manifestUrl}: ${String(error)}`);
+    }
+  }
+
+  /**
+   * Fetch the JSON data from the metadata file, and throw an error if not found.
+   * @return {Promise<any>}
+   */
+  async loadMetadataJson() {
+    try {
+      const res = await axios.get(this.metadataUrl);
+      return res.data;
+    } catch (error) {
+      throw new Error(`Error loading metadata.json file from URL ${this.metadataUrl}: ${String(error)}`);
+    }
+  }
+
+  /**
+   * Pass the model URL to the TensorFlow loadLayersModel function.
+   * If no path is provided, loads file `/model.json` relative to the directory.
+   * But can also be called with the model url from a manifest file.
+   * @param {string} [relativePath]
+   * @return {Promise<tf.LayersModel>}
+   */
+  async loadLayersModel(relativePath) {
+    const url = relativePath ? this.getPath(relativePath) : this.modelUrl;
+    try {
+      return await tf.loadLayersModel(url);
+    } catch (error) {
+      throw new Error(`Error loading model from URL ${url}: ${String(error)}`);
+    }
+  }
+}
+
+/**
+ * @param {string} path
+ * @param {'model'|'manifest'|'metadata'} [expected]
+ * @param {boolean} [prepend]
+ * @return {ModelLoader}
+ */
+export default function modelLoader(path, expected, prepend) {
+  return new ModelLoader(path, expected, prepend);
 }


### PR DESCRIPTION
Creates utility class `ModelLoader` to handle tasks related to formulating model URLs and loading model/manifest/metadata JSON files.

Utility class can:
- Accept either a `model.json` file path or the path to a directory containing that file.
- Prepend the window location to relative URLs.
- Find the path for a `metadata.json` in the same directory as the `model.json`.
- Load the `manifest.json` or `metadata.json` using `axios`.
- "Absolutize" the relative model URL from a `manifest.json` file based on the location of the manifest.
- Load the model (if it is a layers model) by calling `tf.LoadLayersModel`.

Fixes #1351 
Improves #949 (but I don't want to close that one until we have a `manifest.json` in the models and data repo, or can make the manifest optional)