### PR TITLE
🧹 cleanup NeuralNetwork callbacks

### DIFF
--- a/src/NeuralNetwork/NeuralNetworkData.js
+++ b/src/NeuralNetwork/NeuralNetworkData.js
@@ -1,6 +1,5 @@
 import * as tf from '@tensorflow/tfjs';
 import axios from 'axios';
-import handleArguments from "../utils/handleArguments";
 import { saveBlob } from '../utils/io';
 import nnUtils from './NeuralNetworkUtils';
 
@@ -681,10 +680,10 @@ class NeuralNetworkData {
 
   /**
    * loadData from fileinput or path
-   * @param {*} filesOrPath
-   * @param {*} callback
+   * @param {string | FileList} filesOrPath
+   * @return {Promise<void>}
    */
-  async loadData(filesOrPath = null, callback) {
+  async loadData(filesOrPath) {
     try {
       let loadedData;
 
@@ -716,10 +715,6 @@ class NeuralNetworkData {
       if (!this.data.raw.length > 0) {
         console.log('data must be a json object containing an array called "data" ');
       }
-
-      if (callback) {
-        callback();
-      }
     } catch (error) {
       throw new Error(error);
     }
@@ -727,7 +722,8 @@ class NeuralNetworkData {
 
   /**
    * saveData
-   * @param {*} name
+   * @param {string} [name]
+   * @return {Promise<void>}
    */
   async saveData(name) {
     const today = new Date();
@@ -751,25 +747,19 @@ class NeuralNetworkData {
 
   /**
    * Saves metadata of the data
-   * @param {*} nameOrCb
-   * @param {*} cb
+   * @param {string} name
+   * @return {Promise<void>}
    */
-  async saveMeta(nameOrCb, cb) {
-    const { string, callback } = handleArguments(nameOrCb, cb);
-    const modelName = string || 'model';
-
-    await saveBlob(JSON.stringify(this.meta), `${modelName}_meta.json`, 'text/plain');
-    if (callback) {
-      callback();
-    }
+  async saveMeta(name) {
+    await saveBlob(JSON.stringify(this.meta), `${name}_meta.json`, 'text/plain');
   }
 
   /**
    * load a model and metadata
-   * @param {*} filesOrPath
-   * @param {*} callback
+   * @param {string | FileList} filesOrPath
+   * @return {Promise<void>}
    */
-  async loadMeta(filesOrPath = null, callback) {
+  async loadMeta(filesOrPath) {
     if (filesOrPath instanceof FileList) {
       const files = await Promise.all(
         Array.from(filesOrPath).map(async file => {
@@ -818,11 +808,6 @@ class NeuralNetworkData {
 
     this.isMetadataReady = true;
     this.isWarmedUp = true;
-
-    if (callback) {
-      callback();
-    }
-    return this.meta;
   }
 
   /*

--- a/src/NeuralNetwork/index.test.js
+++ b/src/NeuralNetwork/index.test.js
@@ -25,14 +25,6 @@ describe('NeuralNetwork', () => {
       });
     });
 
-    // loadDataFromUrl
-    xdescribe('loadDataFromUrl', () => {
-      it('should loadDataFromUrl', () => {
-        // TODO:
-        // ...
-      });
-    });
-
     // loadDataInternal
     xdescribe('loadDataInternal', () => {
       it('should loadDataInternal', () => {
@@ -340,7 +332,7 @@ describe('NeuralNetwork', () => {
           },
         };
 
-        await brain.trainInternal(trainingOptions);
+        await brain.train(trainingOptions);
 
         expect(brain.isTrained).toBe(true);
       });


### PR DESCRIPTION
Fixes #1343 
* Change typo `this.createMetadata` to `this.createMetaData`.

---

Cleanup
* Remove all callback arguments from the methods of internal classes `NeuralNetwork` and `NeuralNetworkData` and use async methods instead.  The callbacks can be handled by the outer `DiyNeuralNetwork` class when it calls these methods.
* Call async functions pairs (`save`/`saveMeta`, `load`/`loadMeta`) in parallel instead of sequentially.
* Return a promise when no callback is provided in:
  * nn.save()
  * nn.load()
  * nn.loadData()
  * nn.train()
* Add callback and promise handling to:
  * nn.saveData()
* Fix inconsistent handling of `this.ready` where it was sometimes a `Promise` and sometimes a `boolean` `true`.  Now it is always a `Promise` which resolves to the instance.
* Fix `else if` in `init()` which prevented loading both a `dataUrl` and a `modelUrl`.
* Delete unecessary `loadDataFromUrl()` and call `loadDataInternal()` directly.
* Delete unecessary instance property `this.callback`. (Note: a few other models do this too)