### PR TITLE
Fix error in USE tokenizer

### DIFF
--- a/examples/p5js/UniversalSentenceEncoder/UniversalSentenceEncoder_WithTokenizer/index.html
+++ b/examples/p5js/UniversalSentenceEncoder/UniversalSentenceEncoder_WithTokenizer/index.html
@@ -6,7 +6,7 @@
     <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
   </head>
 
-  <body>
+  <body style="display: flex; flex-direction: column;">
     <h1>Universal Sentence Encoder with Tokenizer</h1>
     <script src="sketch.js"></script>
   </body>

--- a/examples/p5js/UniversalSentenceEncoder/UniversalSentenceEncoder_WithTokenizer/sketch.js
+++ b/examples/p5js/UniversalSentenceEncoder/UniversalSentenceEncoder_WithTokenizer/sketch.js
@@ -29,11 +29,10 @@ function gotResults(err, result){
     console.log(err);
     return;
   }
-  console.log(result);
+  console.log('got result:', result);
   clear();
   const padding = 20;
   const rectWidth = (width - 2 * padding)/result.length
-  console.log({rectWidth, width, height})
   result.forEach( (item, idx) => {
     // Map from 8000 tokens in the vocab to a height from 0 to 100
     const rectHeight = map(item, 0, 7999, 0, 100);

--- a/examples/p5js/UniversalSentenceEncoder/UniversalSentenceEncoder_WithTokenizer/sketch.js
+++ b/examples/p5js/UniversalSentenceEncoder/UniversalSentenceEncoder_WithTokenizer/sketch.js
@@ -1,37 +1,44 @@
 let sentenceEncoder;
-const sentence = 'Monday, Tuesday, Wednesday, Thursday, and Friday are days of the Week';
-
+let textInput;
 
 function setup(){
   createCanvas(512, 512);
-  // background(220);
   colorMode(HSB, 360, 100, 100);
   rectMode(CENTER);
-  textAlign(CENTER);
-  sentenceEncoder = ml5.universalSentenceEncoder({withTokenizer:true}, modelLoaded)
+  textInput = createInput('Monday, Tuesday, Wednesday, Thursday, and Friday are days of the week.');
+  textInput.size(500);
+  sentenceEncoder = ml5.universalSentenceEncoder({withTokenizer:false}, modelLoaded);
 }
 
 function modelLoaded(){
-  console.log('model ready')
-  predict();
+  console.log('model ready');
+  // encode the current input.
+  encode();
+  // attach a listener to encode when the input is changed.
+  textInput.input(encode);
 }
 
-function predict(){
-  console.log('predicting')
+function encode(){
+  console.log('encoding');
+  const sentence = textInput.value();
   sentenceEncoder.encode(sentence, gotResults);
 }
 
 function gotResults(err, result){
-  if(err){
-    return err;
+  if (err) {
+    console.log(err);
+    return;
   }
   console.log(result);
-  translate(40, 0);
+  clear();
+  const padding = 20;
+  const rectWidth = (width - 2 * padding)/result.length
+  console.log({rectWidth, width, height})
   result.forEach( (item, idx) => {
+    // Map from 8000 tokens in the vocab to a height from 0 to 100
     const rectHeight = map(item, 0, 7999, 0, 100);
     fill(180, 100, 100);
-    rect(idx * 20, height/2 , 20,  rectHeight);
+    const x = padding + (idx + .5) * rectWidth;
+    rect(x, height/2 , rectWidth,  rectHeight);
   })
-
-
 }

--- a/src/UniversalSentenceEncoder/index.js
+++ b/src/UniversalSentenceEncoder/index.js
@@ -1,78 +1,72 @@
-// import * as tf from '@tensorflow/tfjs';
 import * as USE from '@tensorflow-models/universal-sentence-encoder';
 import callCallback from '../utils/callcallback';
+import handleArguments from '../utils/handleArguments';
 
 const DEFAULTS = {
   withTokenizer: false,
 }
 
 class UniversalSentenceEncoder {
-  constructor(options, callback){
+  constructor(options, callback) {
+    /**
+     * @type {null | USE.UniversalSentenceEncoder}
+     */
     this.model = null;
-    this.tokenizer = null;
     this.config = {
+      // TODO: accept options modelUrl, vocabUrl, returnTensors
       withTokenizer: options.withTokenizer || DEFAULTS.withTokenizer
     };
-
-    callCallback(this.loadModel(), callback);
+    this.ready = callCallback(this.loadModel(), callback);
   }
 
   /**
    * load model
    */
-  async loadModel(){
-    if(this.config.withTokenizer === true){
-      this.tokenizer = await USE.loadTokenizer();
-    } 
+  async loadModel() {
+    // Note: can load tokenizer without loading model, but model will always load a tokenizer.
     this.model = await USE.load();
     return this;
   }
 
   /**
    * Encodes a string or array based on the USE
-   * @param {*} textString 
-   * @param {*} callback 
+   * @param {string | string[]} text
+   * @param {ML5Callback<number[][]>} [callback]
+   * @return {Promise<number[][]>}
    */
-  predict(textArray, callback){
-    return callCallback(this.predictInternal(textArray), callback);
+  predict(text, callback) {
+    return callCallback(this.predictInternal(text), callback);
   }
 
-  async predictInternal(textArray){
-    try{
-      const embeddings = await this.model.embed(textArray);
-      const results = await embeddings.array();
-      embeddings.dispose();
-      return results;
-    } catch(err){
-      console.error(err);
-      return err;
-    }
+  async predictInternal(textArray) {
+    await this.ready;
+    const embeddings = await this.model.embed(textArray);
+    const results = await embeddings.array();
+    embeddings.dispose();
+    return results;
   }
 
   /**
    * Encodes a string based on the loaded tokenizer if the withTokenizer:true
-   * @param {*} textString 
-   * @param {*} callback 
+   * @param {string} textString
+   * @param {ML5Callback<number[]>} [callback]
+   * @return {Promise<number[]>}
    */
-  encode(textString, callback){
+  encode(textString, callback) {
     return callCallback(this.encodeInternal(textString), callback);
   }
 
-  async encodeInternal(textString){
-    if(this.config.withTokenizer === true){
-      return this.tokenizer.encode(textString);
-    } 
-    console.error('withTokenizer must be set to true - please pass "withTokenizer:true" as an option in the constructor');
-    return false;
+  async encodeInternal(textString) {
+    await this.ready;
+    return this.model.tokenizer.encode(textString);
   }
 
 }
 
 const universalSentenceEncoder = (optionsOr, cb) => {
-  const options = (typeof optionsOr === 'object') ? optionsOr : {};
-  const callback = (typeof optionsOr === 'function') ? optionsOr : cb;
-
-  return new UniversalSentenceEncoder(options, callback);
+  const { options = {}, callback } = handleArguments(optionsOr, cb);
+  const instance = new UniversalSentenceEncoder(options, callback);
+  return callback ? instance : instance.ready;
 };
 
 export default universalSentenceEncoder;


### PR DESCRIPTION
Fixes #1391 

- Fixes error in `UniversalSentenceEncoder` due to calling `loadTokenizer` without a path argument (the TFJS documentation incorrectly states that it is optional).
- Allows `ml5.universalSentenceEncoder()` to return a promise.
- Makes the tokenizer example interactive.