### PR TITLE
Use radio buttons for categorical inputs in Titanic example

### DIFF
--- a/examples/p5js/NeuralNetwork/NeuralNetwork_titanic/index.html
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_titanic/index.html
@@ -14,12 +14,20 @@
 <body>
   <script src="sketch.js"></script>
   <h1>Titanic - Neural Network</h1>
-  <p>
-    age: <input id="age" value="32"          /><br />
-    fare: <input id="fare" value="100"          /><br />
-    fare_class: <input id="fare_class" value="first"          /><br />
-    sex: <input id="sex" value="female"          /><br />
-  </p>
+  <form id="inputs">
+    age: <input id="age" value="32" type="number" min="0" step="1"/>
+    <br />
+    fare: <input id="fare" value="100" type="number" min="0" step="1"/>
+    <br />
+    fare class:
+    <input type="radio" name="fare_class" value="first" checked> First
+    <input type="radio" name="fare_class" value="second"> Second
+    <input type="radio" name="fare_class" value="third"> Third
+    <br />
+    sex:
+    <input type="radio" name="sex" value="female" checked> Female
+    <input type="radio" name="sex" value="male"> Male
+  </form>
   <p>
     <button id="submit">submit</button>
   </p>

--- a/examples/p5js/NeuralNetwork/NeuralNetwork_titanic/sketch.js
+++ b/examples/p5js/NeuralNetwork/NeuralNetwork_titanic/sketch.js
@@ -35,10 +35,11 @@ function finishedTraining() {
 
 // TODO: normalize and encode values going into predict?
 function classify() {
+  const form = document.forms[0];
   const age = parseInt(select("#age").value(), 10);
   const fare = parseInt(select("#fare").value(), 10);
-  const fareClass = select("#fare_class").value();
-  const sex = select("#sex").value();
+  const fareClass = form.fare_class.value;
+  const sex = form.sex.value;
 
   // let inputs = {
   //   age: age,
@@ -56,6 +57,6 @@ function gotResults(err, results) {
     console.error(err);
   } else {
     console.log(results);
-    select("#result").html(`prediction: ${results[0].label}`);
+    select("#result").html(`prediction: ${results[0].label} - ${round(100 * results[0].confidence)}%`);
   }
 }


### PR DESCRIPTION
This PR improves the Neural Network Titanic example by enforcing constraints on the inputs.  It does not make sense to use a text input when anything other than `"first"`/`"second"`/`"third"` is an error.

* `sex` and `fare_class`:
  * Convert from text inputs to radio buttons which show the available options.
  * Select the value using `document.forms` since the radio input has multiple elements.
* `age` and `fare`:
  * Prevent string values with `type="number"`
  * Prevent negative values with `min="0"`
  * Added increment/decrement arrows with `step="1"` (for convenience, not validation) 

Also added the % confidence to the result text.