### PR TITLE
Editing the order to get the ml5 first. for the javascript version example for BodyPix / sketch.js

### DIFF
--- a/examples/javascript/BodyPix/BodyPix_Webcam/sketch.js
+++ b/examples/javascript/BodyPix/BodyPix_Webcam/sketch.js
@@ -14,10 +14,11 @@ async function setup() {
   // create a canvas to draw to
   canvas = createCanvas(width, height);
   ctx = canvas.getContext('2d');
-  // get the video
-  video = await getVideo();
   // load bodyPix with video
   bodypix = await ml5.bodyPix(options)
+  // get the video
+  video = await getVideo();
+
 }
 
 // when the dom is loaded, call make();


### PR DESCRIPTION
I got the Error message:

Uncaught TypeError: Cannot read properties of undefined (reading 'segment')
    at HTMLVideoElement.videoReady (sketch.js:30:11)
videoReady @ sketch.js:30

=========

Change the order to load the ml5 first, then get the video. So it works now~


Before
<img width="1321" alt="截圖 2023-11-02 下午6 05 05" src="https://github.com/ml5js/ml5-library/assets/97862198/dfda777d-2f26-4467-ab1b-da103574cafe">


After:
<img width="1309" alt="截圖 2023-11-02 下午6 06 19" src="https://github.com/ml5js/ml5-library/assets/97862198/fdade889-16a0-4827-857d-722f006691fe">



