### PR TITLE
Update URLs in `docs` to archive-docs.ml5js.org 

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-learn.ml5js.org
+archive-docs.ml5js.org

--- a/README.md
+++ b/README.md
@@ -156,15 +156,15 @@ For example:
 
 ## Resources
 
-- [Getting Started](https://learn.ml5js.org/)
-- [API Reference](https://learn.ml5js.org/#/reference/index)
+- [Getting Started](https://archive-docs.ml5js.org/)
+- [API Reference](https://archive-docs.ml5js.org/#/reference/index)
 - [Examples](https://github.com/ml5js/ml5-library/tree/main/examples)
-- [Community](https://ml5js.org/community)
-- [FAQ](https://learn.ml5js.org/#/faq)
+- [Community](https://archive.ml5js.org/community)
+- [FAQ](https://archive-docs.ml5js.org/#/faq)
 
 ## Standalone Examples
 
-You can find a collection of standalone examples in this repository within the `examples/` directory. You can also test working hosted of the examples online on the [ml5.js examples index website](https://examples.ml5js.org/). 
+You can find a collection of standalone examples in this repository within the `examples/` [directory](https://github.com/ml5js/ml5-library/tree/main/examples). 
 
 These examples are meant to serve as an introduction to the library and machine learning concepts.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -84,10 +84,10 @@
       </a>
 
       <div class="Menu__Top__Menu">
-          <a class="Menu__Top__Menu__Item" href="../docs/#/"
+          <a class="Menu__Top__Menu__Item" href="https://archive-docs.ml5js.org/"
           >Getting Started</a
         >
-        <a class="Menu__Top__Menu__Item" href="./#/reference/index"
+        <a class="Menu__Top__Menu__Item" href="https://archive-docs.ml5js.org/#/reference/index"
           >Reference</a
         >
         <a class="Menu__Top__Menu__Item" href="https://archive.ml5js.org/community/">Community</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -75,23 +75,23 @@
   </head>
   <body>
     <nav class="Menu__Top">
-      <a href="https://ml5js.org" class="Menu__Top__LogoContainer">
+      <a href="https://archive.ml5js.org/" class="Menu__Top__LogoContainer">
         <img
           class="Menu__Top__LogoContainer_Logo"
-          src="https://ml5js.org/static/ml5_logo_purple-88e082b8dc81d8729f95bcc092db90c5.png"
+          src="https://archive.ml5js.org/static/ml5_logo_purple-88e082b8dc81d8729f95bcc092db90c5.png"
           alt="ml5 Logo"
         />
       </a>
 
       <div class="Menu__Top__Menu">
-          <a class="Menu__Top__Menu__Item" href="https://learn.ml5js.org/#/"
+          <a class="Menu__Top__Menu__Item" href="../docs/#/"
           >Getting Started</a
         >
-        <a class="Menu__Top__Menu__Item" href="https://learn.ml5js.org/#/reference/index"
+        <a class="Menu__Top__Menu__Item" href="./#/reference/index"
           >Reference</a
         >
-        <a class="Menu__Top__Menu__Item" href="https://ml5js.org/community/">Community</a>
-        <a class="Menu__Top__Menu__Item" href="https://ml5js.org/about/">About</a>
+        <a class="Menu__Top__Menu__Item" href="https://archive.ml5js.org/community/">Community</a>
+        <a class="Menu__Top__Menu__Item" href="https://archive.ml5js.org/about/">About</a>
         <a class="Menu__Top__Menu__Item" href="https://github.com/ml5js/ml5-library">
           <img
             class="Menu__Top__LogoContainer_Logo"
@@ -107,7 +107,7 @@
       const config = {
         editOnGithub: {
           docBase: 'https://github.com/ml5js/ml5-library/tree/main/docs/',
-          docEditBase: 'https://learn.ml5js.org/',
+          docEditBase: 'https://archive-docs.ml5js.org/',
           title: 'Edit document',
         },
       };

--- a/examples/README.md
+++ b/examples/README.md
@@ -39,7 +39,7 @@ npm run develop
 
 ```
 
-If you don't know how to start a server, check [this guide on how to start a local web server](https://learn.ml5js.org/docs/#/tutorials/local-web-server?id=running-a-local-web-server).
+If you don't know how to start a server, check [this guide on how to start a local web server](https://archive-docs.ml5js.org/#/tutorials/local-web-server).
 
 
 ## Examples Index


### PR DESCRIPTION
@shiffman This PR updates the URLs in the CNAME, README.md, and index.html files to point to the archive-docs.ml5js.org domain instead of learn.ml5js.org. This change ensures that users are directed to the archived documentation site after the migration.

https://github.com/ml5js/ml5-website/issues/194#issuecomment-2200258861