### PR TITLE
deleted reference to Atom in hello-ml5 docs

### DIFF
--- a/docs/tutorials/hello-ml5.md
+++ b/docs/tutorials/hello-ml5.md
@@ -19,7 +19,7 @@ ml5.js is growing every day, so be sure to see some of the other applications of
 
 If you've arrived here, we assume you've checked out our [quickstart](/) page to get a simple ml5.js project set up. To get this to run, you'll need:
 
-> + 📝 A text editor (e.g. [Atom](https://atom.io/), [VSCode](https://code.visualstudio.com/), [Sublimetext](https://www.sublimetext.com/))
+> + 📝 A text editor (e.g. [VSCode](https://code.visualstudio.com/), [Sublimetext](https://www.sublimetext.com/))
 > + 💻 Your web browser: Chrome & Firefox preferred
 > + 🖼 An image to run your classification on
 


### PR DESCRIPTION
<!--------------------------------------------
🌈DEAR BELOVED ML5 COMMUNITY MEMBER. WELCOME. 🌈
---------------------------------------------->

Dear ml5 community, 

I'm making a Pull Request(PR). Please see the details below.

### → Atom Deleted from beginner docs 

I noticed that Atom was listed on the webpage for ml5-library/docs/tutorials/hello-ml5.md 

As Atom will be archived on December 15th, I thought it would be best to remove it as a suggested text editor, especially as the documentation is aimed at beginners. 

I've removed mention of Atom from the relevant file.

Website
https://learn.ml5js.org/#/tutorials/hello-ml5

Github
https://github.com/ml5js/ml5-library/blob/main/docs/tutorials/hello-ml5.md

### → Here are the changes I made

#### docs/tutorials/hello-ml5.md changes

Before:
```
> + 📝 A text editor (e.g. [Atom](https://atom.io/), [VSCode](https://code.visualstudio.com/), [Sublimetext](https://www.sublimetext.com/))
> + 💻 Your web browser: Chrome & Firefox preferred
> + 🖼 An image to run your classification on
```

After:
```
> + 📝 A text editor (e.g. [VSCode](https://code.visualstudio.com/), [Sublimetext](https://www.sublimetext.com/))
> + 💻 Your web browser: Chrome & Firefox preferred
> + 🖼 An image to run your classification on
```

### → Notes

Originally I submitted this as an issue:
https://github.com/ml5js/ml5-library/issues/1431 


