### PR TITLE
Allow tensor as input image

### DIFF
--- a/src/BodyPix/index.js
+++ b/src/BodyPix/index.js
@@ -19,7 +19,7 @@ import generatedImageResult from '../utils/generatedImageResult';
 import handleArguments from '../utils/handleArguments';
 import p5Utils from '../utils/p5Utils';
 import BODYPIX_PALETTE from './BODYPIX_PALETTE';
-import { mediaReady } from '../utils/imageUtilities';
+import { mediaReady, toTensor } from '../utils/imageUtilities';
 
 /**
  * @typedef {Record<string, {color: [number, number, number], id: number}>} BodyPixPalette
@@ -135,8 +135,10 @@ class BodyPix {
    */
   async segmentWithPartsInternal(imgToSegment, segmentationOptions) {
     // estimatePartSegmentation
-    await this.ready;
-    await mediaReady(imgToSegment, true);
+    await Promise.all([
+      this.ready,
+      mediaReady(imgToSegment, true)
+    ]);
 
     this.config.palette = segmentationOptions.palette || this.config.palette;
     this.config.outputStride = segmentationOptions.outputStride || this.config.outputStride;
@@ -173,7 +175,7 @@ class BodyPix {
       backgroundMask,
       partMask,
     } = tf.tidy(() => {
-      let normTensor = tf.browser.fromPixels(imgToSegment);
+      let normTensor = toTensor(imgToSegment);
       // create a tensor from the input image
       const alpha = tf.ones([segmentation.height, segmentation.width, 1]).tile([1, 1, 1]).mul(255)
       normTensor = normTensor.concat(alpha, 2)
@@ -247,8 +249,10 @@ class BodyPix {
    */
   async segmentInternal(imgToSegment, segmentationOptions) {
 
-    await this.ready;
-    await mediaReady(imgToSegment, true);
+    await Promise.all([
+      this.ready,
+      mediaReady(imgToSegment, true)
+    ]);
 
     this.config.outputStride = segmentationOptions.outputStride || this.config.outputStride;
     this.config.segmentationThreshold = segmentationOptions.segmentationThreshold || this.config.segmentationThreshold;
@@ -289,7 +293,7 @@ class BodyPix {
       personMask,
       backgroundMask
     } = tf.tidy(() => {
-      let normTensor = tf.browser.fromPixels(imgToSegment);
+      let normTensor = toTensor(imgToSegment);
       // create a tensor from the input image
       const alpha = tf.ones([segmentation.height, segmentation.width, 1]).tile([1, 1, 1]).mul(255)
       normTensor = normTensor.concat(alpha, 2)

--- a/src/CartoonGAN/index.js
+++ b/src/CartoonGAN/index.js
@@ -11,6 +11,7 @@ import * as tf from '@tensorflow/tfjs';
 import callCallback from '../utils/callcallback';
 import generatedImageResult from '../utils/generatedImageResult';
 import handleArguments from '../utils/handleArguments';
+import { mediaReady, toTensor } from '../utils/imageUtilities';
 
 const IMAGE_SIZE = 256;
 
@@ -81,16 +82,17 @@ class Cartoon {
 
   /**
    * @private
-   * TODO: accept tensor3D
    * @param {ImageData | HTMLImageElement | HTMLCanvasElement | HTMLVideoElement} src
    * @return {Promise<CartoonResult>}
    */
   async generateInternal(src) {
-    await this.ready;
-    await tf.nextFrame();
+    await Promise.all([
+      this.ready,
+      mediaReady(src, true)
+    ]);
     const result = tf.tidy(() => {
       // adds resizeBilinear to resize image to 256x256 as required by the model
-      let img = tf.browser.fromPixels(src).resizeBilinear([IMAGE_SIZE, IMAGE_SIZE]);
+      let img = toTensor(src).resizeBilinear([IMAGE_SIZE, IMAGE_SIZE]);
       if (img.shape[0] !== IMAGE_SIZE || img.shape[1] !== IMAGE_SIZE) {
         throw new Error(`Input size should be ${IMAGE_SIZE}*${IMAGE_SIZE} but ${img.shape} is found`);
       } else if (img.shape[2] !== 3) {

--- a/src/FeatureExtractor/Mobilenet.js
+++ b/src/FeatureExtractor/Mobilenet.js
@@ -11,7 +11,7 @@ import * as tf from "@tensorflow/tfjs";
 import axios from "axios";
 import handleArguments from "../utils/handleArguments";
 import Video from "./../utils/Video";
-import { imgToTensor } from "../utils/imageUtilities";
+import { imgToTensor, toTensor } from "../utils/imageUtilities";
 import { saveBlob } from "../utils/io";
 import callCallback from "../utils/callcallback";
 
@@ -431,18 +431,8 @@ class Mobilenet {
   }
 
   mobilenetInfer(input, embedding = false) {
-    let img = input;
-    if (
-      img instanceof tf.Tensor ||
-      img instanceof ImageData ||
-      img instanceof HTMLImageElement ||
-      img instanceof HTMLCanvasElement ||
-      img instanceof HTMLVideoElement
-    ) {
       return tf.tidy(() => {
-        if (!(img instanceof tf.Tensor)) {
-          img = tf.browser.fromPixels(img);
-        }
+        const img = toTensor(input);
         const normalized = img
           .toFloat()
           .sub(this.normalizationOffset)
@@ -468,8 +458,6 @@ class Mobilenet {
         }
         return result;
       });
-    }
-    return null;
   }
 
   infer(input, endpoint) {

--- a/src/ImageClassifier/darknet.js
+++ b/src/ImageClassifier/darknet.js
@@ -16,28 +16,12 @@ const DEFAULTS = {
   IMAGE_SIZE_DARKNET_TINY: 224,
 };
 
-function preProcess(img, size) {
-  let image;
-  if (!(img instanceof tf.Tensor)) {
-    if (
-      img instanceof HTMLImageElement ||
-      img instanceof HTMLVideoElement ||
-      img instanceof HTMLCanvasElement ||
-      img instanceof ImageData
-    ) {
-      image = tf.browser.fromPixels(img);
-    } else if (
-      typeof img === "object" &&
-      (img.elt instanceof HTMLImageElement ||
-        img.elt instanceof HTMLVideoElement ||
-        img.elt instanceof HTMLCanvasElement ||
-        img.elt instanceof ImageData)
-    ) {
-      image = tf.browser.fromPixels(img.elt); // Handle p5.js image and video.
-    }
-  } else {
-    image = img;
-  }
+/**
+ * @param {tf.Tensor3D} image
+ * @param {number} size
+ * @return {tf.Tensor4D}
+ */
+function preProcess(image, size) {
   const normalized = image.toFloat().div(tf.scalar(255));
   let resized = normalized;
   if (normalized.shape[0] !== size || normalized.shape[1] !== size) {
@@ -81,6 +65,11 @@ export class Darknet {
     result.dispose();
   }
 
+  /**
+   * @param {tf.Tensor3D} img
+   * @param {number} topk
+   * @return {Promise<{ className: string, probability: number }[]>}
+   */
   async classify(img, topk = 3) {
     const logits = tf.tidy(() => {
       const imgData = preProcess(img, this.imgSize);

--- a/src/ImageClassifier/doodlenet.js
+++ b/src/ImageClassifier/doodlenet.js
@@ -12,23 +12,12 @@ const DEFAULTS = {
   IMAGE_SIZE_DOODLENET: 28,
 };
 
-function preProcess(img, size) {
-  let image;
-  if (!(img instanceof tf.Tensor)) {
-    if (img instanceof HTMLImageElement 
-      || img instanceof HTMLVideoElement 
-      || img instanceof HTMLCanvasElement
-      || img instanceof ImageData) {
-      image = tf.browser.fromPixels(img);
-    } else if (typeof img === 'object' && (img.elt instanceof HTMLImageElement 
-      || img.elt instanceof HTMLVideoElement 
-      || img.elt instanceof HTMLCanvasElement
-      || img.elt instanceof ImageData)) {
-      image = tf.browser.fromPixels(img.elt); // Handle p5.js image, video and canvas.
-    }
-  } else {
-    image = img;
-  }
+/**
+ * @param {tf.Tensor3D} image
+ * @param {number} size
+ * @return {tf.Tensor4D}
+ */
+function preProcess(image, size) {
   const normalized = tf.scalar(1).sub(image.toFloat().div(tf.scalar(255)));
   let resized = normalized;
   if (normalized.shape[0] !== size || normalized.shape[1] !== size) {
@@ -55,6 +44,11 @@ export class Doodlenet {
     result.dispose();
   }
 
+  /**
+   * @param {tf.Tensor3D} img
+   * @param {number} topk
+   * @return {Promise<{ className: string, probability: number }[]>}
+   */
   async classify(img, topk = 10) {
     const logits = tf.tidy(() => {
       const imgData = preProcess(img, this.imgSize);

--- a/src/ImageClassifier/index.js
+++ b/src/ImageClassifier/index.js
@@ -162,6 +162,7 @@ class ImageClassifier {
       return results;
     }
 
+    // TODO: it does not make sense to resize here and then again in darknet/doodlenet!
     const processedImg = imgToTensor(imgToPredict, imageResize);
     const results = this.model
       .classify(processedImg, numberOfClasses)

--- a/src/Pix2pix/index.js
+++ b/src/Pix2pix/index.js
@@ -12,9 +12,7 @@ This version is heavily based on Christopher Hesse TensorFlow.js implementation:
 
 import * as tf from '@tensorflow/tfjs';
 import CheckpointLoaderPix2pix from '../utils/checkpointLoaderPix2pix';
-import {
-  array3DToImage
-} from '../utils/imageUtilities';
+import { array3DToImage, mediaReady, toTensor } from '../utils/imageUtilities';
 import callCallback from '../utils/callcallback';
 
 class Pix2pix {
@@ -48,12 +46,14 @@ class Pix2pix {
   }
 
   async transferInternal(inputElement) {
-    
+    await Promise.all([
+      this.ready,
+      mediaReady(inputElement, false)
+    ]);
+
     const result = array3DToImage(tf.tidy(() => {
-      const input = tf.browser.fromPixels(inputElement);
-      const inputData = input.dataSync();
-      const floatInput = tf.tensor3d(inputData, input.shape);
-      const normalizedInput = tf.div(floatInput, tf.scalar(255));
+      const input = toTensor(inputElement).cast('float32');
+      const normalizedInput = tf.div(input, tf.scalar(255));
       const preprocessedInput = Pix2pix.preprocess(normalizedInput);
       
       const layers = [];

--- a/src/UNET/index.js
+++ b/src/UNET/index.js
@@ -11,7 +11,7 @@ import * as tf from '@tensorflow/tfjs';
 import callCallback from '../utils/callcallback';
 import generatedImageResult from '../utils/generatedImageResult';
 import handleArguments from "../utils/handleArguments";
-import { mediaReady } from '../utils/imageUtilities';
+import { mediaReady, toTensor } from '../utils/imageUtilities';
 
 const DEFAULTS = {
   modelPath: 'https://raw.githubusercontent.com/zaidalyafeai/HostedModels/master/unet-128/model.json',
@@ -62,7 +62,7 @@ class UNET {
       segmentation
     } = tf.tidy(() => {
       // preprocess the input image
-      const tfImage = tf.browser.fromPixels(imgToPredict).toFloat();
+      const tfImage = toTensor(imgToPredict).toFloat();
       const resizedImg = tf.image.resizeBilinear(tfImage, [this.config.imageSize, this.config.imageSize]);
       let normTensor = resizedImg.div(tf.scalar(255));
       const batchedImage = normTensor.expandDims(0);

--- a/src/utils/imageUtilities.js
+++ b/src/utils/imageUtilities.js
@@ -142,6 +142,18 @@ const flipImage = (img) => {
 }
 
 /**
+ * Wraps the tf.browser.fromPixels() function so that a tensor can be provided as an input.
+ * @param {ImageData | HTMLImageElement | HTMLCanvasElement | HTMLVideoElement | tf.Tensor3D} input
+ * @return {tf.Tensor3D}
+ */
+function toTensor(input) {
+  if (input instanceof tf.Tensor) {
+    return input;
+  }
+  return tf.browser.fromPixels(input);
+}
+
+/**
  * For models which expect an input with a specific size.
  * Converts an image to a tensor, resizes it, and crops it to a square.
  * @param {ImageData | HTMLImageElement | HTMLCanvasElement | HTMLVideoElement} input
@@ -150,13 +162,13 @@ const flipImage = (img) => {
  */
 function imgToTensor(input, size = null) {
   return tf.tidy(() => {
-    let img = tf.browser.fromPixels(input);
+    let img = toTensor(input);
     if (size) {
       img = tf.image.resizeBilinear(img, size);
     }
     const croppedImage = cropImage(img);
     const batchedImage = croppedImage.expandDims(0);
-    return batchedImage.toFloat().div(tf.scalar(127)).sub(tf.scalar(1));
+    return batchedImage.toFloat().div(tf.scalar(127.5)).sub(tf.scalar(1));
   });
 }
 
@@ -205,6 +217,7 @@ export {
   array3DToImage,
   processVideo,
   cropImage,
+  toTensor,
   imgToTensor,
   isInstanceOfSupportedElement,
   flipImage,


### PR DESCRIPTION
We want any model which accepts an image input to also accept a 3D tensor of image pixels.  This means that we should not call `tf.browser.fromPixels` directly with the input as it will be an error if called with a tensor.  I am instead calling a new utility `toTensor` which is a simple wrapper around `tf.browser.fromPixels` that will first check if the input is already a tensor and just return it.

Change `tf.browser.fromPixels` to `toTensor` in:
- [x] BodyPix
- [x] CartoonGAN
- [x] Pix2Pix
- [x] StyleTransfer
- [x] UNET

---

There are chunks of logic in `Darknet` and `Doodlenet` for checking if the image is a tensor and conditionally converting it.  These can be deleted entirely because the `ImageClassifier` handles converting the input to a tensor before calling the specific model's `classify()` function.

---

Two other minor changes:
- I realized that ` await this.ready` and `await mediaReady` should be awaited in parallel rather than sequentially so I changed that in a few places.
- The existing `imgToTensor` function, which rescales and crops in addition to converting, should use `127.5` as the divisor rather than `127`.