### PR TITLE
🧹 Cleanup of DCGAN & CVAE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ml5",
-  "version": "0.12.0",
+  "version": "0.12.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ml5",
-      "version": "0.12.0",
+      "version": "0.12.2",
       "license": "MIT",
       "dependencies": {
         "@magenta/sketch": "0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
         "karma-webpack": "3.0.0",
         "live-server": "^1.2.1",
         "npm-run-all": "^4.1.5",
+        "p5": "^1.4.1",
         "q": "^1.5.1",
         "recursive-readdir": "^2.2.2",
         "regenerator-runtime": "0.11.1",
@@ -26855,6 +26856,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/p5": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/p5/-/p5-1.4.1.tgz",
+      "integrity": "sha512-3/X+qb0bK2Cg8nuZNpZZvzxkeUSRghOf0S+l8c+U8yIkUTVSbbcV0R8y96rx3InVBVhk8cH9kFC93VlZZElqSw==",
+      "dev": true
     },
     "node_modules/pac-proxy-agent": {
       "version": "3.0.1",
@@ -59623,6 +59630,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+    },
+    "p5": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/p5/-/p5-1.4.1.tgz",
+      "integrity": "sha512-3/X+qb0bK2Cg8nuZNpZZvzxkeUSRghOf0S+l8c+U8yIkUTVSbbcV0R8y96rx3InVBVhk8cH9kFC93VlZZElqSw==",
+      "dev": true
     },
     "pac-proxy-agent": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "karma-webpack": "3.0.0",
     "live-server": "^1.2.1",
     "npm-run-all": "^4.1.5",
+    "p5": "^1.4.1",
     "q": "^1.5.1",
     "recursive-readdir": "^2.2.2",
     "regenerator-runtime": "0.11.1",

--- a/src/CVAE/index.js
+++ b/src/CVAE/index.js
@@ -3,8 +3,6 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-/* eslint prefer-destructuring: ["error", {AssignmentExpression: {array: false}}] */
-/* eslint no-await-in-loop: "off" */
 /*
 * CVAE: Run conditional auto-encoder for pro-trained model
 */
@@ -12,72 +10,84 @@
 import * as tf from '@tensorflow/tfjs';
 import callCallback from '../utils/callcallback';
 import generatedImageResult from '../utils/generatedImageResult';
+import handleArguments from '../utils/handleArguments';
 import modelLoader from '../utils/modelLoader';
+import { modelInputShape, validateLatentInput } from '../utils/tensorInput';
 
 class Cvae {
   /**
    * Create a Conditional Variational Autoencoder (CVAE).
-   * @param {String} modelPath - Required. The url path to your model.
-   * @param {function} callback - Required. A function to run once the model has been loaded.
+   * @param {string} modelPath - Required. The url path to your model.
+   * @param {ML5Callback<Cvae>} [callback] - Optional. A function to run once the model has been loaded.
    */
   constructor(modelPath, callback) {
     /**
-     * Boolean value that specifies if the model has loaded.
-     * @type {boolean}
+     * @type {null|tf.LayersModel}
+     */
+    this.model = null;
+    /**
+     * Promise that resolves when the model has loaded.
+     * @type {Promise<Cvae>}
      * @public
      */
-    this.ready = false;
-    this.model = {};
-    this.latentDim = tf.randomUniform([1, 16]);
     this.ready = callCallback(this.loadCVAEModel(modelPath), callback);
+    /**
+     * @type {string[]}
+     */
+    this.labels = [];
   }
-  
+
   // load tfjs model that is converted by tensorflowjs with graph and weights
   async loadCVAEModel(modelPath) {
     const loader = modelLoader(modelPath, 'manifest');
     const manifest = await loader.loadManifestJson();
     this.labels = manifest.labels;
-    // get an array full of zero with the length of labels [0, 0, 0 ...]
-    this.labelVector = Array(this.labels.length + 1).fill(0);
     this.model = await loader.loadLayersModel(manifest.model);
     return this;
   }
 
   /**
+   * @public
    * Generate a random result.
-   * @param {String} label  - A label of the feature your want to generate
-   * @param {function} callback  - A function to handle the results of ".generate()". Likely a function to do something with the generated image data.
-   * @return {Promise<{ raws: Uint8ClampedArray, src: Blob, image: p5.Image }>}
+   * @param {string} label - Required. The label of the feature you want to generate
+   * @param {tf.Tensor2D|number[]|Float32Array} [latentVector] - Optional. Can provide a latent vector to use as the
+   * input for the model. This should be an array with a length matching the input size specified in the model
+   * or a 2D tensor with shape [1, inputSize].
+   * If not provided, will use a random vector.
+   * @param {function} [callback] - Optional. A function to handle the results of ".generate()".
+   *  Likely a function to do something with the generated image data.
+   * @return {Promise<{ raw: Uint8ClampedArray, src: string, image?: p5.Image }>}
    */
-  async generate(label, callback) {
-    return callCallback(this.generateInternal(label), callback);
+  async generate(label, latentVector, callback) {
+    const args = handleArguments(label, latentVector, callback);
+    return callCallback((async () => {
+      await this.ready;
+      const res = tf.tidy(() => {
+        const latentDim = validateLatentInput(this.model, args.array || args.object);
+        // TODO: general utility for one-hot encoding
+        const labelIndex = this.labels.indexOf(args.string);
+        if (labelIndex < 0) {
+          throw new Error(`Label '${label}' not found. Label must be one of: ${this.labels.join(', ')}`);
+        }
+        const labelShape = modelInputShape(this.model, 1);
+        // TODO: is the +1 here always correct?
+        const input = tf.oneHot(labelIndex + 1, labelShape[1]).reshape(labelShape);
+        return this.model.predict([latentDim, input]).squeeze();
+      });
+      const { raw, image, blob } = await generatedImageResult(res, { returnTensors: false });
+      const src = typeof URL !== 'undefined' ? URL.createObjectURL(blob) : undefined;
+      // Note: property `raws` is to provide backwards compatibility and should be removed in a future version.
+      return { src, raws: raw, raw, image };
+    })(), args.callback);
   }
-
-  async generateInternal(label) {
-    const res = tf.tidy(() => {
-      this.latentDim = tf.randomUniform([1, 16]);
-      const cursor = this.labels.indexOf(label);
-      if (cursor < 0) {
-        console.log('Wrong input of the label!');
-        return [undefined, undefined]; // invalid input just return;
-      }
-
-      this.labelVector = this.labelVector.map(() => 0); // clear vector
-      this.labelVector[cursor+1] = 1;
-
-      const input = tf.tensor([this.labelVector]);
-
-      const temp = this.model.predict([this.latentDim, input]);
-      return temp.reshape([temp.shape[1], temp.shape[2], temp.shape[3]]);
-    });
-
-    const { raw, image, blob } = await generatedImageResult(res, { returnTensors: false });
-    const src = typeof URL !== 'undefined' ? URL.createObjectURL(blob) : undefined;
-    return { src, raws: raw, image };
-  }
-
 }
 
+// TODO: accept options with `returnTensors`
+/**
+ * Create a Conditional Variational Autoencoder (CVAE).
+ * @param {string} model - Required. The url path to your model.
+ * @param {ML5Callback<Cvae>} [callback] - Optional. A function to run once the model has been loaded.
+ */
 const CVAE = (model, callback) => new Cvae(model, callback);
 
 

--- a/src/CVAE/index.js
+++ b/src/CVAE/index.js
@@ -10,8 +10,8 @@
 */
 
 import * as tf from '@tensorflow/tfjs';
-import axios from "axios";
 import callCallback from '../utils/callcallback';
+import modelLoader from '../utils/modelLoader';
 import p5Utils from '../utils/p5Utils';
 
 class Cvae {
@@ -29,19 +29,17 @@ class Cvae {
     this.ready = false;
     this.model = {};
     this.latentDim = tf.randomUniform([1, 16]);
-
-    const [modelPathPrefix] = modelPath.split('manifest.json');
-    axios.get(modelPath).then(({ data }) => {
-      this.ready = callCallback(this.loadCVAEModel(modelPathPrefix + data.model), callback);
-      this.labels = data.labels;
-      // get an array full of zero with the length of labels [0, 0, 0 ...]
-      this.labelVector = Array(this.labels.length+1).fill(0);
-    });
+    this.ready = callCallback(this.loadCVAEModel(modelPath), callback);
   }
   
   // load tfjs model that is converted by tensorflowjs with graph and weights
   async loadCVAEModel(modelPath) {
-    this.model = await tf.loadLayersModel(modelPath);
+    const loader = modelLoader(modelPath, 'manifest');
+    const manifest = await loader.loadManifestJson();
+    this.labels = manifest.labels;
+    // get an array full of zero with the length of labels [0, 0, 0 ...]
+    this.labelVector = Array(this.labels.length + 1).fill(0);
+    this.model = await loader.loadLayersModel(manifest.model);
     return this;
   }
 

--- a/src/CVAE/index.test.js
+++ b/src/CVAE/index.test.js
@@ -1,0 +1,65 @@
+import * as tf from '@tensorflow/tfjs';
+import cvae from './index';
+
+const MODEL_PATH = 'https://raw.githubusercontent.com/ml5js/ml5-data-and-models/main/models/CVAE/quick_draw/manifest.json';
+const LATENT_DIM = 16;
+const OUTPUT_PIXELS = 28 * 28 * 4;
+const EXAMPLE_LABEL = 'airplane';
+
+describe('CVAE', () => {
+  let model;
+
+  const callbacks = {
+    onGenerate: () => null,
+    onConstruct: () => null
+  }
+
+  beforeAll(async () => {
+    window.URL.createObjectURL = jest.fn();
+    jest.setTimeout(10000);
+    model = await cvae(MODEL_PATH);
+  });
+
+  afterEach(() => {
+    window.URL.createObjectURL.mockReset();
+  })
+
+  it("Can be created asynchronously", async () => {
+    await expect(model.ready).resolves.toBeTruthy();
+    expect(model.model).toBeInstanceOf(tf.LayersModel);
+  });
+
+  it("Can be created with a callback function", async () => {
+    jest.spyOn(callbacks, 'onConstruct');
+    const otherModel = cvae(MODEL_PATH, callbacks.onConstruct);
+    await otherModel.ready;
+    expect(callbacks.onConstruct).toHaveBeenCalledTimes(1);
+    expect(otherModel).toHaveProperty('generate');
+  });
+
+  it("Can create an image", async () => {
+    const result = await model.generate(EXAMPLE_LABEL);
+    expect(result.raw.length).toEqual(OUTPUT_PIXELS);
+  });
+
+  it("Accepts a latent vector", async () => {
+    const values = Array.from({ length: LATENT_DIM }, () => Math.random() - .5);
+    const result = await model.generate(EXAMPLE_LABEL, values);
+    expect(result.raw.length).toEqual(OUTPUT_PIXELS);
+  });
+
+  it("Calls a callback on generate()", async () => {
+    jest.spyOn(callbacks, 'onGenerate');
+    await model.generate(EXAMPLE_LABEL, callbacks.onGenerate);
+    expect(callbacks.onGenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it("Rejects when called with an invalid label", async () => {
+    expect.assertions(3);
+    const callback = (err, result) => {
+      expect(err).toBeInstanceOf(Error);
+      expect(result).toBeUndefined();
+    }
+    await expect(model.generate('not a label', callback)).rejects.toThrowError();
+  });
+});

--- a/src/DCGAN/index.js
+++ b/src/DCGAN/index.js
@@ -9,8 +9,8 @@ This version is based on alantian's TensorFlow.js implementation: https://github
 */
 
 import * as tf from '@tensorflow/tfjs';
-import axios from 'axios';
 import callCallback from '../utils/callcallback';
+import modelLoader from '../utils/modelLoader';
 import  p5Utils from '../utils/p5Utils';
 
 // Default pre-trained face model
@@ -32,7 +32,6 @@ class DCGANBase {
     this.model = {};
     this.modelPath = modelPath;
     this.modelInfo = {};
-    this.modelPathPrefix = '';
     this.modelReady = false;
     this.config = {
       returnTensors: options.returnTensors || false,
@@ -45,15 +44,9 @@ class DCGANBase {
      * @return {this} the dcgan.
      */
   async loadModel() {
-    const modelInfo = await axios.get(this.modelPath);
-    const modelInfoJson = modelInfo.data;
-
-    this.modelInfo = modelInfoJson
-        
-    const [modelUrl] = this.modelPath.split('manifest.json')
-    const modelJsonPath = this.isAbsoluteURL(modelUrl) ? this.modelInfo.model : this.modelPathPrefix + this.modelInfo.model
-
-    this.model = await tf.loadLayersModel(modelJsonPath);
+    const loader = modelLoader(this.modelPath, 'manifest');
+    this.modelInfo = await loader.loadManifestJson();
+    this.model = await loader.loadLayersModel(this.modelInfo.model);
     this.modelReady = true;
     return this;
   }
@@ -139,13 +132,6 @@ class DCGANBase {
 
     return result;
 
-  }
-
-    
-  /* eslint class-methods-use-this: "off" */
-  isAbsoluteURL(str) {
-    const pattern = new RegExp('^(?:[a-z]+:)?//', 'i');
-    return !!pattern.test(str);
   }
 
 }

--- a/src/DCGAN/index.test.js
+++ b/src/DCGAN/index.test.js
@@ -1,0 +1,61 @@
+import * as tf from '@tensorflow/tfjs';
+import dcgan from './index';
+
+const MODEL_PATH = 'https://raw.githubusercontent.com/ml5js/ml5-library/main/examples/javascript/DCGAN/DCGAN_Random/model/geo/model.json';
+const LATENT_DIM = 128;
+const OUTPUT_PIXELS = 64 * 64 * 4;
+
+describe('DCGAN', () => {
+  let model;
+
+  const callbacks = {
+    onGenerate: () => null,
+    onConstruct: () => null
+  }
+
+  beforeAll(async () => {
+    jest.setTimeout(10000);
+    model = await dcgan(MODEL_PATH);
+  });
+
+  it("Can be created asynchronously", async () => {
+    await expect(model.ready).resolves.toBeTruthy();
+    expect(model.model).toBeInstanceOf(tf.LayersModel);
+  });
+
+  it("Can be created with a callback function", async () => {
+    jest.spyOn(callbacks, 'onConstruct');
+    const otherModel = dcgan(MODEL_PATH, callbacks.onConstruct);
+    await otherModel.ready;
+    expect(callbacks.onConstruct).toHaveBeenCalledTimes(1);
+    expect(otherModel).toHaveProperty('generate');
+  });
+
+  it("Can load from a manifest.json", async () => {
+    const otherModel = await dcgan(MODEL_PATH.replace('model.json', 'manifest.json'));
+    expect(otherModel.ready).resolves.toBeTruthy();
+    expect(otherModel.model).toBeInstanceOf(tf.LayersModel);
+  });
+
+  // TODO: should it reject the promise instead?
+  it("Throws an error if no model is provided", async () => {
+    expect(() => dcgan()).toThrowError();
+  });
+
+  it("Can create an image", async () => {
+    const result = await model.generate();
+    expect(result.raw.length).toEqual(OUTPUT_PIXELS);
+  });
+
+  it("Accepts a latent vector", async () => {
+    const values = Array.from({ length: LATENT_DIM }, () => Math.random() - .5);
+    const result = await model.generate(values);
+    expect(result.raw.length).toEqual(OUTPUT_PIXELS);
+  });
+
+  it("Calls a callback on generate()", async () => {
+    jest.spyOn(callbacks, 'onGenerate');
+    await model.generate(callbacks.onGenerate);
+    expect(callbacks.onGenerate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/FaceApi/index.js
+++ b/src/FaceApi/index.js
@@ -15,7 +15,7 @@
 import * as tf from "@tensorflow/tfjs";
 import * as faceapi from "face-api.js";
 import callCallback from "../utils/callcallback";
-import modelLoader from "../utils/modelLoader";
+import { getModelPath } from "../utils/modelLoader";
 
 const DEFAULTS = {
   withLandmarks: true,
@@ -95,7 +95,7 @@ class FaceApiBase {
 
     Object.keys(this.config.MODEL_URLS).forEach(item => {
       if (modelOptions.includes(item)) {
-        this.config.MODEL_URLS[item] = modelLoader.getModelPath(this.config.MODEL_URLS[item]);
+        this.config.MODEL_URLS[item] = getModelPath(this.config.MODEL_URLS[item]);
       }
     });
 

--- a/src/ObjectDetector/YOLO/index.js
+++ b/src/ObjectDetector/YOLO/index.js
@@ -74,13 +74,8 @@ export class YOLOBase extends Video {
       this.video = await this.loadVideo();
     }
 
-    if (modelLoader.isAbsoluteURL(this.modelUrl) === true) {
-      this.model = await tf.loadLayersModel(this.modelUrl);
-    } else {
-      const modelPath = modelLoader.getModelPath(this.modelUrl);
-      this.modelUrl = `${modelPath}/model.json`;
-      this.model = await tf.loadLayersModel(this.modelUrl);
-    }
+    const loader = modelLoader(this.modelUrl, 'model');
+    this.model = await loader.loadLayersModel();
 
     this.modelReady = true;
     return this;

--- a/src/PitchDetection/index.js
+++ b/src/PitchDetection/index.js
@@ -11,6 +11,7 @@
 
 import * as tf from '@tensorflow/tfjs';
 import callCallback from '../utils/callcallback';
+import modelLoader from '../utils/modelLoader';
 
 class PitchDetection {
   /**
@@ -44,7 +45,8 @@ class PitchDetection {
   }
 
   async loadModel(model) {
-    this.model = await tf.loadLayersModel(`${model}/model.json`);
+    const loader = modelLoader(model, 'model');
+    this.model = await loader.loadLayersModel();
     if (this.audioContext) {
       await this.processStream();
     } else {

--- a/src/SketchRNN/index.js
+++ b/src/SketchRNN/index.js
@@ -11,8 +11,8 @@ SketchRNN
 
 import * as ms from '@magenta/sketch';
 import callCallback from '../utils/callcallback';
+import { getModelPath, isAbsoluteURL } from '../utils/modelLoader';
 import modelPaths from './models';
-import modelLoader from '../utils/modelLoader';
 
 // const PATH_START_LARGE = 'https://storage.googleapis.com/quickdraw-models/sketchRNN/large_models/';
 // const PATH_START_SMALL = 'https://storage.googleapis.com/quickdraw-models/sketchRNN/models/';
@@ -30,10 +30,10 @@ const DEFAULTS = {
 
 class SketchRNN {
   /**
-   * Create SketchRNN. 
+   * Create SketchRNN.
    * @param {String} model - The name of the sketch model to be loaded.
    *    The names can be found in the models.js file
-   * @param {function} callback - Optional. A callback function that is called once the model has loaded. If no callback is provided, it will return a promise 
+   * @param {function} callback - Optional. A callback function that is called once the model has loaded. If no callback is provided, it will return a promise
    *    that will be resolved once the model has loaded.
    */
   constructor(model, callback, large = true) {
@@ -47,13 +47,11 @@ class SketchRNN {
       modelPath_large: DEFAULTS.modelPath_large,
       PATH_END: DEFAULTS.PATH_END,
     };
-    
-    
-    if(modelLoader.isAbsoluteURL(checkpointUrl) === true){
-      const modelPath = modelLoader.getModelPath(checkpointUrl);
-      this.config.modelPath = modelPath;
 
-    } else if(modelPaths.has(checkpointUrl)) {
+    // TODO: support relative URL
+    if (isAbsoluteURL(checkpointUrl) === true) {
+      this.config.modelPath = getModelPath(checkpointUrl);
+    } else if (modelPaths.has(checkpointUrl)) {
       checkpointUrl = (large ? this.config.modelPath : this.config.modelPath_small) + checkpointUrl + this.config.PATH_END;
       this.config.modelPath = checkpointUrl;
     } else {

--- a/src/SoundClassifier/speechcommands.js
+++ b/src/SoundClassifier/speechcommands.js
@@ -15,7 +15,7 @@ export class SpeechCommands {
   async load(url) {
     if (url) {
       const loader = modelLoader(url);
-      this.model = tfjsSpeechCommands.create('BROWSER_FFT', undefined, url, loader.metadataUrl);
+      this.model = tfjsSpeechCommands.create('BROWSER_FFT', undefined, loader.modelUrl, loader.metadataUrl);
     } else this.model = tfjsSpeechCommands.create('BROWSER_FFT');
     await this.model.ensureModelLoaded();
     this.allLabels = this.model.wordLabels();

--- a/src/SoundClassifier/speechcommands.js
+++ b/src/SoundClassifier/speechcommands.js
@@ -5,6 +5,7 @@
 
 import * as tfjsSpeechCommands from '@tensorflow-models/speech-commands';
 import { getTopKClassesFromArray } from '../utils/gettopkclasses';
+import modelLoader from '../utils/modelLoader';
 
 export class SpeechCommands {
   constructor(options) {
@@ -13,10 +14,8 @@ export class SpeechCommands {
 
   async load(url) {
     if (url) {
-      const split = url.split("/");
-      const prefix = split.slice(0, split.length - 1).join("/");
-      const metadataJson = `${prefix}/metadata.json`;
-      this.model = tfjsSpeechCommands.create('BROWSER_FFT', undefined, url, metadataJson);
+      const loader = modelLoader(url);
+      this.model = tfjsSpeechCommands.create('BROWSER_FFT', undefined, url, loader.metadataUrl);
     } else this.model = tfjsSpeechCommands.create('BROWSER_FFT');
     await this.model.ensureModelLoaded();
     this.allLabels = this.model.wordLabels();

--- a/src/utils/generatedImageResult.js
+++ b/src/utils/generatedImageResult.js
@@ -18,11 +18,11 @@ import p5Utils from './p5Utils';
  * Accepts options as an object with property `returnTensors` so that models can pass this.config.
  *
  * @param {tf.Tensor3D} tensor
- * @param {{ returnTensors: boolean }} options
+ * @param {{ returnTensors?: boolean }} [options]
  * @return {Promise<GeneratedImageResult>}
  */
-export default async function generatedImageResult(tensor, options) {
-  const raw = await tf.browser.toPixels(tensor); // or tensor.data()??
+export default async function generatedImageResult(tensor, options = {}) {
+  const raw = await tf.browser.toPixels(tensor);
   const [height, width] = tensor.shape;
   const blob = await p5Utils.rawToBlob(raw, width, height);
   const image = await p5Utils.blobToP5Image(blob);

--- a/src/utils/generatedImageResult.test.js
+++ b/src/utils/generatedImageResult.test.js
@@ -1,0 +1,81 @@
+import * as tf from '@tensorflow/tfjs';
+import p5 from 'p5';
+import generatedImageResult from './generatedImageResult';
+import p5Utils from './p5Utils';
+
+const IMAGE_SIZE = 10;
+const OUTPUT_LENGTH = 10 * 10 * 4;
+
+/**
+ * @param {tf.DataType} dtype
+ * @param {number} channels
+ * @return {tf.Tensor3D}
+ */
+const createTensor = (dtype = 'float32', channels = 3) => {
+  const shape = [IMAGE_SIZE, IMAGE_SIZE, channels];
+  const length = IMAGE_SIZE * IMAGE_SIZE * channels;
+  const data = Array.from({ length }, () => Math.random() * (dtype === 'int32' ? 255 : 1));
+  return tf.tensor3d(data, shape, dtype);
+}
+
+describe('generatedImageResult', () => {
+
+  it("Can accept float values (0-1)", async () => {
+    const input = createTensor('float32');
+    const result = await generatedImageResult(input);
+    expect(result.raw).toHaveLength(OUTPUT_LENGTH);
+  });
+
+  it("Can accept int values (0-255)", async () => {
+    const input = createTensor('int32');
+    const result = await generatedImageResult(input);
+    expect(result.raw).toHaveLength(OUTPUT_LENGTH);
+  });
+
+  it("Can accept a 2D image", async () => {
+    const input = createTensor('float32', 1).squeeze();
+    const result = await generatedImageResult(input);
+    expect(result.raw).toHaveLength(OUTPUT_LENGTH);
+  });
+
+  it("Can return tensors", async () => {
+    const input = createTensor();
+    const result = await generatedImageResult(input, { returnTensors: true });
+    expect(result.tensor).toBeInstanceOf(tf.Tensor);
+    expect(result.tensor).toBe(input);
+    expect(input.isDisposed).toBe(false);
+  });
+
+  it("Can dispose of tensors", async () => {
+    const input = createTensor();
+    const result = await generatedImageResult(input, { returnTensors: false });
+    expect(result.tensor).toBeUndefined();
+    expect(input.isDisposed).toBe(true);
+  });
+
+  it("Can create a blob", async () => {
+    const input = createTensor();
+    const result = await generatedImageResult(input);
+    expect(result.blob).not.toBeNull();
+    expect(result.blob).toBeInstanceOf(Blob);
+  });
+
+  it("Will return image: `null` without p5", async () => {
+    const input = createTensor();
+    const result = await generatedImageResult(input);
+    expect(result.image).toBeNull();
+  });
+
+  it("Can create a p5 image", async () => {
+    p5Utils.setP5Instance(p5);
+    window.URL.createObjectURL = jest.fn();
+    const input = createTensor();
+    const result = await generatedImageResult(input);
+    expect(result.image).not.toBeNull();
+    expect(result.image.width).toBe(IMAGE_SIZE);
+    expect(result.image.height).toBe(IMAGE_SIZE);
+    p5Utils.setP5Instance(undefined);
+    window.URL.createObjectURL.mockReset();
+  });
+
+});

--- a/src/utils/modelLoader.js
+++ b/src/utils/modelLoader.js
@@ -1,10 +1,13 @@
+import * as tf from '@tensorflow/tfjs';
+import axios from 'axios';
+
 /**
  * Check if the provided URL string starts with a hostname,
  * such as http://, https://, etc.
  * @param {string} str
  * @returns {boolean}
  */
-function isAbsoluteURL(str) {
+export function isAbsoluteURL(str) {
   const pattern = new RegExp('^(?:[a-z]+:)?//', 'i');
   return pattern.test(str);
 }
@@ -15,14 +18,112 @@ function isAbsoluteURL(str) {
  * @param {string} absoluteOrRelativeUrl
  * @returns {string}
  */
-function getModelPath(absoluteOrRelativeUrl) {
+export function getModelPath(absoluteOrRelativeUrl) {
   if (!isAbsoluteURL(absoluteOrRelativeUrl) && typeof window !== 'undefined') {
     return window.location.pathname + absoluteOrRelativeUrl;
   }
   return absoluteOrRelativeUrl;
 }
 
-export default {
-  isAbsoluteURL,
-  getModelPath
+function isKnownName(name) {
+  return ['model', 'manifest', 'metadata'].includes(name);
+}
+
+/**
+ * @property {string} directory
+ * @property {string} modelUrl
+ * @property {string} manifestUrl
+ * @property {string} metadataUrl
+ */
+class ModelLoader {
+  /**
+   * Can provide the url to a model.json/metadata.json/manifest.json file,
+   * or to a folder containing the files.
+   *
+   * @param {string} path
+   * @param {'model'|'manifest'|'metadata'} expected
+   * @param {boolean} prepend
+   */
+  constructor(path, expected = 'model', prepend = true) {
+    const url = prepend ? getModelPath(path) : path;
+    const known = {};
+    // If a specific URL is provided, make sure that we don't overwrite it with generic '/model.json'
+    // But warn the user and try to correct if it seems like they passed the wrong file type.
+    if (url.endsWith('.json')) {
+      const pos = url.lastIndexOf('/') + 1;
+      this.directory = url.slice(0, pos);
+      const fileName = url.slice(pos, -5);
+      if (fileName !== expected && isKnownName(fileName)) {
+        console.warn(`Expected a ${expected}.json file URL, but received a ${fileName}.json file instead.`);
+      } else {
+        known[expected] = url;
+      }
+    } else {
+      this.directory = url.endsWith('/') ? url : `${url}/`;
+    }
+    this.modelUrl = known.model || this.getPath('model.json');
+    this.metadataUrl = known.metadata || this.getPath('metadata.json');
+    this.manifestUrl = known.manifest || this.getPath('manifest.json');
+  }
+
+  /**
+   * Appends the filename to the base directory.
+   * @param {string} filename
+   * @return {string}
+   */
+  getPath(filename) {
+    return isAbsoluteURL(filename) ? filename : this.directory + filename;
+  }
+
+  /**
+   * Fetch the JSON data from the manifest file, and throw an error if not found.
+   * @return {Promise<any>}
+   */
+  async loadManifestJson() {
+    try {
+      const res = await axios.get(this.manifestUrl);
+      return res.data;
+    } catch (error) {
+      throw new Error(`Error loading manifest.json file from URL ${this.manifestUrl}: ${String(error)}`);
+    }
+  }
+
+  /**
+   * Fetch the JSON data from the metadata file, and throw an error if not found.
+   * @return {Promise<any>}
+   */
+  async loadMetadataJson() {
+    try {
+      const res = await axios.get(this.metadataUrl);
+      return res.data;
+    } catch (error) {
+      throw new Error(`Error loading metadata.json file from URL ${this.metadataUrl}: ${String(error)}`);
+    }
+  }
+
+  /**
+   * Pass the model URL to the TensorFlow loadLayersModel function.
+   * If no path is provided, loads file `/model.json` relative to the directory.
+   * But can also be called with the model url from a manifest file.
+   * @param {string} [relativePath]
+   * @return {Promise<tf.LayersModel>}
+   */
+  async loadLayersModel(relativePath) {
+    const url = relativePath ? this.getPath(relativePath) : this.modelUrl;
+    try {
+      return await tf.loadLayersModel(url);
+    } catch (error) {
+      throw new Error(`Error loading model from URL ${url}: ${String(error)}`);
+    }
+  }
+}
+
+/**
+ * @param {string} path
+ * @param {'model'|'manifest'|'metadata'} [expected]
+ * @param {boolean} [prepend]
+ * @return {ModelLoader}
+ */
+export default function modelLoader(path, expected, prepend) {
+  return new ModelLoader(path, expected, prepend);
 }

--- a/src/utils/modelLoader.js
+++ b/src/utils/modelLoader.js
@@ -41,10 +41,10 @@ class ModelLoader {
    * or to a folder containing the files.
    *
    * @param {string} path
-   * @param {'model'|'manifest'|'metadata'} expected
-   * @param {boolean} prepend
+   * @param {'model'|'manifest'|'metadata'} [expected]
+   * @param {boolean} [prepend]
    */
-  constructor(path, expected = 'model', prepend = true) {
+  constructor(path, expected, prepend = true) {
     const url = prepend ? getModelPath(path) : path;
     const known = {};
     // If a specific URL is provided, make sure that we don't overwrite it with generic '/model.json'
@@ -53,7 +53,7 @@ class ModelLoader {
       const pos = url.lastIndexOf('/') + 1;
       this.directory = url.slice(0, pos);
       const fileName = url.slice(pos, -5);
-      if (fileName !== expected && isKnownName(fileName)) {
+      if (expected && fileName !== expected && isKnownName(fileName)) {
         console.warn(`Expected a ${expected}.json file URL, but received a ${fileName}.json file instead.`);
       } else {
         known[expected] = url;

--- a/src/utils/tensorInput.js
+++ b/src/utils/tensorInput.js
@@ -1,0 +1,63 @@
+import * as tf from '@tensorflow/tfjs';
+
+/**
+ * Helper for creating a latent input for generator models DCGAN and CVAE
+ */
+
+/**
+ * Replace `null` with `1`.
+ * @param {tf.SymbolicTensor}layer
+ * @return {number[]}
+ */
+function layerShape(layer) {
+  return layer.shape.map(value => value === null ? 1 : value);
+}
+
+/**
+ * If there are multiple input tensors, look at the specified index only.
+ * @param {tf.LayersModel} model
+ * @param {number} [layerIndex]
+ * @return {number[]}
+ */
+export function modelInputShape(model, layerIndex = 0) {
+  const inputLayer = Array.isArray(model.input) ? model.input[layerIndex] : model.input;
+  return layerShape(inputLayer);
+}
+
+/**
+ * Return all input layer shapes as an array.
+ * @param {tf.LayersModel} model
+ * @return {number[][]}
+ */
+export function modelInputShapes(model) {
+  const inputLayers = Array.isArray(model.input) ? model.input : [model.input];
+  return inputLayers.map(layerShape);
+}
+
+/**
+ * Create a tensor from an array input or create a random input.
+ * @param {tf.LayersModel} model
+ * @param {tf.Tensor2D|number[]|Float32Array|undefined} [input]
+ * @return {tf.Tensor2D}
+ */
+export function validateLatentInput(model, input) {
+  // handle tensor
+  if (input instanceof tf.Tensor) {
+    return input;
+    // Note: could validate the shape here.
+  }
+  const shape = modelInputShape(model);
+  return tf.tidy(() => {
+    // handle no input by returning a random vector
+    if (!input) {
+      return tf.randomNormal(shape);
+    }
+    // handle array
+    const totalSize = shape.reduce((a, b) => a * b);
+    if (totalSize !== input.length) {
+      throw new Error(`Length of the latent vector ${input.length} ` +
+        `and the input dimensions of the model ${totalSize} must match.`);
+    }
+    return tf.tensor2d(input, shape, 'float32');
+  });
+}


### PR DESCRIPTION
Extends PR #1376 -- merge that first.
Fixes #949
Possible resolves #1386, subject to discussion.

## CVAE
- `generate()` accepts an optional `latentVector` (inspired by DCGAN).
- Throw an error if the label cannot be found instead of returning nonsensical garbage `[undefined, undefined]`.
- Remove hard-coded input size of `[1, 16]` as this will vary based on the model.  Accesses the input shape by looking at the model instead.
- Remove unnecessary instance properties `this.labelVector` and `this.latentDim`.  These are now local variables in `generate()`.
- Make use of built tensorflow functions:
  - `tf.oneHot()` to encode the label input
  - `.squeeze()` instead of verbose `.reshape([temp.shape[1], temp.shape[2], temp.shape[3]])`
- Should use property `raw` instead of `raws` to match other models.  Now returns both to be non-breaking.
- Better JSDoc -- I need to find a system that can sync these JSDoc types and description into our documentation website.
- Inline `generateInternal()` as an IIFE inside of `generate()` so that I didn't need to duplicate the JSDoc.
- Exhaustive unit tests.

## DCGAN
- Can accept either a `model.json` or a `manifest.json`, since the manifest does not provide any necessary info. (see issue #1386)
- `generate()` can accept both a `callback` and a `latentVector` with both optional and in any order.  Callbacks should always be last so the way that we had it did not make sense.
- Combine `generate()`, `generateInternal()` and `compute()` into one method.
- Offload the first 10 lines of `compute()` into a utility.
- Exhaustive unit tests.

## tensorInput
- New utility file handles common logic in both CVAE and DCGAN (and potentially others in the future).
- `modelInputShape` figures out the correct tensor shape based on the model.  This is really important and should be used [in a few other models](https://github.com/ml5js/ml5-library/search?q=image_size) as well. Having hard-coded variables like `IMAGE_SIZE` will not work if the user provides a URL to a custom model which uses a different input size than what is expected by the code.
  - Argument `layerIndex` allows this to work for models like `CVAE` which take an array of tensors instead of a single tensor input.
- `validateLatentInput` includes the existing logic which I removed from `DCGAN.compute()` for creating either a random input tensor or a tensor from a provided array.
  - Adds an error message if the array size is wrong.  This should be *slightly* more helpful than the TF error that would get thrown on the next line ("Uncaught Error: Based on the provided shape, [2,2], the tensor should have 4 values but has 6").
  - The user can now provide a Tensor in addition to an array.

## Failed Tests
There are 2 failures in the new tests that I've added:
1. Loading a DCGAN from the current geo `manifest.json` does not work due to the relative URL issue discussed in #1386 
2. Generating a P5 image fails.  I added P5 as a devDependency so that we can do tests like this.  However, calling `p5Utils.setP5Instance()` does not work as intended.  I believe that there is an issue in the `P5Util` class.