### PR TITLE
Fix a bug that I introduced in #1322

### DIFF
--- a/src/DCGAN/index.js
+++ b/src/DCGAN/index.js
@@ -118,7 +118,7 @@ class DCGANBase {
 }
 
 const DCGAN = (modelPath, optionsOrCb, cb) => {
-  const { string, options, callback } = handleArguments(modelPath, optionsOrCb, cb);
+  const { string, options = {}, callback } = handleArguments(modelPath, optionsOrCb, cb);
   if (!string) {
     throw new Error(`Please specify a path to a "manifest.json" file: \n
          "models/face/manifest.json" \n\n

--- a/src/FeatureExtractor/index.js
+++ b/src/FeatureExtractor/index.js
@@ -30,7 +30,7 @@ import Mobilenet from './Mobilenet';
  * @param {function} cb - Optional. 
  */
 const featureExtractor = (model, optionsOrCallback, cb) => {
-  const { string: modelName, options, callback } = handleArguments(model, optionsOrCallback, cb);
+  const { string: modelName, options = {}, callback } = handleArguments(model, optionsOrCallback, cb);
 
   // Default to using MobileNet if no model is provided.
 

--- a/src/SoundClassifier/index.js
+++ b/src/SoundClassifier/index.js
@@ -74,7 +74,7 @@ class SoundClassifier {
 }
 
 const soundClassifier = (modelName, optionsOrCallback, cb) => {
-  const { string, options, callback } = handleArguments(modelName, optionsOrCallback, cb)
+  const { string, options = {}, callback } = handleArguments(modelName, optionsOrCallback, cb)
     .require('string', 'Please specify a model to use. E.g: "SpeechCommands18w"');
 
   let model = string;


### PR DESCRIPTION
There were a few places in PR #1322 where I neglected to include a fallback value for `options`.   That causes an error `TypeError: Cannot read properties of undefined`.