### PR TITLE
StyleTransfer infers the number of filters

### DIFF
--- a/src/StyleTransfer/index.js
+++ b/src/StyleTransfer/index.js
@@ -3,8 +3,6 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-/* eslint max-len: "off" */
-/* eslint no-trailing-spaces: "off" */
 /*
 Fast Style Transfer
 This implementation is heavily based on github.com/reiinakano/fast-style-transfer-deeplearnjs by Reiichiro Nakano.
@@ -43,7 +41,6 @@ class StyleTransfer extends Video {
     this.timesScalar = tf.scalar(150);
     this.plusScalar = tf.scalar(255.0 / 2);
     this.epsilonScalar = tf.scalar(1e-3);
-    this.video = null;
     this.ready = callCallback(this.load(model), callback);
     // this.then = this.ready.then;
   }
@@ -83,8 +80,8 @@ class StyleTransfer extends Video {
       const moments = tf.moments(input, [0, 1]);
       const mu = moments.mean;
       const sigmaSq = moments.variance;
-      const shift = this.variables[StyleTransfer.getVariableName(id)];
-      const scale = this.variables[StyleTransfer.getVariableName(id + 1)];
+      const shift = this.getVariable(id);
+      const scale = this.getVariable(id + 1);
       const epsilon = this.epsilonScalar;
       const normalized = tf.div(tf.sub(input.asType('float32'), mu), tf.sqrt(tf.add(sigmaSq, epsilon)));
       const shifted = tf.add(tf.mul(scale, normalized), shift);
@@ -102,7 +99,7 @@ class StyleTransfer extends Video {
    */
   convLayer(input, strides, relu, id) {
     return tf.tidy(() => {
-      const y = tf.conv2d(input, this.variables[StyleTransfer.getVariableName(id)], [strides, strides], 'same');
+      const y = tf.conv2d(input, this.getVariable(id), [strides, strides], 'same');
       const y2 = this.instanceNorm(y, id + 1);
       return relu ? tf.relu(y2) : y2;
     });
@@ -135,7 +132,7 @@ class StyleTransfer extends Video {
       const newRows = height * strides;
       const newCols = width * strides;
       const newShape = [newRows, newCols, numFilters];
-      const y = tf.conv2dTranspose(input, this.variables[StyleTransfer.getVariableName(id)], newShape, [strides, strides], 'same');
+      const y = tf.conv2dTranspose(input, this.getVariable(id), newShape, [strides, strides], 'same');
       const y2 = this.instanceNorm(y, id + 1);
       const y3 = tf.relu(y2);
       return y3;
@@ -154,6 +151,10 @@ class StyleTransfer extends Video {
 
   /**
    * @private
+   *
+   * Applies each layer of the model in sequence, where the output of one layer
+   * is used as the input of the next layer.
+   *
    * @param {ImageData | HTMLImageElement | HTMLCanvasElement | HTMLVideoElement} input
    * @return {Promise<HTMLImageElement>}
    */
@@ -195,12 +196,19 @@ class StyleTransfer extends Video {
     this.epsilonScalar.dispose();
   }
 
-  // Static Methods
-  static getVariableName(id) {
-    if (id === 0) {
-      return 'Variable';
-    }
-    return `Variable_${id}`;
+  /**
+   * @private
+   *
+   * Access a variable's tensor from its numeric index.
+   * Model contains variables with ids from 0 to 47.
+   * The returned tensor will be 4D if `id` is divisible by 3, or 1D otherwise.
+   *
+   * @param {number} id
+   * @returns {tf.Tensor}
+   */
+  getVariable(id) {
+    const key = id === 0 ? 'Variable' : `Variable_${id}`;
+    return this.variables[key];
   }
 }
 


### PR DESCRIPTION
Extends #1380 

Closes #281 

This PR removes some of the hard-coded values in `StyleTransfer` so that it can work with user-trained models which were trained using a different number of filters.  Specifically, the Van Gogh models [here](https://github.com/acerwebai/VangoghCrazyWorld-Web).

We can derive the `numFilters` by looking at the shape of the filter variable.  These shapes are specified in the manifest.json, but I'm just looking at the filter tensor directly.

The input does not need to be any particular size, so I am removing the `IMAGE_SIZE` and the `Video` base class which uses it.  The resizing [didn't work](https://github.com/ml5js/ml5-library/issues/1413) anyways!  We still have issues with video loading in Safari, though I'm getting a different error than [before](https://github.com/ml5js/ml5-library/issues/626).

I wonder if the `strides` is also something that's variable which we want to infer?