### PR TITLE
replace deprecated `request-promise` with `axios`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ml5",
-  "version": "0.12.0",
+  "version": "0.12.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ml5",
-      "version": "0.12.0",
+      "version": "0.12.2",
       "license": "MIT",
       "dependencies": {
         "@magenta/sketch": "0.2.0",
@@ -70,7 +70,6 @@
         "q": "^1.5.1",
         "recursive-readdir": "^2.2.2",
         "regenerator-runtime": "0.11.1",
-        "request-promise": "^4.2.5",
         "rimraf": "2.6.2",
         "semantic-release": "^17.2.3",
         "uglifyjs-webpack-plugin": "^1.2.5",
@@ -4774,6 +4773,7 @@
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
       "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "safer-buffer": "~2.1.0"
       }
@@ -4811,6 +4811,7 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -4892,6 +4893,7 @@
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
       "dev": true,
+      "optional": true,
       "engines": {
         "node": "*"
       }
@@ -4900,7 +4902,8 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/axios": {
       "version": "0.21.4",
@@ -6215,6 +6218,7 @@
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "tweetnacl": "^0.14.3"
       }
@@ -7241,7 +7245,8 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -9275,6 +9280,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "assert-plus": "^1.0.0"
       },
@@ -10583,6 +10589,7 @@
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -12903,7 +12910,8 @@
       "dev": true,
       "engines": [
         "node >=0.6.0"
-      ]
+      ],
+      "optional": true
     },
     "node_modules/face-api.js": {
       "version": "0.22.2",
@@ -13677,6 +13685,7 @@
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true,
+      "optional": true,
       "engines": {
         "node": "*"
       }
@@ -14048,6 +14057,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "assert-plus": "^1.0.0"
       }
@@ -14483,6 +14493,7 @@
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
       "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -14493,6 +14504,7 @@
       "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
       "deprecated": "this library is no longer supported",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
@@ -15477,6 +15489,7 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -16648,7 +16661,8 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/issue-parser": {
       "version": "6.0.0",
@@ -17754,7 +17768,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/jscodeshift": {
       "version": "0.4.1",
@@ -18084,7 +18099,8 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -18191,6 +18207,7 @@
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
       "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -26179,6 +26196,7 @@
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true,
+      "optional": true,
       "engines": {
         "node": "*"
       }
@@ -27292,7 +27310,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
@@ -28749,6 +28768,7 @@
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -28775,45 +28795,12 @@
         "node": ">= 6"
       }
     },
-    "node_modules/request-promise": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.6.tgz",
-      "integrity": "sha512-HCHI3DJJUakkOr8fNoCc73E5nU5bqITjOYFMDrKHYOXWXrgD/SBaC7LjwuPymUprRyuF06UK7hd/lMHkmUXglQ==",
-      "deprecated": "request-promise has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
-      "dev": true,
-      "dependencies": {
-        "bluebird": "^3.5.0",
-        "request-promise-core": "1.1.4",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/request-promise-core": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
-      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
-      "dev": true,
-      "dependencies": {
-        "lodash": "^4.17.19"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
     "node_modules/request/node_modules/form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -28828,6 +28815,7 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
       "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
       "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -30566,6 +30554,7 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
       "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -30648,15 +30637,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/stream-browserify": {
@@ -31710,6 +31690,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
@@ -31823,6 +31804,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -31834,7 +31816,8 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/tweezer.js": {
       "version": "1.5.0",
@@ -33144,6 +33127,7 @@
       "engines": [
         "node >=0.6.0"
       ],
+      "optional": true,
       "dependencies": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -33154,7 +33138,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/vinyl": {
       "version": "2.2.1",
@@ -41930,6 +41915,7 @@
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
       "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -41985,7 +41971,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -42036,13 +42023,15 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "aws4": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "axios": {
       "version": "0.21.4",
@@ -43229,6 +43218,7 @@
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
+      "optional": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -44107,7 +44097,8 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "chalk": {
       "version": "4.1.2",
@@ -45739,6 +45730,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
+      "optional": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -46793,6 +46785,7 @@
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
+      "optional": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -48667,7 +48660,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "face-api.js": {
       "version": "0.22.2",
@@ -49300,7 +49294,8 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "form-data": {
       "version": "3.0.1",
@@ -49593,6 +49588,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
+      "optional": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -49963,13 +49959,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "har-validator": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
       "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
       "dev": true,
+      "optional": true,
       "requires": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
@@ -50758,6 +50756,7 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
+      "optional": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -51642,7 +51641,8 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "issue-parser": {
       "version": "6.0.0",
@@ -52518,7 +52518,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "jscodeshift": {
       "version": "0.4.1",
@@ -52774,7 +52775,8 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -52863,6 +52865,7 @@
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
       "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -59107,7 +59110,8 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -59990,7 +59994,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "picocolors": {
       "version": "1.0.0",
@@ -61140,6 +61145,7 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -61168,6 +61174,7 @@
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
           "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.6",
@@ -61178,29 +61185,9 @@
           "version": "6.5.3",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
           "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
-      }
-    },
-    "request-promise": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.6.tgz",
-      "integrity": "sha512-HCHI3DJJUakkOr8fNoCc73E5nU5bqITjOYFMDrKHYOXWXrgD/SBaC7LjwuPymUprRyuF06UK7hd/lMHkmUXglQ==",
-      "dev": true,
-      "requires": {
-        "bluebird": "^3.5.0",
-        "request-promise-core": "1.1.4",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      }
-    },
-    "request-promise-core": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
-      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.19"
       }
     },
     "requestretry": {
@@ -62631,6 +62618,7 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
       "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -62694,12 +62682,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-      "dev": true
-    },
-    "stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
     "stream-browserify": {
@@ -63528,6 +63510,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "dev": true,
+      "optional": true,
       "requires": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
@@ -63605,6 +63588,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
+      "optional": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -63613,7 +63597,8 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "tweezer.js": {
       "version": "1.5.0",
@@ -64761,6 +64746,7 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
+      "optional": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -64771,7 +64757,8 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "q": "^1.5.1",
     "recursive-readdir": "^2.2.2",
     "regenerator-runtime": "0.11.1",
-    "request-promise": "^4.2.5",
     "rimraf": "2.6.2",
     "semantic-release": "^17.2.3",
     "uglifyjs-webpack-plugin": "^1.2.5",

--- a/scripts/batch-update-p5webeditor.js
+++ b/scripts/batch-update-p5webeditor.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 require("dotenv").config();
+const axios = require("axios");
 const fs = require("fs");
-const rp = require("request-promise");
 const Q = require("q");
 const { ok } = require("assert");
 
@@ -24,16 +24,14 @@ ok(editorUsername, "ML5_EXAMPLES_USERNAME is required");
 ok(personalAccessToken, "EDITOR_API_ACCESS_TOKEN is required");
 ok(editorApiUrl, "EDITOR_API_URL is required");
 
-//
 const githubRequestOptions = {
   url: baseUrl,
-  qs: {
+  params: {
     client_id: clientId,
     client_secret: clientSecret,
   },
   method: "GET",
-  headers,
-  json: true,
+  headers
 };
 
 const editorRequestOptions = {
@@ -44,8 +42,7 @@ const editorRequestOptions = {
     Authorization: `Basic ${Buffer.from(`${editorUsername}:${personalAccessToken}`).toString(
       "base64",
     )}`,
-  },
-  json: true,
+  }
 };
 
 console.log("------", editorRequestOptions);
@@ -54,6 +51,14 @@ console.log("------", editorRequestOptions);
  * --------------------- helper functions --------------------
  * ---------------------------------------------------------
  */
+
+/**
+ * Execute a GET, POST, or DELETE request to a URL
+ */
+async function rp(options) {
+  const res = await axios.request(options);
+  return res.data;
+}
 
 /**
  * fatten a nested array


### PR DESCRIPTION
Related: #1260 

Removes devDependency `request-promise` which is deprecated.  Replaces the usages of `request-promise` in `scripts/batch-update-p5webeditor.js` with `axios.request()`.

**THIS IS UNTESTED** as I don't know how to execute this file with the correct environment variables.