### PR TITLE
Support promises in Sentiment

### DIFF
--- a/src/Sentiment/index.js
+++ b/src/Sentiment/index.js
@@ -46,8 +46,8 @@ class Sentiment {
    */
   constructor(modelName, callback) {
     /**
-     * Boolean value that specifies if the model has loaded.
-     * @type {boolean}
+     * Promise that specifies if the model has loaded.
+     * @type {Promise<Sentiment>}
      * @public
      */
     this.ready = callCallback(this.loadModel(modelName), callback);
@@ -132,6 +132,9 @@ class Sentiment {
   }
 }
 
-const sentiment = (modelName, callback) => new Sentiment(modelName, callback);
+const sentiment = (modelName, callback) => {
+  const instance = new Sentiment(modelName, callback);
+  return callback ? instance : instance.ready;
+}
 
 export default sentiment;


### PR DESCRIPTION
Fixes #1313 

Calling `await ml5.sentiment('movieReviews')` should return a Promise which resolves when the model is ready.