### PR TITLE
Support saving model in node js

### DIFF
--- a/src/utils/io.js
+++ b/src/utils/io.js
@@ -6,13 +6,31 @@
 import axios from "axios";
 
 const saveBlob = async (data, name, type) => {
-  const link = document.createElement('a');
-  link.style.display = 'none';
-  document.body.appendChild(link);
   const blob = new Blob([data], { type });
-  link.href = URL.createObjectURL(blob);
-  link.download = name;
-  link.click();
+  // No foolproof way to detect node. So try loading what you require.
+  // If it quacks like a duck...
+  let fs, os, path;
+  try{
+    fs = require('fs');
+    os = require('os');
+    path = require('path');
+  }catch(_){}
+
+  if(fs && os && path){
+    // is node
+    const buffer = Buffer.from(await blob.arrayBuffer());
+    fs.writeFile(path.join(os.homedir(), "Downloads", name), // assume its named Downloads on all platforms?
+                 buffer,
+                 () => console.log(`Saved ${name} to Downloads folder.`) );
+  }else{
+    // is browser
+    const link = document.createElement('a');
+    link.style.display = 'none';
+    document.body.appendChild(link);
+    link.href = URL.createObjectURL(blob);
+    link.download = name;
+    link.click();
+  }
 };
 
 const loadFile = async (path, callback) => axios.get(path)


### PR DESCRIPTION
Without modifying any existing functionality, this change adds the feature of allowing saving models in a node js environment. 
This specially helps electronjs where saving a blob by simulating a link click leads to a dialog prompt for saving files preventing any but the first file from being saved. In a regular browser environment, simulating link clicks automatically downloads the files without a prompt, provided the user doesn't have the setting to ask download location each time, turned on ( a rare but very much possible scenario). Also since the change is to saveBlob, this should work for any saving of files across the codebase.

This solves Issue [Saving a neural network model only saves the model.weights.bin file. No model json or meta data json](https://github.com/ml5js/ml5-library/issues/1393)